### PR TITLE
Remove docker cli from repo .devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,13 +10,6 @@ FROM debian:9
 RUN apt-get update \
 	&& apt-get install -y git procps lsb-release
 
-# Install Docker CE CLI
-RUN apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
-    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get install -y docker-ce-cli
-
 # Clean up
 RUN apt-get autoremove -y \
     && apt-get clean -y \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
         "streetsidesoftware.code-spell-checker",
         "DavidAnson.vscode-markdownlint",
         "esbenp.prettier-vscode",
-        "PeterJausovec.vscode-docker",
         "eamodio.gitlens",
         "mutantdino.resourcemonitor"
     ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "extensions.ignoreRecommendations": true
+}


### PR DESCRIPTION
Removed docker cli from .devcontainer to speed up initial build time. Also added setting to ignore extension recommendations so that users aren't prompted to download the docker extension.