### PR TITLE
Use correct PowerShell container

### DIFF
--- a/containers/powershell/.devcontainer/Dockerfile
+++ b/containers/powershell/.devcontainer/Dockerfile
@@ -6,9 +6,8 @@
 FROM mcr.microsoft.com/powershell
 
 # Install git, process tools
-RUN apt-get update && apt-get -y install git procps
-
-# Clean up
-RUN apt-get autoremove -y \
+RUN apt-get update && apt-get -y install git procps \
+    # Clean up
+    && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*

--- a/containers/powershell/.devcontainer/Dockerfile
+++ b/containers/powershell/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM microsoft/powershell
+FROM mcr.microsoft.com/powershell
 
 # Install git, process tools
 RUN apt-get update && apt-get -y install git procps


### PR DESCRIPTION
A lot of Microsoft containers are moving the MCR - PowerShell being one that has already made the switch.

I would recommend checking with the other containers to see if they use MCR - it's easy to check. It shows up in Docker Hub:

https://hub.docker.com/_/microsoft-powershell?tab=description

Full list:
https://hub.docker.com/publishers/microsoftowner

cc @TravisEz13 