### PR TITLE
Set java home via settings property

### DIFF
--- a/containers/sfdx-project/.devcontainer/devcontainer.json
+++ b/containers/sfdx-project/.devcontainer/devcontainer.json
@@ -6,6 +6,9 @@
       "redhat.vscode-xml",
       "dbaeumer.vscode-eslint",
       "esbenp.prettier-vscode"
-    ]
+    ],
+    "settings": {
+      "salesforcedx-vscode-apex.java.home": "/usr/lib/jvm/java-11-openjdk-amd64"
+    }
   }
   


### PR DESCRIPTION
This PR updates the devcontainer.json file to use the settings property to point to the container installed path of java home.  Thanks for help @Chuxel 