### PR TITLE
Add setting to workaround VSCR #1203, add runServices comment to Docker Compose defs

### DIFF
--- a/container-templates/docker-compose/.devcontainer/devcontainer.json
+++ b/container-templates/docker-compose/.devcontainer/devcontainer.json
@@ -12,16 +12,21 @@
 	// connected. This is typically a volume mount in .devcontainer/docker-compose.yml
 	"workspaceFolder": "/workspace",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
 	// Uncomment this like if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "uname -a"
 
-	// Add the IDs of any extensions you want installed in the array below.
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": []
-
 }

--- a/container-templates/dockerfile/.devcontainer/devcontainer.json
+++ b/container-templates/dockerfile/.devcontainer/devcontainer.json
@@ -18,16 +18,18 @@
 		// "-u", "vscode"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
 
-	// Add the IDs of any extensions you want installed in the array below.
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": []
-
-}
+	}

--- a/container-templates/image/.devcontainer/devcontainer.json
+++ b/container-templates/image/.devcontainer/devcontainer.json
@@ -15,15 +15,18 @@
 		// "-u", "vscode"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created - like installing git
 	// "postCreateCommand": "apt-get update && apt-get install -y git",
 
-	// Add the IDs of any extensions you want installed in the array below.
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": []
 }

--- a/containers/azure-ansible/.devcontainer/devcontainer.json
+++ b/containers/azure-ansible/.devcontainer/devcontainer.json
@@ -13,24 +13,26 @@
 		"-v", "/var/run/docker.sock:/var/run/docker.sock"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+        "remote.extensionKind": {
+            "ms-azuretools.vscode-docker": "workspace"
+		}
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "ansible --version",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"vscoss.vscode-ansible",
 		"redhat.vscode-yaml",
 		"ms-vscode.azurecli",
 		"ms-azuretools.vscode-docker"
-	],
-	"settings": {
-        "remote.extensionKind": {
-            "ms-azuretools.vscode-docker": "workspace"
-		}
-	}
+	]
 }

--- a/containers/azure-blockchain/.devcontainer/devcontainer.json
+++ b/containers/azure-blockchain/.devcontainer/devcontainer.json
@@ -2,12 +2,15 @@
 	"name": "Azure Blockchain",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-	
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
-	
+		
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "az --version",
 
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.azurecli",
 		"azblockchain.azure-blockchain"

--- a/containers/azure-cli/.devcontainer/devcontainer.json
+++ b/containers/azure-cli/.devcontainer/devcontainer.json
@@ -13,15 +13,19 @@
 		// "-u", "vscode"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "az --version",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.azurecli"
 	]

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/devcontainer.json
@@ -3,8 +3,11 @@
 	"dockerFile": "Dockerfile",
 	"appPort": 7071,
 
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
@@ -14,6 +17,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"ms-vscode.csharp"

--- a/containers/azure-functions-dotnetcore-latest/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-latest/.devcontainer/devcontainer.json
@@ -3,8 +3,11 @@
 	"dockerFile": "Dockerfile",
 	"appPort": 7071,
 
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
@@ -14,6 +17,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"ms-vscode.csharp"

--- a/containers/azure-functions-java-8/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-8/.devcontainer/devcontainer.json
@@ -3,8 +3,12 @@
 	"dockerFile": "Dockerfile",
 	"appPort": 7071,
 
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"java.home": "/docker-java-home"
+	},
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "java -version",
@@ -14,11 +18,9 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"vscjava.vscode-java-pack"
-	],
-	"settings": {
-		"java.home": "/docker-java-home"
-	}
+	]
 }

--- a/containers/azure-functions-node-8/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-node-8/.devcontainer/devcontainer.json
@@ -3,8 +3,11 @@
 	"dockerFile": "Dockerfile",
 	"appPort": 7071,
 
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "npm install",
@@ -14,6 +17,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "node" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"dbaeumer.vscode-eslint"

--- a/containers/azure-functions-node-lts/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-node-lts/.devcontainer/devcontainer.json
@@ -3,8 +3,11 @@
 	"dockerFile": "Dockerfile",
 	"appPort": 7071,
 
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "npm install",
@@ -14,6 +17,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "node" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"dbaeumer.vscode-eslint"

--- a/containers/azure-functions-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-python-3/.devcontainer/devcontainer.json
@@ -11,17 +11,22 @@
 		"-v","/var/run/docker.sock:/var/run/docker.sock"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings":  {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"remote.extensionKind": {
+			"ms-azuretools.vscode-docker": "workspace"
+		}
+	},
+
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "npm install",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"ms-azuretools.vscode-docker",
 		"ms-python.python"
-	],
-	"settings":  {
-		"remote.extensionKind": {
-			"ms-azuretools.vscode-docker": "workspace"
-		}
-	}
+	]
 }

--- a/containers/azure-machine-learning-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-machine-learning-python-3/.devcontainer/devcontainer.json
@@ -10,22 +10,28 @@
 		"-v", "/var/run/docker.sock:/var/run/docker.sock"
 	],
 	
-	// Uncomment the next line if you want to publish any ports.
-	// "appPort": [],
 
-	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "pip install -r requirements.txt",
-	
-	"extensions": [ 
-		"ms-toolsai.vscode-ai",
-		"ms-azuretools.vscode-docker"
-	], 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
 	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
 		"remote.extensionKind": {
 			"ms-azuretools.vscode-docker": "workspace"
 		},
 		"python.pythonPath": "/opt/conda/bin/python",
 		"python.linting.pylintEnabled": true,
 		"python.linting.enabled": true
-	}
+	},
+	
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [],
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "pip install -r requirements.txt",
+	
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [ 
+		"ms-toolsai.vscode-ai",
+		"ms-azuretools.vscode-docker"
+	]
 } 

--- a/containers/azure-terraform/.devcontainer/devcontainer.json
+++ b/containers/azure-terraform/.devcontainer/devcontainer.json
@@ -13,24 +13,26 @@
 		"-v", "/var/run/docker.sock:/var/run/docker.sock"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+        "remote.extensionKind": {
+            "ms-azuretools.vscode-docker": "workspace"
+		}
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "terraform --version",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"mauve.terraform",
 		"ms-azuretools.vscode-azureterraform",
 		"ms-vscode.azurecli",
         "ms-azuretools.vscode-docker"
-	],
-	"settings": {
-        "remote.extensionKind": {
-            "ms-azuretools.vscode-docker": "workspace"
-		}
-	}
+	]
 }

--- a/containers/bazel/.devcontainer/devcontainer.json
+++ b/containers/bazel/.devcontainer/devcontainer.json
@@ -13,15 +13,19 @@
 		// "-u", "vscode"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"devondcarew.bazel-code"
 	]

--- a/containers/cpp/.devcontainer/devcontainer.json
+++ b/containers/cpp/.devcontainer/devcontainer.json
@@ -10,15 +10,19 @@
 		"--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "gcc -v",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.cpptools"
 	]

--- a/containers/dart/.devcontainer/devcontainer.json
+++ b/containers/dart/.devcontainer/devcontainer.json
@@ -5,8 +5,11 @@
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"dart-code.dart-code"
 	]

--- a/containers/debian-9-git/.devcontainer/devcontainer.json
+++ b/containers/debian-9-git/.devcontainer/devcontainer.json
@@ -12,12 +12,15 @@
 		// "-u", "vscode"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
-
-	// Add the IDs of any extensions you want installed in the array below.
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": []
 }

--- a/containers/docker-existing-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-existing-docker-compose/.devcontainer/devcontainer.json
@@ -17,15 +17,21 @@
 	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
 	"workspaceFolder": "/workspace",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created - for example installing git.
 	// "postCreateCommand": "apt-get update && apt-get install -y git",
 
-	// Add the IDs of any extensions you want installed in the array below.
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": []
 }

--- a/containers/docker-existing-dockerfile/.devcontainer/devcontainer.json
+++ b/containers/docker-existing-dockerfile/.devcontainer/devcontainer.json
@@ -21,15 +21,18 @@
 		// "-u", "vscode"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-	
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created - for example installing git.
 	// "postCreateCommand": "apt-get update && apt-get install -y git",
 
-	// Add the IDs of any extensions you want installed in the array below.
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": []
 }

--- a/containers/docker-in-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-in-docker-compose/.devcontainer/devcontainer.json
@@ -4,6 +4,18 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "docker-in-docker",
 	"workspaceFolder": "/workspace",
+	
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"remote.extensionKind": {
+			"ms-azuretools.vscode-docker": "workspace"
+		}
+	},
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
 
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
@@ -11,12 +23,8 @@
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "docker --version"
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-docker"
-	],
-	"settings": {
-		"remote.extensionKind": {
-			"ms-azuretools.vscode-docker": "workspace"
-		}
-	}
+	]	
 }

--- a/containers/docker-in-docker/.devcontainer/devcontainer.json
+++ b/containers/docker-in-docker/.devcontainer/devcontainer.json
@@ -13,18 +13,23 @@
 		"-v", "/var/run/docker.sock:/var/run/docker.sock"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+	    "remote.extensionKind": {
+			"ms-azuretools.vscode-docker": "workspace"
+		}	
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "docker --version",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-docker"
-	],
-	"settings": {
-	    "remote.extensionKind": {
-			"ms-azuretools.vscode-docker": "workspace"
-		}	
-	}
+	]
 }

--- a/containers/dotnetcore-2.1-fsharp/.devcontainer/devcontainer.json
+++ b/containers/dotnetcore-2.1-fsharp/.devcontainer/devcontainer.json
@@ -2,6 +2,13 @@
 	"name": "F# (.NET Core 2.1)",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"FSharp.fsacRuntime":"netcore"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
@@ -13,11 +20,9 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"Ionide.Ionide-fsharp",
 		"ms-vscode.csharp"
-	],
-	"settings": {
-		"FSharp.fsacRuntime":"netcore"
-	}
+	]
 }

--- a/containers/dotnetcore-2.1/.devcontainer/devcontainer.json
+++ b/containers/dotnetcore-2.1/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "C# (.NET Core 2.1)",
 	"dockerFile": "Dockerfile",
 	
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore"
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.csharp"
 	]

--- a/containers/dotnetcore-latest-fsharp/.devcontainer/devcontainer.json
+++ b/containers/dotnetcore-latest-fsharp/.devcontainer/devcontainer.json
@@ -2,6 +2,13 @@
 	"name": "F# (.NET Core Latest)",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"FSharp.fsacRuntime":"netcore"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
@@ -13,11 +20,9 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"Ionide.Ionide-fsharp",
 		"ms-vscode.csharp"
-	],
-	"settings": {
-		"FSharp.fsacRuntime":"netcore"
-	}
+	]
 }

--- a/containers/dotnetcore-latest/.devcontainer/devcontainer.json
+++ b/containers/dotnetcore-latest/.devcontainer/devcontainer.json
@@ -1,12 +1,15 @@
 {
 	"name": "C# (.NET Core Latest)",
 	"dockerFile": "Dockerfile",
-	
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.csharp"
 	]

--- a/containers/elm/.devcontainer/devcontainer.json
+++ b/containers/elm/.devcontainer/devcontainer.json
@@ -2,12 +2,15 @@
 	"name": "Elm",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// 8000 is the default port used for the `elm reactor` command
 	//"appPort": [8000],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "elm make",
@@ -17,6 +20,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"sbrink.elm"
 	]

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -9,6 +9,13 @@
 
 		"--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
 	],
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"go.gopath": "/go"
+	},
 	
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
@@ -16,10 +23,8 @@
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "go version",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.go"
-	],
-	"settings": {
-		"go.gopath": "/go"
-	}
+	]
 }

--- a/containers/java-11/.devcontainer/devcontainer.json
+++ b/containers/java-11/.devcontainer/devcontainer.json
@@ -1,6 +1,13 @@
 {
 	"name": "Java 11",
 	"dockerFile": "Dockerfile",
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"java.home": "/docker-java-home"
+	},
 	
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
@@ -13,10 +20,8 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"vscjava.vscode-java-pack"
-	],
-	"settings": {
-		"java.home": "/docker-java-home"
-	}
+	]
 }

--- a/containers/java-12/.devcontainer/devcontainer.json
+++ b/containers/java-12/.devcontainer/devcontainer.json
@@ -1,6 +1,14 @@
 {
 	"name": "Java 12",
 	"dockerFile": "Dockerfile",
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"java.home": "/usr/java/openjdk-12",
+		"git.ignoreLegacyWarning": true
+	},
 	
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
@@ -13,12 +21,8 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"vscjava.vscode-java-pack"
-	],
-	"settings": {
-		"java.home": "/usr/java/openjdk-12",
-		"git.ignoreLegacyWarning": true
-	}
-
+	]
 }

--- a/containers/java-8-tomcat-8.5/.devcontainer/devcontainer.json
+++ b/containers/java-8-tomcat-8.5/.devcontainer/devcontainer.json
@@ -1,6 +1,13 @@
 {
 	"name": "Java 8 & Tomcat 8.5",
 	"dockerFile": "Dockerfile",
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"java.home": "/docker-java-home"
+	},
 	
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
@@ -13,11 +20,9 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"vscjava.vscode-java-pack",
 		"adashen.vscode-tomcat"
-	],
-	"settings": {
-		"java.home": "/docker-java-home"
-	}
+	]
 }

--- a/containers/java-8/.devcontainer/devcontainer.json
+++ b/containers/java-8/.devcontainer/devcontainer.json
@@ -1,6 +1,13 @@
 {
 	"name": "Java 8",
 	"dockerFile": "Dockerfile",
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"java.home": "/docker-java-home"
+	},
 	
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
@@ -13,10 +20,8 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"vscjava.vscode-java-pack"
-	],
-	"settings": {
-		"java.home": "/docker-java-home"
-	}
+	]
 }

--- a/containers/javascript-node-8/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-8/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "Node.js 8",
 	"dockerFile": "Dockerfile",
 	
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "node" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"dbaeumer.vscode-eslint"
 	]

--- a/containers/javascript-node-lts-mongo/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-lts-mongo/.devcontainer/devcontainer.json
@@ -5,15 +5,23 @@
 	"service": "web",
 	"workspaceFolder": "/workspace",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
 	// Uncomment the line below if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
 
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"dbaeumer.vscode-eslint"
 	]

--- a/containers/javascript-node-lts-postgres/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-lts-postgres/.devcontainer/devcontainer.json
@@ -5,15 +5,22 @@
 	"service": "web",
 	"workspaceFolder": "/workspace",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
 	// Uncomment the line below if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "npm install",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"dbaeumer.vscode-eslint"
 	]

--- a/containers/javascript-node-lts/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-lts/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "Node.js (latest LTS)",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "node" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"dbaeumer.vscode-eslint"
 	]

--- a/containers/kubernetes-helm/.devcontainer/devcontainer.json
+++ b/containers/kubernetes-helm/.devcontainer/devcontainer.json
@@ -19,19 +19,24 @@
 		"-e", "SYNC_LOCALHOST_KUBECONFIG=true"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"remote.extensionKind": {
+			"ms-azuretools.vscode-docker": "workspace"
+		}	
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "kubectl version",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-azuretools.vscode-docker",
 		"ms-kubernetes-tools.vscode-kubernetes-tools"
-	],
-	"settings": {
-		"remote.extensionKind": {
-			"ms-azuretools.vscode-docker": "workspace"
-		}	
-	}
+	]
 }

--- a/containers/markdown/.devcontainer/devcontainer.json
+++ b/containers/markdown/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "Markdown Editing",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "uname -a"
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"yzhang.markdown-all-in-one",
 		"streetsidesoftware.code-spell-checker",

--- a/containers/perl/.devcontainer/devcontainer.json
+++ b/containers/perl/.devcontainer/devcontainer.json
@@ -10,15 +10,19 @@
 		"--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "perl -v",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"mortenhenriksen.perl-debug",
 		"d9705996.perl-toolbox"

--- a/containers/php-7/.devcontainer/devcontainer.json
+++ b/containers/php-7/.devcontainer/devcontainer.json
@@ -1,12 +1,14 @@
 {
 	"name": "PHP 7",
 	"dockerFile": "Dockerfile",
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
 		
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "php -v",
@@ -16,6 +18,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"felixfbecker.php-debug",
 		"felixfbecker.php-intellisense"

--- a/containers/plantuml/.devcontainer/devcontainer.json
+++ b/containers/plantuml/.devcontainer/devcontainer.json
@@ -1,6 +1,13 @@
 {
     "name": "PlantUML",
     "dockerFile": "Dockerfile",
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+        "plantuml.java": "/usr/local/openjdk-8/bin/java"
+	},
 		
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
@@ -13,10 +20,8 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 	
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
         "jebbs.plantuml"
-	],
-	"settings": {
-        "plantuml.java": "/usr/local/openjdk-8/bin/java"
-	}
+	]
 }

--- a/containers/powershell/.devcontainer/devcontainer.json
+++ b/containers/powershell/.devcontainer/devcontainer.json
@@ -1,12 +1,15 @@
 {
 	"name": "PowerShell",
 	"dockerFile": "Dockerfile",
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
 		
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created. This gets run in bash which is why we call `pwsh`.
 	// "postCreateCommand": "pwsh -c '$PSVersionTable'",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.powershell"
 	]

--- a/containers/puppet/.devcontainer/devcontainer.json
+++ b/containers/puppet/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "Puppet Development Kit - Dockerfile",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "pdk --version",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"jpogran.puppet-vscode",
 		"rebornix.Ruby"

--- a/containers/python-2/.devcontainer/devcontainer.json
+++ b/containers/python-2/.devcontainer/devcontainer.json
@@ -3,6 +3,16 @@
 	"context": "..",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/usr/local/bin/pylint"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
@@ -16,11 +26,5 @@
 
 	"extensions": [
 		"ms-python.python"
-	],
-	"settings": {
-		"python.pythonPath": "/usr/local/bin/python",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/usr/local/bin/pylint"
-	}
+	]
 }

--- a/containers/python-3-anaconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-anaconda/.devcontainer/devcontainer.json
@@ -3,6 +3,16 @@
 	"context": "..",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/opt/conda/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/opt/conda/bin/pylint"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
@@ -14,13 +24,8 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-python.python"
-	],
-	"settings": {
-		"python.pythonPath": "/opt/conda/bin/python",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/opt/conda/bin/pylint"
-	}
+	]
 }

--- a/containers/python-3-miniconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-miniconda/.devcontainer/devcontainer.json
@@ -3,6 +3,16 @@
 	"context": "..",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/opt/conda/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/opt/conda/bin/pylint"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
@@ -14,13 +24,8 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-python.python"
-	],
-	"settings": {
-		"python.pythonPath": "/opt/conda/bin/python",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/opt/conda/bin/pylint"
-	}
+	]
 }

--- a/containers/python-3-postgres/.devcontainer/devcontainer.json
+++ b/containers/python-3-postgres/.devcontainer/devcontainer.json
@@ -5,19 +5,27 @@
 	"service": "app",
 	"workspaceFolder": "/workspace",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/usr/local/bin/pylint"
+	},
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "pip install -r requirements.txt",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-python.python"
-	],
-	"settings": {
-		"python.pythonPath": "/usr/local/bin/python",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/usr/local/bin/pylint"
-	}
+	]
 }

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -3,6 +3,16 @@
 	"context": "..",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"python.pythonPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.linting.pylintPath": "/usr/local/bin/pylint"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
@@ -14,13 +24,8 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-python.python"
-	],
-	"settings": {
-		"python.pythonPath": "/usr/local/bin/python",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/usr/local/bin/pylint"
-	}
+	]
 }

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -10,15 +10,19 @@
 		"--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "R --version",
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ikuyadeu.r",
 		"mikhail-arkhipov.r"

--- a/containers/ruby-2-rails-5/.devcontainer/devcontainer.json
+++ b/containers/ruby-2-rails-5/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "Ruby 2 Rails",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": ["80:80"],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "cd ${input:projectName} && bundle install",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"rebornix.Ruby"
 	]

--- a/containers/ruby-2-sinatra/.devcontainer/devcontainer.json
+++ b/containers/ruby-2-sinatra/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "Ruby 2 Sinatra",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment and edit the next line if you want to publish any ports.
 	// "appPort": ["4567:4567"]
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"rebornix.Ruby"
 	]

--- a/containers/ruby-2/.devcontainer/devcontainer.json
+++ b/containers/ruby-2/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "Ruby 2",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "ruby --version",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "vscode" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"rebornix.Ruby"
 	]

--- a/containers/rust/.devcontainer/devcontainer.json
+++ b/containers/rust/.devcontainer/devcontainer.json
@@ -10,19 +10,24 @@
 		"--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"lldb.adapterType": "bundled",
+		"lldb.executable": "/usr/bin/lldb"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "rustc --version"
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"rust-lang.rust",
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb"
-	],
-	"settings": {
-		"lldb.adapterType": "bundled",
-		"lldb.executable": "/usr/bin/lldb"
-	}
+	]
 }

--- a/containers/swift-4/.devcontainer/devcontainer.json
+++ b/containers/swift-4/.devcontainer/devcontainer.json
@@ -10,17 +10,22 @@
 		"--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"swift.path.sourcekite": "/sourcekite/.build/x86_64-unknown-linux/release/sourcekite"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "swiftc --version"
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"vknabel.vscode-swift-development-environment",
 		"vadimcn.vscode-lldb"
-	],
-	"settings": {
-		"swift.path.sourcekite": "/sourcekite/.build/x86_64-unknown-linux/release/sourcekite"
-	}
+	]
 }

--- a/containers/typescript-node-8/.devcontainer/devcontainer.json
+++ b/containers/typescript-node-8/.devcontainer/devcontainer.json
@@ -2,12 +2,15 @@
 	"name": "Node.js 8 & TypeScript",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
-
+	
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
 
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "node" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.vscode-typescript-tslint-plugin"
 	]

--- a/containers/typescript-node-lts/.devcontainer/devcontainer.json
+++ b/containers/typescript-node-lts/.devcontainer/devcontainer.json
@@ -2,11 +2,14 @@
 	"name": "Node.js (latest LTS) & TypeScript",
 	"dockerFile": "Dockerfile",
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
@@ -16,6 +19,7 @@
 	// and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
 	// "runArgs": [ "-u", "node" ],
 
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
 		"ms-vscode.vscode-typescript-tslint-plugin"
 	]

--- a/containers/ubuntu-18.04-git/.devcontainer/devcontainer.json
+++ b/containers/ubuntu-18.04-git/.devcontainer/devcontainer.json
@@ -12,15 +12,18 @@
 		// "-u", "vscode"
 	],
 
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
 	// Uncomment the next line if you want to publish any ports.
 	// "appPort": [],
-
-	// Uncomment the next line if you want to add in default container specific settings.json values
-	// "settings":  { "workbench.colorTheme": "Quiet Light" },
 
 	// Uncomment the next line to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
 
-	// Add the IDs of any extensions you want installed in the array below.
+	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": []
 }


### PR DESCRIPTION
This PR:
1. Sets the default terminal to /bin/bash to workaround issues where users have set an alternate shell (e.g. zsh) locally for Linux or WSL.
2. Adds a comment for the new `runServices` property
3. Updates comments to be a bit more specific about when settings get applied.