### PR TITLE
Update postCreateCommand

### DIFF
--- a/containers/powershell/.devcontainer/devcontainer.json
+++ b/containers/powershell/.devcontainer/devcontainer.json
@@ -8,8 +8,8 @@
 	// Uncomment the next line if you want to add in default container specific settings.json values
 	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
-	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "powershell echo $PSVersionTable",
+	// Uncomment the next line to run commands after the container is created. This gets run in bash which is why we call `pwsh`.
+	// "postCreateCommand": "pwsh -c '$PSVersionTable'",
 
 	"extensions": [
 		"ms-vscode.powershell"


### PR DESCRIPTION
The original command had a couple issues:

1. It's `pwsh` not `powershell`
3. You need to use `-c` to specify a script in PowerShell
4. since `$PSVersionTable` is not escaped, bash will first evaluate it (which will evaluate it to empty string).

Also `echo` is more of a bash-ism so I took that out.

I do want to ask a greater question... Is there a reason the `CMD` in the container isn't used for the `postCreateCommand`?