### PR TITLE
Tweak Python 3 setup

### DIFF
--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Copy requirements.txt (if found) to a temp locaition so we can install it. Also
 # copy "noop.txt" so the COPY instruction does not fail if no requirements.txt exists.
-COPY requirements.txt* .devcontainer/noop.txt /tmp/pip-tmp/
+COPY requirements.txt .devcontainer/noop.txt /tmp/pip-tmp/
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -8,9 +8,11 @@ FROM python:3
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Copy requirements.txt (if found) to a temp locaition so we can install it. Also
-# copy "noop.txt" so the COPY instruction does not fail if no requirements.txt exists.
-COPY requirements.txt .devcontainer/noop.txt /tmp/pip-tmp/
+# Copy requirements.txt (if found) to a temp location so we can install it. The `*`
+# is required so COPY doesn't think that part of the command should fail is nothing is
+# found. Also copy "noop.txt" so the COPY instruction copies _something_ to guarantee
+# success somehow.
+COPY *requirements.txt .devcontainer/noop.txt /tmp/pip-tmp/
 
 # Configure apt and install packages
 RUN apt-get update \

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -20,10 +20,10 @@ RUN apt-get update \
     && apt-get -y install git procps lsb-release \
     #
     # Install pylint
-    && pip install pylint \
+    && pip --disable-pip-version-check --no-cache-dir install pylint \
     #
     # Update Python environment based on requirements.txt (if presenet)
-    && if [ -f "/tmp/pip-tmp/requirements.txt" ]; then pip install -r /tmp/pip-tmp/requirements.txt; fi \
+    && if [ -f "/tmp/pip-tmp/requirements.txt" ]; then pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt; fi \
     && rm -rf /tmp/pip-tmp \
     #
     # Clean up

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
 	"settings": {
 		"python.pythonPath": "/usr/local/bin/python",
 		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/usr/local/bin/pylint",
 		"python.linting.enabled": true
 	}
 }


### PR DESCRIPTION
- Drop an unnecessary `*` at the end of a file name for copying
- Don't have pip bother checking for a newer version of pip (assume it's new enough as it came with the latest version of Python which the container is pulling from)
- Don't cache wheel files (to keep the image smaller)
- Specify the location of the `pylint` executable to turn on Pylint development