### PR TITLE
Python: adding back pylint, removing intellicode

### DIFF
--- a/containers/python-2/.devcontainer/Dockerfile
+++ b/containers/python-2/.devcontainer/Dockerfile
@@ -8,10 +8,14 @@ FROM python:2
 # Copy endpoint specific user settings overrides into container to specify Python path
 COPY .devcontainer/settings.vscode.json /root/.vscode-remote/data/Machine/settings.json
 
-RUN pip install pylint
-
 # Install git, process tools
 RUN apt-get update && apt-get -y install git procps
+
+RUN mkdir /workspace
+WORKDIR /workspace
+
+# Install pylint
+RUN pip install pylint
 
 # Install Python dependencies from requirements.txt if it exists
 COPY .devcontainer/requirements.txt.temp requirements.txt* /workspace/

--- a/containers/python-2/.devcontainer/devcontainer.json
+++ b/containers/python-2/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 	"dockerFile": "Dockerfile",
 	"workspaceFolder": "/workspace",
 	"extensions": [
-		"ms-python.python",
-		"VisualStudioExptTeam.vscodeintellicode"
+		"ms-python.python"
 	]
 }

--- a/containers/python-2/.devcontainer/settings.vscode.json
+++ b/containers/python-2/.devcontainer/settings.vscode.json
@@ -1,3 +1,5 @@
 {
-    "python.pythonPath": "/usr/local/bin/python"
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
 }

--- a/containers/python-3-anaconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-anaconda/.devcontainer/devcontainer.json
@@ -5,7 +5,6 @@
 	"appPort": "5000:5000",
 	"workspaceFolder": "/workspace",
 	"extensions": [
-		"ms-python.python",
-		"VisualStudioExptTeam.vscodeintellicode"
+		"ms-python.python"
 	]
 }

--- a/containers/python-3-anaconda/.devcontainer/settings.vscode.json
+++ b/containers/python-3-anaconda/.devcontainer/settings.vscode.json
@@ -1,3 +1,5 @@
 {
-    "python.pythonPath": "/opt/conda/bin/python"
+    "python.pythonPath": "/opt/conda/bin/python",
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
 }

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get -y install git procps
 RUN mkdir /workspace
 WORKDIR /workspace
 
+# Install pylint
+RUN pip install pylint
+
 # Install Python dependencies from requirements.txt if it exists
 COPY .devcontainer/environment.yml.temp environment.yml* /workspace/
 RUN if [ -f "environment.yml" ]; then conda env update base -f environment.yml && rm environment.yml*; fi

--- a/containers/python-3-miniconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-miniconda/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 	"dockerFile": "Dockerfile",
 	"workspaceFolder": "/workspace",
 	"extensions": [
-		"ms-python.python",
-		"VisualStudioExptTeam.vscodeintellicode"
+		"ms-python.python"
 	]
 }

--- a/containers/python-3-miniconda/.devcontainer/settings.vscode.json
+++ b/containers/python-3-miniconda/.devcontainer/settings.vscode.json
@@ -1,3 +1,5 @@
 {
-    "python.pythonPath": "/opt/conda/bin/python"
+    "python.pythonPath": "/opt/conda/bin/python",
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
 }

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -10,11 +10,14 @@ COPY .devcontainer/settings.vscode.json /root/.vscode-remote/data/Machine/settin
 
 ENV PYTHONUNBUFFERED 1
 
+# Install git, process tools
+RUN apt-get update && apt-get -y install git procps
+
 RUN mkdir /workspace
 WORKDIR /workspace
 
-# Install git, process tools
-RUN apt-get update && apt-get -y install git procps
+# Install pylint
+RUN pip install pylint
 
 # Install Python dependencies from requirements.txt if it exists
 COPY .devcontainer/requirements.txt.temp requirements.txt* /workspace/

--- a/containers/python-3-postgres/.devcontainer/devcontainer.json
+++ b/containers/python-3-postgres/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 	"extensions": [
-		"ms-python.python",
-		"VisualStudioExptTeam.vscodeintellicode"
+		"ms-python.python"
 	]
 }

--- a/containers/python-3-postgres/.devcontainer/settings.vscode.json
+++ b/containers/python-3-postgres/.devcontainer/settings.vscode.json
@@ -1,3 +1,5 @@
 {
-    "python.pythonPath": "/usr/local/bin/python"
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
 }

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -14,6 +14,9 @@ RUN apt-get update && apt-get -y install git procps
 RUN mkdir /workspace
 WORKDIR /workspace
 
+# Install pylint
+RUN pip install pylint
+
 # Install Python dependencies from requirements.txt if it exists
 COPY .devcontainer/requirements.txt.temp requirements.txt* /workspace/
 RUN if [ -f "requirements.txt" ]; then pip install -r requirements.txt && rm requirements.txt*; fi

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 	"dockerFile": "Dockerfile",
 	"workspaceFolder": "/workspace",
 	"extensions": [
-		"ms-python.python",
-		"VisualStudioExptTeam.vscodeintellicode"
+		"ms-python.python"
 	]
 }

--- a/containers/python-3/.devcontainer/settings.vscode.json
+++ b/containers/python-3/.devcontainer/settings.vscode.json
@@ -1,3 +1,5 @@
 {
-    "python.pythonPath": "/usr/local/bin/python"
+    "python.pythonPath": "/usr/local/bin/python",
+    "python.linting.pylintEnabled": true,
+    "python.linting.enabled": true
 }


### PR DESCRIPTION
The language server won't be default by 5/2, so adding back pylint and removing intellicode for now.

- Pylint is installed via Dockerfiles
- Made the dockerfiles all consistent in the ordering of statements
- Tested that all Python containers are working
