### PR TITLE
[Non-blocking cosmetic fix] Add missing "&&" into Node definitions when updating yarn

### DIFF
--- a/containers/javascript-node-8/.devcontainer/Dockerfile
+++ b/containers/javascript-node-8/.devcontainer/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get install -y git procps
 # Remove outdated yarn from /opt and install via package 
 # so it can be easily updated via apt-get upgrade yarn
 RUN rm -rf /opt/yarn-* \
-    rm -f /usr/local/bin/yarn \
-    rm -f /usr/local/bin/yarnpkg \
+    && rm -f /usr/local/bin/yarn \
+    && rm -f /usr/local/bin/yarnpkg \
     && apt-get install -y curl apt-transport-https lsb-release \
     && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
     && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \

--- a/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get install -y git procps
 # Remove outdated yarn from /opt and install via package 
 # so it can be easily updated via apt-get upgrade yarn
 RUN rm -rf /opt/yarn-* \
-    rm -f /usr/local/bin/yarn \
-    rm -f /usr/local/bin/yarnpkg \
+    && rm -f /usr/local/bin/yarn \
+    && rm -f /usr/local/bin/yarnpkg \
     && apt-get install -y curl apt-transport-https lsb-release \
     && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
     && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \

--- a/containers/javascript-node-lts/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts/.devcontainer/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get install -y git procps
 # Remove outdated yarn from /opt and install via package 
 # so it can be easily updated via apt-get upgrade yarn
 RUN rm -rf /opt/yarn-* \
-    rm -f /usr/local/bin/yarn \
-    rm -f /usr/local/bin/yarnpkg \
+    && rm -f /usr/local/bin/yarn \
+    && rm -f /usr/local/bin/yarnpkg \
     && apt-get install -y curl apt-transport-https lsb-release \
     && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
     && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \

--- a/containers/typescript-node-8/.devcontainer/Dockerfile
+++ b/containers/typescript-node-8/.devcontainer/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get install -y git procps
 # Remove outdated yarn from /opt and install via package 
 # so it can be easily updated via apt-get upgrade yarn
 RUN rm -rf /opt/yarn-* \
-    rm -f /usr/local/bin/yarn \
-    rm -f /usr/local/bin/yarnpkg \
+    && rm -f /usr/local/bin/yarn \
+    && rm -f /usr/local/bin/yarnpkg \
     && apt-get install -y curl apt-transport-https lsb-release \
     && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
     && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \

--- a/containers/typescript-node-lts/.devcontainer/Dockerfile
+++ b/containers/typescript-node-lts/.devcontainer/Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get install -y git procps
 # Remove outdated yarn from /opt and install via package 
 # so it can be easily updated via apt-get upgrade yarn
 RUN rm -rf /opt/yarn-* \
-    rm -f /usr/local/bin/yarn \
-    rm -f /usr/local/bin/yarnpkg \
+    && rm -f /usr/local/bin/yarn \
+    && rm -f /usr/local/bin/yarnpkg \
     && apt-get install -y curl apt-transport-https lsb-release \
     && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
     && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
Currently the node definitions clear out the `/opt/yarn` location in the base node images and install `yarn` using `apt-get` so it can be upgraded in-place by the user as needed. The code looks like this:

```Dockerfile
rm -rf /opt/yarn-* \
    rm -f /usr/local/bin/yarn \	   
    rm -f /usr/local/bin/yarnpkg \
    ...
```

This is wrong, because the last two paths won't be deleted.  It should be:

```Dockerfile
rm -rf /opt/yarn-* \
    && rm -f /usr/local/bin/yarn \	   
    && rm -f /usr/local/bin/yarnpkg \
    ...
```

However, because /opt/yarn-* is removed, the links in `/usr/local/bin` are ignored and everything works anyway.  So this is more of a cosmetic fix and **not blocking**.