### PR TITLE
docker-in-docker container

### DIFF
--- a/dev-containers/docker-in-docker-container/.vscode/devContainer.json
+++ b/dev-containers/docker-in-docker-container/.vscode/devContainer.json
@@ -1,0 +1,7 @@
+{
+    "dockerFile": "dev-container.dockerfile",
+    "extensions": [
+        "peterjausovec.vscode-docker"
+    ],
+    "runArgs": ["-v","/var/run/docker.sock:/var/run/docker.sock"]
+}

--- a/dev-containers/docker-in-docker-container/README.md
+++ b/dev-containers/docker-in-docker-container/README.md
@@ -1,0 +1,23 @@
+# Docker in Docker Container
+
+This example has a dev container that actually contains the Docker CLI. This allows you to use the Docker extension and run docker commands from within a dev container that can still control, interact with, and deploy to your local OS Docker install!
+
+While this will run out-of-box on macOS and Linux, there is an extra **step for Windows**.
+
+## Windows Steps
+
+1. Install "Docker Desktop for Windows" locally if you have not.
+   
+2. Right Click on Docker system tray icon and select "Settings"
+   
+3. Check **General > "Expose daemon on tcp://localhost:2375 without TLS"**
+   
+4. Wait for Docker to restart.
+   
+5. Open this folder in VS Code and modify the `runArgs` in `.vscode/devContainer.json` as follows:
+   ```
+    "runArgs": ["-e","DOCKER_HOST=tcp://host.docker.internal:2375"]
+   ```
+   > **Note:** Resolving [vscode-remote#669](https://github.com/Microsoft/vscode-remote/issues/669) will remove this step.
+
+6. Run the **Remote: Reopen folder in Container"** command

--- a/dev-containers/docker-in-docker-container/dev-container.dockerfile
+++ b/dev-containers/docker-in-docker-container/dev-container.dockerfile
@@ -1,0 +1,20 @@
+# Note: You can use any Debian/Ubuntu based image you want. 
+FROM ubuntu:latest
+
+# Install required tools
+RUN apt-get update \
+	&& apt-get install -y git
+
+# Install Docker CE
+RUN apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && apt-get autoclean -y \
+    && rm -rf /var/lib/apt/lists/*
+


### PR DESCRIPTION
Adds an example container that can interact with the host operating system's Docker install and comes pre-configured with the Docker extension as a workspace extension.

The Docker extension itself has issues when running this way as described in [vscode-remote#529](https://github.com/Microsoft/vscode-remote/issues/529). Also affected by [vscode-remote#669](https://github.com/Microsoft/vscode-remote/issues/669) but not blocking.