### PR TITLE
Enable optional installation of Node and the Azure CLI

### DIFF
--- a/containers/dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1/.devcontainer/Dockerfile
@@ -5,9 +5,6 @@
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
 # this user's GID/UID must match your local user UID/GID to avoid permission issues
 # with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
@@ -16,12 +13,37 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+# [Optional] Version of Node.js to install.
+ARG INSTALL_NODE="true"
+ARG NODE_MAJOR_VERSION="10"
+
+# [Optional] Install the Azure CLI
+ARG INSTALL_AZURE_CLI="false"
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git iproute2 procps lsb-release \
+    #
+    # [Optional] Install Node.js for ASP.NET Core Web Applicationss
+    && if [ "$INSTALL_NODE" = "true" ]; then \
+        curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR_VERSION.x | bash - \
+        && apt-get install -y nodejs; \
+    fi \
+    #
+    # [Optional] Install the Azure CLI
+    && if [ "$INSTALL_AZURE_CLI" = "true" ]; then \
+        apt-get install -y apt-transport-https curl gnupg2 lsb-release \
+        && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+        && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
+        && apt-get update \
+        && apt-get install -y azure-cli; \
+    fi \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/dotnetcore-2.1/README.md
+++ b/containers/dotnetcore-2.1/README.md
@@ -12,11 +12,26 @@
 
 ## Using this definition with an existing folder
 
-Note that only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
+A few notes on this definition:
 
-```json
-"console": "integratedTerminal"
-```
+1. Only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
+
+    ```json
+    "console": "integratedTerminal"
+    ```
+
+2. Given how frequently ASP.NET applications use Node.js for front end code, this container also includes Node.js. You can change the version of Node.js installed or disable its installation by updating these lines in `.devcontainer/Dockerfile`.
+
+    ```Dockerfile
+    ARG INSTALL_NODE="true"
+    ARG NODE_MAJOR_VERSION="10"
+    ```
+
+3. If you would like to install the Azure CLI update this line in `.devcontainer/Dockerfile`:
+
+    ```Dockerfile
+    ARG INSTALL_AZURE_CLI="true"
+    ```
 
 Beyond that, just follow these steps to use the definition:
 

--- a/containers/dotnetcore-2.2/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.2/.devcontainer/Dockerfile
@@ -5,10 +5,7 @@
 
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
-# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
+## This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
 # this user's GID/UID must match your local user UID/GID to avoid permission issues
 # with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
 # https://aka.ms/vscode-remote/containers/non-root-user for details.
@@ -16,12 +13,37 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+# [Optional] Version of Node.js to install.
+ARG INSTALL_NODE="true"
+ARG NODE_MAJOR_VERSION="10"
+
+# [Optional] Install the Azure CLI
+ARG INSTALL_AZURE_CLI="false"
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git iproute2 procps lsb-release \
+    #
+    # [Optional] Install Node.js for ASP.NET Core Web Applicationss
+    && if [ "$INSTALL_NODE" = "true" ]; then \
+        curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR_VERSION.x | bash - \
+        && apt-get install -y nodejs; \
+    fi \
+    #
+    # [Optional] Install the Azure CLI
+    && if [ "$INSTALL_AZURE_CLI" = "true" ]; then \
+        apt-get install -y apt-transport-https curl gnupg2 lsb-release \
+        && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+        && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
+        && apt-get update \
+        && apt-get install -y azure-cli; \
+    fi \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/dotnetcore-2.2/README.md
+++ b/containers/dotnetcore-2.2/README.md
@@ -12,11 +12,26 @@
 
 ## Using this definition with an existing folder
 
-Note that only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
+A few notes on this definition:
 
-```json
-"console": "integratedTerminal"
-```
+1. Only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
+
+    ```json
+    "console": "integratedTerminal"
+    ```
+
+2. Given how frequently ASP.NET applications use Node.js for front end code, this container also includes Node.js. You can change the version of Node.js installed or disable its installation by updating these lines in `.devcontainer/Dockerfile`.
+
+    ```Dockerfile
+    ARG INSTALL_NODE="true"
+    ARG NODE_MAJOR_VERSION="10"
+    ```
+
+3. If you would like to install the Azure CLI update this line in `.devcontainer/Dockerfile`:
+
+    ```Dockerfile
+    ARG INSTALL_AZURE_CLI="true"
+    ```
 
 Beyond that, just follow these steps to use the definition:
 

--- a/containers/dotnetcore-latest/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-latest/.devcontainer/Dockerfile
@@ -5,9 +5,6 @@
 
 FROM mcr.microsoft.com/dotnet/core/sdk:latest
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
 # this user's GID/UID must match your local user UID/GID to avoid permission issues
 # with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
@@ -16,12 +13,37 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+# [Optional] Version of Node.js to install.
+ARG INSTALL_NODE="true"
+ARG NODE_MAJOR_VERSION="10"
+
+# [Optional] Install the Azure CLI
+ARG INSTALL_AZURE_CLI="false"
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
     && apt-get -y install git iproute2 procps lsb-release \
+    #
+    # [Optional] Install Node.js for ASP.NET Core Web Applicationss
+    && if [ "$INSTALL_NODE" = "true" ]; then \
+        curl -sL https://deb.nodesource.com/setup_$NODE_MAJOR_VERSION.x | bash - \
+        && apt-get install -y nodejs; \
+    fi \
+    #
+    # [Optional] Install the Azure CLI
+    && if [ "$INSTALL_AZURE_CLI" = "true" ]; then \
+        apt-get install -y apt-transport-https curl gnupg2 lsb-release \
+        && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+        && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
+        && apt-get update \
+        && apt-get install -y azure-cli; \
+    fi \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/dotnetcore-latest/README.md
+++ b/containers/dotnetcore-latest/README.md
@@ -12,11 +12,26 @@
 
 ## Using this definition with an existing folder
 
-Note that only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
+A few notes on this definition:
 
-```json
-"console": "integratedTerminal"
-```
+1. Only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
+
+    ```json
+    "console": "integratedTerminal"
+    ```
+
+2. Given how frequently ASP.NET applications use Node.js for front end code, this container also includes Node.js. You can change the version of Node.js installed or disable its installation by updating these lines in `.devcontainer/Dockerfile`.
+
+    ```Dockerfile
+    ARG INSTALL_NODE="true"
+    ARG NODE_MAJOR_VERSION="10"
+    ```
+
+3. If you would like to install the Azure CLI update this line in `.devcontainer/Dockerfile`:
+
+    ```Dockerfile
+    ARG INSTALL_AZURE_CLI="true"
+    ```
 
 Beyond that, just follow these steps to use the definition:
 


### PR DESCRIPTION
Resolves #133. 

This PR includes arguments in the Dockerfile that will install Node.js (common need for ASP.NET web apps) and the Azure CLI.

By default, Node.js is installed, but the Azure CLI is not.

READMEs also contain this information.