### PR TITLE
Avoid warning about ip / ifconfig missing

### DIFF
--- a/container-templates/docker-compose/.devcontainer/Dockerfile
+++ b/container-templates/docker-compose/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # *****************************************************
     # * Add steps for installing needed dependencies here *

--- a/container-templates/dockerfile/.devcontainer/Dockerfile
+++ b/container-templates/dockerfile/.devcontainer/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # *****************************************************
     # * Add steps for installing needed dependencies here *

--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
     # Verify git, required tools installed
     && apt-get install -y \
         git \
+        iproute2 \
         curl \
         procps \
         unzip \

--- a/containers/azure-blockchain/.devcontainer/Dockerfile
+++ b/containers/azure-blockchain/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Install nodejs
     && curl -sL https://deb.nodesource.com/setup_10.x | bash - \

--- a/containers/azure-cli/.devcontainer/Dockerfile
+++ b/containers/azure-cli/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Install the Azure CLI
     && apt-get install -y apt-transport-https curl gnupg2 lsb-release \

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        iproute2 \
         procps \
         curl \
         apt-transport-https \

--- a/containers/azure-functions-dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-latest/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        iproute2 \
         procps \
         curl \
         apt-transport-https \

--- a/containers/azure-functions-java-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-8/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        iproute2 \
         procps \
         curl \
         apt-transport-https \

--- a/containers/azure-functions-node-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-8/.devcontainer/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        iproute2 \
         procps \
         curl \
         apt-transport-https \

--- a/containers/azure-functions-node-lts/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-lts/.devcontainer/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        iproute2 \
         procps \
         curl \
         apt-transport-https \

--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        iproute2 \
         procps \
         curl \
         apt-transport-https \

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ ARG USER_GID=$USER_UID
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
-    # Install git, required tools installed
+    # install git iproute2, required tools installed
     && apt-get install -y \
         git \
         curl \

--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verifty git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install Bazel
     && apt-get -y install curl pkg-config zip g++ zlib1g-dev unzip python \

--- a/containers/cpp/.devcontainer/Dockerfile
+++ b/containers/cpp/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     # 
     # Verify git, process tools, lsb-release (useful for CLI installs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install C++ tools
     && apt-get -y install build-essential cmake cppcheck valgrind \

--- a/containers/dart/.devcontainer/Dockerfile
+++ b/containers/dart/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/debian-9-git/.devcontainer/Dockerfile
+++ b/containers/debian-9-git/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/docker-in-docker-compose/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker-compose/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Install Docker CE CLI
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/containers/docker-in-docker/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Install Docker CE CLI
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs)
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install F#
     && apt-get install -y fsharp \

--- a/containers/dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/dotnetcore-latest-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest-fsharp/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install F#
     && apt-get install -y fsharp \

--- a/containers/dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install gocode-gomod
     && go get -x -d github.com/stamblerre/gocode 2>&1 \

--- a/containers/java-11/.devcontainer/Dockerfile
+++ b/containers/java-11/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git procps curl lsb-release
+    && apt-get -y install git iproute2 procps curl lsb-release
 
 #-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
 # ARG MAVEN_VERSION=3.6.1

--- a/containers/java-12/.devcontainer/Dockerfile
+++ b/containers/java-12/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME 
 
 # Verify git, needed tools installed
-RUN yum install -y git curl procps unzip
+RUN yum install -y git iproute2 curl procps unzip
 
 #-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
 # ARG MAVEN_VERSION=3.6.1

--- a/containers/java-12/.devcontainer/Dockerfile
+++ b/containers/java-12/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME 
 
 # Verify git, needed tools installed
-RUN yum install -y git iproute2 curl procps unzip
+RUN yum install -y git net-tools curl procps unzip
 
 #-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
 # ARG MAVEN_VERSION=3.6.1

--- a/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
+++ b/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git procps curl lsb-release \
+    && apt-get -y install git iproute2 procps curl lsb-release \
     #
     # Install openjdk 8
     && apt-get -y install --no-install-recommends openjdk-8-jdk \

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git procps curl lsb-release
+    && apt-get -y install git iproute2 procps curl lsb-release
 
 #-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
 # ARG MAVEN_VERSION=3.6.1

--- a/containers/javascript-node-8/.devcontainer/Dockerfile
+++ b/containers/javascript-node-8/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
-    && apt-get install -y git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Remove outdated yarn from /opt and install via package 
     # so it can be easily updated via apt-get upgrade yarn

--- a/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-mongo/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
-    && apt-get install -y git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Remove outdated yarn from /opt and install via package 
     # so it can be easily updated via apt-get upgrade yarn

--- a/containers/javascript-node-lts-postgres/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-postgres/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
-    && apt-get install -y git procps \
+    && apt-get-y install git iproute2 procps \
     #
     # Remove outdated yarn from /opt and install via package 
     # so it can be easily updated via apt-get upgrade yarn

--- a/containers/javascript-node-lts-postgres/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts-postgres/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
-    && apt-get-y install git iproute2 procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Remove outdated yarn from /opt and install via package 
     # so it can be easily updated via apt-get upgrade yarn

--- a/containers/javascript-node-lts/.devcontainer/Dockerfile
+++ b/containers/javascript-node-lts/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
-    && apt-get install -y git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Remove outdated yarn from /opt and install via package 
     # so it can be easily updated via apt-get upgrade yarn

--- a/containers/kubernetes-helm/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm/.devcontainer/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Install Docker CE CLI
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/containers/markdown/.devcontainer/Dockerfile
+++ b/containers/markdown/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
-    && apt-get install -y git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/perl/.devcontainer/Dockerfile
+++ b/containers/perl/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/php-7/.devcontainer/Dockerfile
+++ b/containers/php-7/.devcontainer/Dockerfile
@@ -20,8 +20,8 @@ ARG USER_GID=$USER_UID
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
-    # Install git, procps, lsb-release (useful for CLI installs)
-    && apt-get -y install git procps iproute2 lsb-release \
+    # install git iproute2, procps, lsb-release (useful for CLI installs)
+    && apt-get -y install git iproute2 procps iproute2 lsb-release \
     #
     # Install xdebug
     && yes | pecl install xdebug \

--- a/containers/plantuml/.devcontainer/Dockerfile
+++ b/containers/plantuml/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install GraphViz
     && apt-get install -y graphviz \

--- a/containers/powershell/.devcontainer/Dockerfile
+++ b/containers/powershell/.devcontainer/Dockerfile
@@ -13,8 +13,8 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-# Install git, process tools
-RUN apt-get update && apt-get -y install git procps \
+# install git iproute2, process tools
+RUN apt-get update && apt-get -y install git iproute2 procps \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/puppet/.devcontainer/Dockerfile
+++ b/containers/puppet/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ ADD https://apt.puppetlabs.com/puppet6-release-xenial.deb /puppet6-release-xenia
 RUN dpkg -i /puppet6-release-xenial.deb
 
 RUN apt-get update \
-    && apt-get -y install git procps pdk \
+    && apt-get -y install git iproute2 procps pdk \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/python-2/.devcontainer/Dockerfile
+++ b/containers/python-2/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install pylint
     && pip install pylint \

--- a/containers/python-3-anaconda/.devcontainer/Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps iproute2 lsb-release \
+    && apt-get -y install git iproute2 procps iproute2 lsb-release \
     #
     # Install pylint
     && /opt/conda/bin/pip install pylint \

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps iproute2 lsb-release \
+    && apt-get -y install git iproute2 procps iproute2 lsb-release \
     #
     # Install pylint
     && /opt/conda/bin/pip install pylint \

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install pylint
     && pip install pylint \

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install pylint
     && pip --disable-pip-version-check --no-cache-dir install pylint \

--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -20,8 +20,8 @@ ARG USER_GID=$USER_UID
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
-    # Install git, process tools, lsb-release (common in install instructions for CLIs) and libzip for R Tools extension
-    && apt-get -y install git procps lsb-release libzip-dev \
+    # install git iproute2, process tools, lsb-release (common in install instructions for CLIs) and libzip for R Tools extension
+    && apt-get -y install git iproute2 procps lsb-release libzip-dev \
     #
     # Register Microsoft key and feed
     && wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb \

--- a/containers/ruby-2-rails-5/.devcontainer/Dockerfile
+++ b/containers/ruby-2-rails-5/.devcontainer/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
     && apt-get install -y \
         vim \
         git \
+        iproute2 \
         procps \
         lsb-release \
     #

--- a/containers/ruby-2-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-2-sinatra/.devcontainer/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
     && apt-get install -y \
         vim \
         git \
+        iproute2 \ 
         procps \
         lsb-release \
     #

--- a/containers/ruby-2/.devcontainer/Dockerfile
+++ b/containers/ruby-2/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ ARG USER_GID=$USER_UID
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     # Verify git, process tools installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install ruby-debug-ide and debase
     && gem install ruby-debug-ide \

--- a/containers/rust/.devcontainer/Dockerfile
+++ b/containers/rust/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install other dependencies
     && apt-get install -y lldb-3.9 \

--- a/containers/swift-4/.devcontainer/Dockerfile
+++ b/containers/swift-4/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Install SourceKite, see https://github.com/vknabel/vscode-swift-development-environment/blob/master/README.md#installation
     && git clone https://github.com/jinmingjian/sourcekite.git \

--- a/containers/typescript-node-8/.devcontainer/Dockerfile
+++ b/containers/typescript-node-8/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git and needed tools are installed
-    && apt-get install -y git procps \    
+    && apt-get -y install git iproute2 procps \    
     #
     # Remove outdated yarn from /opt and install via package 
     # so it can be easily updated via apt-get upgrade yarn

--- a/containers/typescript-node-lts/.devcontainer/Dockerfile
+++ b/containers/typescript-node-lts/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
-    && apt-get install -y git procps \
+    && apt-get -y install git iproute2 procps \
     #
     # Remove outdated yarn from /opt and install via package 
     # so it can be easily updated via apt-get upgrade yarn

--- a/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
+++ b/containers/ubuntu-18.04-git/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git procps lsb-release \
+    && apt-get -y install git iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/repository-containers/github.com/angular/angular/.devcontainer/Dockerfile
+++ b/repository-containers/github.com/angular/angular/.devcontainer/Dockerfile
@@ -5,8 +5,8 @@
 
 FROM openjdk:8
 
-# Install git
-RUN apt-get update && apt-get -y install git
+# install git iproute2
+RUN apt-get update && apt-get -y install git iproute2
 
 # https support
 RUN apt-get install apt-transport-https

--- a/repository-containers/github.com/aymericdamien/TensorFlow-Examples/.devcontainer/Dockerfile
+++ b/repository-containers/github.com/aymericdamien/TensorFlow-Examples/.devcontainer/Dockerfile
@@ -5,8 +5,8 @@
 
 FROM python:3
 
-# Install git
-RUN apt-get update && apt-get -y install git
+# install git iproute2
+RUN apt-get update && apt-get -y install git iproute2
 
 # Install dev tools
 RUN pip install pylint

--- a/repository-containers/github.com/barryclark/jekyll-now/.devcontainer/Dockerfile
+++ b/repository-containers/github.com/barryclark/jekyll-now/.devcontainer/Dockerfile
@@ -5,8 +5,8 @@
 
 FROM ruby:2
 
-# Install git, process tools
-RUN apt-get update && apt-get -y install git procps
+# install git iproute2, process tools
+RUN apt-get update && apt-get -y install git iproute2 procps
 
 # Clean up
 RUN apt-get autoremove -y \
@@ -14,4 +14,4 @@ RUN apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install jekyll
-RUN gem install github-pages
+RUN gem install git iproute2hub-pages

--- a/repository-containers/github.com/django/django/.devcontainer/Dockerfile
+++ b/repository-containers/github.com/django/django/.devcontainer/Dockerfile
@@ -5,8 +5,8 @@
 
 FROM python:3
 
-# Install git
-RUN apt-get update && apt-get -y install git
+# install git iproute2
+RUN apt-get update && apt-get -y install git iproute2
 
 # Install node
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -


### PR DESCRIPTION
The terminal output in some images complains about ip /ifconfig being missing on certain images. This update ensures the packages are present.