### PR TITLE
Fixes VS Code Setting for "java.home"

### DIFF
--- a/containers/java-12/.devcontainer/devcontainer.json
+++ b/containers/java-12/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 	// You can edit these settings after create using File > Preferences > Settings > Remote.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"java.home": "/usr/java/openjdk-12",
+		"java.home": "/docker-java-home",
 		"git.ignoreLegacyWarning": true
 	},
 	


### PR DESCRIPTION
[Here](https://github.com/microsoft/vscode-dev-containers/blob/4f962ab90596775ff9a1ba3bb0ea2eb4d3cbdf2c/containers/java-12/.devcontainer/Dockerfile#L56) `$JAVA_HOME` is linked to `/docker-java-home` to have a consistent java home location, but it is then not used in the VS Code [settings](https://github.com/microsoft/vscode-dev-containers/blob/4f962ab90596775ff9a1ba3bb0ea2eb4d3cbdf2c/containers/java-12/.devcontainer/devcontainer.json#L9).

So I changed it to make use of the linked folder.
The same pattern is also used for [Java 8](https://github.com/microsoft/vscode-dev-containers/blob/4f962ab90596775ff9a1ba3bb0ea2eb4d3cbdf2c/containers/java-8/.devcontainer/devcontainer.json#L9), [Java 8 & Tomcat 8.5](https://github.com/microsoft/vscode-dev-containers/blob/4f962ab90596775ff9a1ba3bb0ea2eb4d3cbdf2c/containers/java-8-tomcat-8.5/.devcontainer/devcontainer.json#L9) and [Java 11](https://github.com/microsoft/vscode-dev-containers/blob/4f962ab90596775ff9a1ba3bb0ea2eb4d3cbdf2c/containers/java-11/.devcontainer/devcontainer.json#L9)