### PR TITLE
Simplify Java Dockerfiles

### DIFF
--- a/containers/java-11/.devcontainer/Dockerfile
+++ b/containers/java-11/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM maven:3-jdk-11
+FROM openjdk:11-jdk
 
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
@@ -13,16 +13,31 @@ RUN apt-get update \
 # Verify git, needed tools installed
 RUN apt-get -y install git procps curl
 
-# Install Gradle
-ENV GRADLE_HOME /opt/gradle
-ENV GRADLE_VERSION 5.4.1
-ARG GRADLE_DOWNLOAD_SHA256=7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc
-RUN curl -sSL --output gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
-    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
-    && unzip gradle.zip \
-    && rm gradle.zip \
-    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
-    && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+#-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
+# ARG MAVEN_VERSION=3.6.1
+# ARG MAVEN_SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
+# RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+#   && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+#   && echo "${MAVEN_SHA} /tmp/apache-maven.tar.gz" | sha512sum -c - \
+#   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+#   && rm -f /tmp/apache-maven.tar.gz \
+#   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+# COPY maven-settings.xml /usr/share/maven/ref/
+# ENV MAVEN_HOME /usr/share/maven
+# ENV MAVEN_CONFIG /root/.m2
+#-------------------------------------------------------------------------------------------------------------
+
+#-------------------Uncomment the following steps to install Gradle CLI Tools---------------------------------
+# ENV GRADLE_HOME /opt/gradle
+# ENV GRADLE_VERSION 5.4.1
+# ARG GRADLE_DOWNLOAD_SHA256=7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc
+# RUN curl -sSL --output gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+#     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+#     && unzip gradle.zip \
+#     && rm gradle.zip \
+#     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+#     && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+#-------------------------------------------------------------------------------------------------------------
 
 # Clean up
 RUN apt-get autoremove -y \

--- a/containers/java-11/.devcontainer/maven-settings.xml
+++ b/containers/java-11/.devcontainer/maven-settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>

--- a/containers/java-11/README.md
+++ b/containers/java-11/README.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-*Develop Java 11 applications. Includes the JDK 11, Maven, and Gradle build tools.*
+*Develop Java 11 applications. Includes JDK 11 and Java extensions.*
 
 | Metadata | Value |  
 |----------|-------|
 | *Contributors* | The VS Code Java Team |
 | *Definition type* | Dockerfile |
-| *Languages, platforms* | Java, Maven, Gradle |
+| *Languages, platforms* | Java |
 
 ## Using this definition with an existing folder
 
@@ -35,6 +35,8 @@ Beyond that, just follow these steps to use the definition:
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
 5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+6. If you want to include maven or gradle build tools into your dev container, please uncomment the corresponding steps from the `containers/java-11/.devcontainer/Dockerfile`, and run **Remote-Containers: Rebuild Container** to rebuild the dev container.
 
 ## Testing the definition
 

--- a/containers/java-12/.devcontainer/Dockerfile
+++ b/containers/java-12/.devcontainer/Dockerfile
@@ -37,7 +37,7 @@ RUN yum install -y git curl procps unzip
 # Clean yum cache
 RUN yum clean all
 
-# Allow for a consistant java home location for settings - image is changing over time
+# Allow for a consistent java home location for settings - image is changing over time
 RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi
 
 # Set the default shell to bash instead of sh

--- a/containers/java-12/.devcontainer/Dockerfile
+++ b/containers/java-12/.devcontainer/Dockerfile
@@ -3,24 +3,42 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM maven:3-jdk-12
+FROM openjdk:12-jdk
 
 # Verify git, needed tools installed
 RUN yum install -y git curl procps unzip
 
-# Install Gradle
-ENV GRADLE_HOME /opt/gradle
-ENV GRADLE_VERSION 5.4.1
-ARG GRADLE_DOWNLOAD_SHA256=7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc
-RUN curl -sSL --output gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
-    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
-    && unzip gradle.zip \
-    && rm gradle.zip \
-    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
-    && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+#-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
+# ARG MAVEN_VERSION=3.6.1
+# ARG MAVEN_SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
+# RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+#   && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+#   && echo "${MAVEN_SHA} /tmp/apache-maven.tar.gz" | sha512sum -c - \
+#   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+#   && rm -f /tmp/apache-maven.tar.gz \
+#   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+# COPY maven-settings.xml /usr/share/maven/ref/
+# ENV MAVEN_HOME /usr/share/maven
+# ENV MAVEN_CONFIG /root/.m2
+#-------------------------------------------------------------------------------------------------------------
+
+#-------------------Uncomment the following steps to install Gradle CLI Tools---------------------------------
+# ENV GRADLE_HOME /opt/gradle
+# ENV GRADLE_VERSION 5.4.1
+# ARG GRADLE_DOWNLOAD_SHA256=7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc
+# RUN curl -sSL --output gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+#     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+#     && unzip gradle.zip \
+#     && rm gradle.zip \
+#     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+#     && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+#-------------------------------------------------------------------------------------------------------------
 
 # Clean yum cache
 RUN yum clean all
+
+# Allow for a consistant java home location for settings - image is changing over time
+RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi
 
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/containers/java-12/.devcontainer/maven-settings.xml
+++ b/containers/java-12/.devcontainer/maven-settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>

--- a/containers/java-12/README.md
+++ b/containers/java-12/README.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-*Develop Java 12 applications. Includes JDK 12, Maven, and Gradle build tools.*
+*Develop Java 12 applications. Includes JDK 12 and Java extensions.*
 
 | Metadata | Value |  
 |----------|-------|
 | *Contributors* | The VS Code Java Team |
 | *Definition type* | Dockerfile |
-| *Languages, platforms* | Java, Maven, Gradle |
+| *Languages, platforms* | Java |
 
 ## Using this definition with an existing folder
 
@@ -35,6 +35,8 @@ Beyond that, just follow these steps to use the definition:
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
 5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+6. If you want to include maven or gradle build tools into your dev container, please uncomment the corresponding steps from the `containers/java-12/.devcontainer/Dockerfile`, and run **Remote-Containers: Rebuild Container** to rebuild the dev container.
 
 ## Testing the definition
 

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM maven:3-jdk-8
+FROM openjdk:8-jdk
 
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
@@ -13,16 +13,31 @@ RUN apt-get update \
 # Verify git, needed tools installed
 RUN apt-get -y install git procps curl lsb-release
 
-# Install Gradle
-ENV GRADLE_HOME /opt/gradle
-ENV GRADLE_VERSION 5.4.1
-ARG GRADLE_DOWNLOAD_SHA256=7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc
-RUN curl -sSL --output gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
-    && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
-    && unzip gradle.zip \
-    && rm gradle.zip \
-    && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
-    && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+#-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
+# ARG MAVEN_VERSION=3.6.1
+# ARG MAVEN_SHA=b4880fb7a3d81edd190a029440cdf17f308621af68475a4fe976296e71ff4a4b546dd6d8a58aaafba334d309cc11e638c52808a4b0e818fc0fd544226d952544
+# RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
+#   && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+#   && echo "${MAVEN_SHA} /tmp/apache-maven.tar.gz" | sha512sum -c - \
+#   && tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 \
+#   && rm -f /tmp/apache-maven.tar.gz \
+#   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+# COPY maven-settings.xml /usr/share/maven/ref/
+# ENV MAVEN_HOME /usr/share/maven
+# ENV MAVEN_CONFIG /root/.m2
+#-------------------------------------------------------------------------------------------------------------
+
+#-------------------Uncomment the following steps to install Gradle CLI Tools---------------------------------
+# ENV GRADLE_HOME /opt/gradle
+# ENV GRADLE_VERSION 5.4.1
+# ARG GRADLE_DOWNLOAD_SHA256=7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc
+# RUN curl -sSL --output gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \
+#     && echo "${GRADLE_DOWNLOAD_SHA256} *gradle.zip" | sha256sum --check - \
+#     && unzip gradle.zip \
+#     && rm gradle.zip \
+#     && mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" \
+#     && ln -s "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
+#-------------------------------------------------------------------------------------------------------------
 
 # Clean up
 RUN apt-get autoremove -y \

--- a/containers/java-8/.devcontainer/maven-settings.xml
+++ b/containers/java-8/.devcontainer/maven-settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>

--- a/containers/java-8/README.md
+++ b/containers/java-8/README.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-*Develop Java 8 applications. Includes JDK 8, Maven, and Gradle build tools.*
+*Develop Java 8 applications. Includes JDK 8 and Java extensions.*
 
 | Metadata | Value |  
 |----------|-------|
 | *Contributors* | The VS Code Java Team |
 | *Definition type* | Dockerfile |
-| *Languages, platforms* | Java, Maven |
+| *Languages, platforms* | Java |
 
 ## Using this definition with an existing folder
 
@@ -35,6 +35,8 @@ Beyond that, just follow these steps to use the definition:
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
 5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+6. If you want to include maven or gradle build tools into your dev container, please uncomment the corresponding steps from the `containers/java-8/.devcontainer/Dockerfile`, and run **Remote-Containers: Rebuild Container** to rebuild the dev container.
 
 ## Testing the definition
 


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Address issue #31 .
- Use openjdk as the base image.
- Comment out the steps to install maven and gradle build tools.
- Update README about how to enable maven and gradle in the Dockerfile.