### PR TITLE
Puppet PDK Docker Container file

### DIFF
--- a/containers/puppet/.devcontainer/Dockerfile
+++ b/containers/puppet/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:2
+
+RUN gem install ruby-debug-ide
+RUN gem install debase
+
+ADD https://apt.puppetlabs.com/puppet6-release-xenial.deb /puppet6-release-xenial.deb
+RUN dpkg -i /puppet6-release-xenial.deb
+
+RUN apt-get update \
+    && apt-get -y install git procps pdk
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*

--- a/containers/puppet/.devcontainer/devcontainer.json
+++ b/containers/puppet/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Puppet Development Kit - Dockerfile",
+  "dockerFile": "Dockerfile",
+
+  // Uncomment the next line if you want to publish any ports.
+  // "appPort": [],
+
+  // Uncomment the next line if you want to add in default container specific settings.json values
+  // "settings":  { "workbench.colorTheme": "Quiet Light" },
+
+  // Uncomment the next line to run commands after the container is created.
+  // "postCreateCommand": "pdk --version",
+
+  "extensions": [
+    "jpogran.puppet-vscode",
+    "rebornix.Ruby"
+  ]
+}

--- a/containers/puppet/.npmignore
+++ b/containers/puppet/.npmignore
@@ -1,0 +1,4 @@
+README.md
+test-project
+.vscode
+.npmignore

--- a/containers/puppet/README.md
+++ b/containers/puppet/README.md
@@ -1,0 +1,41 @@
+# Puppet Development Kit Docker Container
+
+## Summary
+
+*Develop Puppet based applications. Includes everything you need to get up and running.*
+
+| Metadata | Value |
+|----------|-------|
+| *Contributors* | Puppet |
+| *Definition type* | Dockerfile |
+| *Languages, platforms* | Puppet |
+
+## Description
+
+Develop Puppet manifests, modules, and code using VS Code without installing any extra tools: `puppet-development-in-a-box`!
+
+## Using this definition with an existing folder
+
+Just follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Create Container Configuration File...** from the command palette.
+   3. Select the `Puppet` definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).


### PR DESCRIPTION
This PR adds a [Puppet Development Kit](https://puppet.com/docs/pdk/1.x/pdk.html) docker container to VS Code Remote Container extension. It contains a Dockerfile that uses a base `ruby:2` docker image and installs PDK, git, and Ruby debugging gems.

This allows a user to create and edit Puppet manifests, modules and other code without installing the PDK or other Ruby tools on their machine. The [Puppet VSCode Extension](https://pup.pt/vscode) is included in the defintion to provide advanced intellisense and other IDE capabilties. The Ruby VS Code extension is also included to help with editing Ruby files.