### PR TITLE
Alpine definition

### DIFF
--- a/containers/alpine-3.10-git/.devcontainer/Dockerfile
+++ b/containers/alpine-3.10-git/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+FROM alpine:3.10
+
+ARG GLIBC_VERSION=2.29-r0
+
+RUN apk add --no-cache -q git \
+    #
+    # Install glibc compatibility - optional, but extnesion more likely to work
+    && apk add --no-cache ca-certificates wget libstdc++ libgcc \
+    && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
+    && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \
+    && apk add --no-cache glibc-${GLIBC_VERSION}.apk \
+    && rm glibc-${GLIBC_VERSION}.apk

--- a/containers/alpine-3.10-git/.devcontainer/Dockerfile
+++ b/containers/alpine-3.10-git/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ ARG GLIBC_VERSION=2.29-r0
 
 RUN apk add --no-cache -q git \
     #
-    # Install glibc compatibility - optional, but extnesion more likely to work
+    # Install glibc compatibility - optional, but extensions more likely to work
     && apk add --no-cache ca-certificates wget libstdc++ libgcc \
     && wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub \
     && wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/glibc-${GLIBC_VERSION}.apk \

--- a/containers/alpine-3.10-git/.devcontainer/devcontainer.json
+++ b/containers/alpine-3.10-git/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+{
+	"name": "Alpine 3.10 & Git",
+	"dockerFile": "Dockerfile",
+
+	// Uncomment the next line if you will use a ptrace-based debugger like C++, Go, and Rust.
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [],
+
+	// Uncomment the next line to automatically install extensions.
+	// "extensions": [ "eamodio.gitlens" ],
+
+	// Uncomment the next line if you want to add in default container specific settings.json values
+	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Add the IDs of any extensions you want installed in the array below.
+	"extensions": []
+}

--- a/containers/alpine-3.10-git/.npmignore
+++ b/containers/alpine-3.10-git/.npmignore
@@ -1,0 +1,4 @@
+README.md
+test-project
+.vscode
+.npmignore

--- a/containers/alpine-3.10-git/README.md
+++ b/containers/alpine-3.10-git/README.md
@@ -1,0 +1,49 @@
+# Alpine 3.10 & Git
+
+## Summary
+
+*Simple Alpine 3.10 container with Git and glibc compat installed.*
+
+| Metadata | Value |  
+|----------|-------|
+| *Contributors* | The VS Code Team |
+| *Definition type* | Dockerfile |
+| *Languages, platforms* | Any |
+
+## Using this definition with an existing folder
+
+This definition does not require any special steps to use. However, the `Dockerfile` includes **optional** `glibc` compatibility support which will reduce the chances of extensions with native dependencies failing. If you want, you can remove this section of the Dockerfile and rebuild the container with your preferred extensions installed to see if you actually need it.
+
+Just follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Create Container Configuration File...** from the command palette.
+   3. Select the Alpine 3.10 & Git definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of `containers/alpine-3.10-git/.devcontainer` to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## Testing the definition
+
+This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Clone this repository.
+3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
+4. Select the `containers/alpine-3.10-git` folder.
+5. Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> and type the following command to verify installation: ``
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)


### PR DESCRIPTION
Now that we have Alpine support in Remote - Containers for VS Code Insiders (🎉🎉🎉), it seems to make sense to create a container definition similar to the Debian / Ubuntu.

One of the things I noticed was the C++ extension didn't work out-of-box since it seemed to depend on glibc. So this container definition includes an optional glibc compat library for that reason - it should raise the chances of extensions working unmodified, so it seemed worth including in addition to git.

Anything else that jumps out we should include @chrmarti?