### PR TITLE
Added security configs for the docker-in-docker-compose example

### DIFF
--- a/containers/docker-in-docker-compose/.devcontainer/docker-compose.yml
+++ b/containers/docker-in-docker-compose/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@
 version: '3'
 services:
   docker-in-docker:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile
     volumes:
@@ -18,8 +18,13 @@ services:
 
       # Forwarding the socket is optional, but lets docker work inside the container if you install the Docker CLI.
       # See the docker-in-docker-compose definition for details on how to install it.
-      - /var/run/docker.sock:/var/run/docker.sock 
-    
+      - /var/run/docker.sock:/var/run/docker.sock
+
     # Overrides default command so things don't shut down after the process ends - useful for debugging
-    command: sleep infinity 
-    
+    command: sleep infinity
+    # Allows vscode's debugger to connect to the container
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp:unconfined
+


### PR DESCRIPTION
While trying to get this to work for my own project, I realized most of the examples set the security permissions in `devcontainer.json`:
```
	"runArgs": [
		"--cap-add=SYS_PTRACE",
		"--security-opt",
		"seccomp=unconfined"
	]
```

When overriding docker-compose, the `runArgs` field is ignored, preventing vscode's debugger from working. 

To get over this limitation, we need to define the security permissions in the service in the docker-compose file.

I've updated the docs here: https://github.com/microsoft/vscode-docs/pull/2633