### PR TITLE
Drop SHELL ENV var

### DIFF
--- a/container-templates/docker-compose/.devcontainer/Dockerfile
+++ b/container-templates/docker-compose/.devcontainer/Dockerfile
@@ -13,8 +13,6 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/container-templates/dockerfile/.devcontainer/Dockerfile
+++ b/container-templates/dockerfile/.devcontainer/Dockerfile
@@ -8,8 +8,6 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -8,8 +8,6 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-blockchain/.devcontainer/Dockerfile
+++ b/containers/azure-blockchain/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM python:2.7
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-cli/.devcontainer/Dockerfile
+++ b/containers/azure-cli/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.1
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-functions-dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-latest/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:latest
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-functions-java-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-8/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM maven:3-jdk-8
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-functions-node-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-8/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM node:8
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-functions-node-lts/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-lts/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM node:lts
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
@@ -9,8 +9,6 @@ FROM continuumio/anaconda3
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -8,8 +8,7 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
+
 # Terraform and tflint versions
 ARG TERRAFORM_VERSION=0.11.13
 ARG TFLINT_VERSION=0.7.5

--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -6,8 +6,7 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
+
 # Bazel version and hash
 ENV BAZEL_VERSION=0.25.2 
 ENV BAZEL_SHA256=5b9ab8a68c53421256909f79c47bde76a051910217531cbf35ee995448254fa7 

--- a/containers/cpp/.devcontainer/Dockerfile
+++ b/containers/cpp/.devcontainer/Dockerfile
@@ -10,13 +10,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set the default shell to bash rather than sh
 ENV SHELL /bin/bash
 
+# Configure apt and install packages
 RUN apt-get update \
-    #
-    # Configure apt
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \
     # 
     # Verify git, process tools, lsb-release (useful for CLI installs) installed
-    && apt-get update && apt-get -y install git procps lsb-release \
+    && apt-get -y install git procps lsb-release \
     #
     # Install C++ tools
     && apt-get -y install build-essential cmake cppcheck valgrind \

--- a/containers/cpp/.devcontainer/Dockerfile
+++ b/containers/cpp/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/dart/.devcontainer/Dockerfile
+++ b/containers/dart/.devcontainer/Dockerfile
@@ -7,8 +7,7 @@ FROM google/dart:2
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
+
 # Add bin location to path
 ENV PATH="$PATH":"/root/.pub-cache/bin"
 

--- a/containers/debian-9-git/.devcontainer/Dockerfile
+++ b/containers/debian-9-git/.devcontainer/Dockerfile
@@ -6,8 +6,6 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/docker-in-docker-compose/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker-compose/.devcontainer/Dockerfile
@@ -8,8 +8,7 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
+
 # Docker Compose version
 ARG COMPOSE_VERSION=1.24.0
 

--- a/containers/docker-in-docker/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker/.devcontainer/Dockerfile
@@ -9,8 +9,7 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
+
 # Docker Compose version
 ARG COMPOSE_VERSION=1.24.0
 

--- a/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.1
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:2.1
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/dotnetcore-latest-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest-fsharp/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:latest
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM mcr.microsoft.com/dotnet/core/sdk:latest
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -5,6 +5,9 @@
 
 FROM golang:1
 
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \

--- a/containers/java-11/.devcontainer/Dockerfile
+++ b/containers/java-11/.devcontainer/Dockerfile
@@ -47,6 +47,3 @@ ENV DEBIAN_FRONTEND=dialog
 
 # Allow for a consistant java home location for settings - image is changing over time
 RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi
-
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash

--- a/containers/java-12/.devcontainer/Dockerfile
+++ b/containers/java-12/.devcontainer/Dockerfile
@@ -39,6 +39,3 @@ RUN yum clean all
 
 # Allow for a consistent java home location for settings - image is changing over time
 RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi
-
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash

--- a/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
+++ b/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
@@ -40,6 +40,3 @@ ENV DEBIAN_FRONTEND=dialog
 
 # Allow for a consistant java home location for settings - image is changing over time
 RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi
-
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -47,6 +47,3 @@ ENV DEBIAN_FRONTEND=dialog
 
 # Allow for a consistant java home location for settings - image is changing over time
 RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi
-
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash

--- a/containers/javascript-node-8/.devcontainer/Dockerfile
+++ b/containers/javascript-node-8/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM node:8
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM node:lts
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/javascript-node-lts/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM node:lts
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/kubernetes-helm/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm/.devcontainer/Dockerfile
@@ -8,8 +8,6 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/markdown/.devcontainer/Dockerfile
+++ b/containers/markdown/.devcontainer/Dockerfile
@@ -10,7 +10,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set the default shell to bash rather than sh
 ENV SHELL /bin/bash
 
-
 # Configure apt and install packages
 RUN apt-get update \
     #

--- a/containers/markdown/.devcontainer/Dockerfile
+++ b/containers/markdown/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM debian:9
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/perl/.devcontainer/Dockerfile
+++ b/containers/perl/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM perl:5
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/php-7/.devcontainer/Dockerfile
+++ b/containers/php-7/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM php:7-cli
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/plantuml/.devcontainer/Dockerfile
+++ b/containers/plantuml/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM openjdk:8
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/powershell/.devcontainer/Dockerfile
+++ b/containers/powershell/.devcontainer/Dockerfile
@@ -11,6 +11,3 @@ RUN apt-get update && apt-get -y install git procps \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash

--- a/containers/python-2/.devcontainer/Dockerfile
+++ b/containers/python-2/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM python:2
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Copy requirements.txt (if found) to a temp locaition so we can install it. Also
 # copy "noop.txt" so the COPY instruction does not fail if no requirements.txt exists.

--- a/containers/python-3-anaconda/.devcontainer/Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM continuumio/anaconda3
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM continuumio/miniconda3
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM python:3
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 ENV PYTHONUNBUFFERED 1
 

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM python:3
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Copy requirements.txt (if found) to a temp locaition so we can install it. Also
 # copy "noop.txt" so the COPY instruction does not fail if no requirements.txt exists.

--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM rocker/r-apt:bionic
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/ruby-2-rails-5/.devcontainer/Dockerfile
+++ b/containers/ruby-2-rails-5/.devcontainer/Dockerfile
@@ -2,8 +2,6 @@ FROM debian:latest
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/ruby-2-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-2-sinatra/.devcontainer/Dockerfile
@@ -2,8 +2,6 @@ FROM debian:latest
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/ruby-2/.devcontainer/Dockerfile
+++ b/containers/ruby-2/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ ENV SHELL /bin/bash
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils 2>&1 \
     # Verify git, process tools installed
-    && apt-get update && apt-get -y install git procps lsb-release \
+    && apt-get -y install git procps lsb-release \
     #
     # Install ruby-debug-ide and debase
     && gem install ruby-debug-ide \

--- a/containers/ruby-2/.devcontainer/Dockerfile
+++ b/containers/ruby-2/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM ruby:2
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/rust/.devcontainer/Dockerfile
+++ b/containers/rust/.devcontainer/Dockerfile
@@ -4,10 +4,9 @@
 #-------------------------------------------------------------------------------------------------------------
 
 FROM rust:1
+
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/swift-4/.devcontainer/Dockerfile
+++ b/containers/swift-4/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM swift:4
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/typescript-node-8/.devcontainer/Dockerfile
+++ b/containers/typescript-node-8/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM node:8
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/typescript-node-lts/.devcontainer/Dockerfile
+++ b/containers/typescript-node-lts/.devcontainer/Dockerfile
@@ -7,8 +7,6 @@ FROM node:lts
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash instead of sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
+++ b/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
@@ -6,8 +6,6 @@ FROM ubuntu:bionic
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
-# Set the default shell to bash rather than sh
-ENV SHELL /bin/bash
 
 # Configure apt and install packages
 RUN apt-get update \


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-dev-containers/issues/85

VS Code Remote now pays attention to /etc/passwd, so it is no longer necessary to include ENV SHELL in dev container definitions. 
