### PR TITLE
Suppress the warning: “unable to initialize frontend: Dialog” on Debian based images.

### DIFF
--- a/container-templates/docker-compose/.devcontainer/Dockerfile
+++ b/container-templates/docker-compose/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/container-templates/docker-compose/.devcontainer/Dockerfile
+++ b/container-templates/docker-compose/.devcontainer/Dockerfile
@@ -31,5 +31,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 

--- a/container-templates/dockerfile/.devcontainer/Dockerfile
+++ b/container-templates/dockerfile/.devcontainer/Dockerfile
@@ -26,4 +26,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/container-templates/dockerfile/.devcontainer/Dockerfile
+++ b/container-templates/dockerfile/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -56,5 +56,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 

--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, required tools installed
     && apt-get install -y \

--- a/containers/azure-blockchain/.devcontainer/Dockerfile
+++ b/containers/azure-blockchain/.devcontainer/Dockerfile
@@ -38,4 +38,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-blockchain/.devcontainer/Dockerfile
+++ b/containers/azure-blockchain/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
     && apt-get -y install git procps \

--- a/containers/azure-cli/.devcontainer/Dockerfile
+++ b/containers/azure-cli/.devcontainer/Dockerfile
@@ -28,4 +28,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-cli/.devcontainer/Dockerfile
+++ b/containers/azure-cli/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
     && apt-get -y install git procps \

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
@@ -34,4 +34,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
     && apt-get -y install \

--- a/containers/azure-functions-dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-latest/.devcontainer/Dockerfile
@@ -34,4 +34,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-functions-dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-latest/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
     && apt-get -y install \

--- a/containers/azure-functions-java-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-8/.devcontainer/Dockerfile
@@ -38,4 +38,4 @@ RUN apt-get update \
 
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-functions-java-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-8/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
     && apt-get -y install \

--- a/containers/azure-functions-node-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-8/.devcontainer/Dockerfile
@@ -37,4 +37,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
         
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-functions-node-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-8/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
     && apt-get -y install \

--- a/containers/azure-functions-node-lts/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-lts/.devcontainer/Dockerfile
@@ -37,4 +37,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
         
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-functions-node-lts/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-lts/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
     && apt-get -y install \

--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -45,4 +45,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
         
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
     && apt-get -y install \

--- a/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, required tools installed
     && apt-get install -y \

--- a/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
@@ -41,4 +41,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -68,4 +68,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ ARG TFLINT_VERSION=0.7.5
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Install git, required tools installed
     && apt-get install -y \

--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ ENV BAZEL_SHA256=5b9ab8a68c53421256909f79c47bde76a051910217531cbf35ee995448254fa
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verifty git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -36,4 +36,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/cpp/.devcontainer/Dockerfile
+++ b/containers/cpp/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     # 
     # Verify git, process tools, lsb-release (useful for CLI installs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/cpp/.devcontainer/Dockerfile
+++ b/containers/cpp/.devcontainer/Dockerfile
@@ -24,4 +24,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/dart/.devcontainer/Dockerfile
+++ b/containers/dart/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ ENV PATH="$PATH":"/root/.pub-cache/bin"
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/dart/.devcontainer/Dockerfile
+++ b/containers/dart/.devcontainer/Dockerfile
@@ -24,4 +24,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/debian-9-git/.devcontainer/Dockerfile
+++ b/containers/debian-9-git/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/debian-9-git/.devcontainer/Dockerfile
+++ b/containers/debian-9-git/.devcontainer/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/docker-in-docker-compose/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker-compose/.devcontainer/Dockerfile
@@ -36,4 +36,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/docker-in-docker-compose/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker-compose/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ ARG COMPOSE_VERSION=1.24.0
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
     && apt-get -y install git procps \

--- a/containers/docker-in-docker/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ ARG COMPOSE_VERSION=1.24.0
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
     && apt-get -y install git procps \

--- a/containers/docker-in-docker/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker/.devcontainer/Dockerfile
@@ -37,4 +37,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs)
     && apt-get -y install git procps lsb-release \

--- a/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
@@ -24,4 +24,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1/.devcontainer/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/dotnetcore-latest-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest-fsharp/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/dotnetcore-latest-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest-fsharp/.devcontainer/Dockerfile
@@ -24,4 +24,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest/.devcontainer/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt, install packages and tools
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/java-11/.devcontainer/Dockerfile
+++ b/containers/java-11/.devcontainer/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get -y install git procps curl
 RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 
 # Allow for a consistant java home location for settings - image is changing over time
 RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi

--- a/containers/java-11/.devcontainer/Dockerfile
+++ b/containers/java-11/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ FROM openjdk:11-jdk
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1
 
 # Verify git, needed tools installed
 RUN apt-get -y install git procps curl

--- a/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
+++ b/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ FROM tomcat:8.5-jre8
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1
 
 # Verify git, needed tools installed
 RUN apt-get -y install git procps curl lsb-release

--- a/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
+++ b/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
@@ -36,7 +36,7 @@ ENV MAVEN_CONFIG /root/.m2
 RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 
 # Allow for a consistant java home location for settings - image is changing over time
 RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get -y install git procps curl lsb-release
 RUN apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 
 # Allow for a consistant java home location for settings - image is changing over time
 RUN if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -8,7 +8,7 @@ FROM openjdk:8-jdk
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1
 
 # Verify git, needed tools installed
 RUN apt-get -y install git procps curl lsb-release

--- a/containers/javascript-node-8/.devcontainer/Dockerfile
+++ b/containers/javascript-node-8/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \ 
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
     && apt-get install -y git procps \

--- a/containers/javascript-node-8/.devcontainer/Dockerfile
+++ b/containers/javascript-node-8/.devcontainer/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \ 
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
     && apt-get install -y git procps \

--- a/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/javascript-node-lts-postgres/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-postgres/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \ 
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
     && apt-get install -y git procps \

--- a/containers/javascript-node-lts-postgres/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-postgres/.devcontainer/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/javascript-node-lts/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \ 
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
     && apt-get install -y git procps \

--- a/containers/javascript-node-lts/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts/.devcontainer/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/kubernetes-helm/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm/.devcontainer/Dockerfile
@@ -56,4 +56,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/kubernetes-helm/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
     && apt-get -y install git procps \

--- a/containers/markdown/.devcontainer/Dockerfile
+++ b/containers/markdown/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     #
     # Configure apt
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
     && apt-get install -y git procps lsb-release \

--- a/containers/markdown/.devcontainer/Dockerfile
+++ b/containers/markdown/.devcontainer/Dockerfile
@@ -23,4 +23,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/perl/.devcontainer/Dockerfile
+++ b/containers/perl/.devcontainer/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/perl/.devcontainer/Dockerfile
+++ b/containers/perl/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/php-7/.devcontainer/Dockerfile
+++ b/containers/php-7/.devcontainer/Dockerfile
@@ -27,6 +27,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 
 

--- a/containers/php-7/.devcontainer/Dockerfile
+++ b/containers/php-7/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Install git, procps, lsb-release (useful for CLI installs)
     && apt-get -y install git procps lsb-release \

--- a/containers/plantuml/.devcontainer/Dockerfile
+++ b/containers/plantuml/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/plantuml/.devcontainer/Dockerfile
+++ b/containers/plantuml/.devcontainer/Dockerfile
@@ -24,6 +24,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 
 

--- a/containers/python-2/.devcontainer/Dockerfile
+++ b/containers/python-2/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ COPY requirements.txt* .devcontainer/noop.txt /tmp/pip-tmp/
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/python-2/.devcontainer/Dockerfile
+++ b/containers/python-2/.devcontainer/Dockerfile
@@ -32,4 +32,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/python-3-anaconda/.devcontainer/Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/python-3-anaconda/.devcontainer/Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/Dockerfile
@@ -32,6 +32,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 
 

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -32,4 +32,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -34,4 +34,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ COPY requirements.txt* .devcontainer/noop.txt /tmp/pip-tmp/
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -34,6 +34,6 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 
 

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -16,7 +16,7 @@ COPY *requirements.txt .devcontainer/noop.txt /tmp/pip-tmp/
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Install git, process tools, lsb-release (common in install instructions for CLIs) and libzip for R Tools extension
     && apt-get -y install git procps lsb-release libzip-dev \

--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -31,4 +31,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/ruby-2-rails-5/.devcontainer/Dockerfile
+++ b/containers/ruby-2-rails-5/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Install vim, git, process tools, lsb-release
     && apt-get install -y \

--- a/containers/ruby-2-rails-5/.devcontainer/Dockerfile
+++ b/containers/ruby-2-rails-5/.devcontainer/Dockerfile
@@ -43,4 +43,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/ruby-2-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-2-sinatra/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Install vim, git, process tools, lsb-release
     && apt-get install -y \

--- a/containers/ruby-2-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-2-sinatra/.devcontainer/Dockerfile
@@ -41,4 +41,4 @@ RUN apt-get update \
         && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/ruby-2/.devcontainer/Dockerfile
+++ b/containers/ruby-2/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     # Verify git, process tools installed
     && apt-get -y install git procps lsb-release \
     #

--- a/containers/ruby-2/.devcontainer/Dockerfile
+++ b/containers/ruby-2/.devcontainer/Dockerfile
@@ -24,4 +24,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/rust/.devcontainer/Dockerfile
+++ b/containers/rust/.devcontainer/Dockerfile
@@ -28,4 +28,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/rust/.devcontainer/Dockerfile
+++ b/containers/rust/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, needed tools installed
     && apt-get -y install git procps lsb-release \

--- a/containers/swift-4/.devcontainer/Dockerfile
+++ b/containers/swift-4/.devcontainer/Dockerfile
@@ -27,5 +27,5 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=
 

--- a/containers/swift-4/.devcontainer/Dockerfile
+++ b/containers/swift-4/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/typescript-node-8/.devcontainer/Dockerfile
+++ b/containers/typescript-node-8/.devcontainer/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/typescript-node-8/.devcontainer/Dockerfile
+++ b/containers/typescript-node-8/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
     && apt-get install -y git procps \    

--- a/containers/typescript-node-lts/.devcontainer/Dockerfile
+++ b/containers/typescript-node-lts/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \ 
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
     && apt-get install -y git procps \

--- a/containers/typescript-node-lts/.devcontainer/Dockerfile
+++ b/containers/typescript-node-lts/.devcontainer/Dockerfile
@@ -35,4 +35,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=

--- a/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
+++ b/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Configure apt and install packages
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1 \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git procps lsb-release \

--- a/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
+++ b/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
@@ -20,4 +20,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog
+ENV DEBIAN_FRONTEND=


### PR DESCRIPTION
## My checklist

- [x] I read [CONTRIBUTING.md](https://github.com/microsoft/vscode-dev-containers/blob/master/CONTRIBUTING.md)
- [x] Search the issue repository to ensure your report is a new issue
- Recreate the issue after disabling all extensions
- [x] Simplify your code around the issue to better isolate the problem

## My environments

```shellsession
$ docker --version
Docker version 18.09.2, build 6247962
$ docker images debian:9
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
debian              9                   5a6d49d5e833        9 days ago          101MB
```

```shellsession
$ docker run -it debian:9 /bin/bash
root@3ef01a935271:/# env | grep -c DEBIAN_FRONTEND 
0
root@3ef01a935271:/# type dialog
bash: type: dialog: not found
```

## The problem

We occurred the following warnings: `debconf: unable to initialize frontend: Dialog`.

```shellsession
root@e51d8207768e:/# apt-get update -qq
root@e51d8207768e:/# apt-get install --assume-yes --no-install-recommends apt-utils > /dev/null 
debconf: delaying package configuration, since apt-utils is not installed
root@e51d8207768e:/# apt-get install --assume-yes --no-install-recommends locales > /dev/null 
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 76, <> line 2.)
debconf: falling back to frontend: Readline
debconf: unable to initialize frontend: Readline
debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/x86_64-linux-gnu/perl/5.24.1 /usr/local/share/perl/5.24.1 /usr/lib/x86_64-linux-gnu/perl5/5.24 /usr/share/perl5 /usr/lib/x86_64-linux-gnu/perl/5.24 /usr/share/perl/5.24 /usr/local/lib/site_perl /usr/lib/x86_64-linux-gnu/perl-base .) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7, <> line 2.)
debconf: falling back to frontend: Teletype
```

## Solution

- Install the `dialog` package each Debian based image.

And I think we should only unset the `DEBIAN_FRONTEND` environment variable, that sufficient to switch back to default frontend.