### PR TITLE
Add the go src directory to the clean up.

### DIFF
--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -65,4 +65,4 @@ RUN apt-get update \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* /go/src


### PR DESCRIPTION
This saves about 130 megs. Not a huge deal if local but if folks end up
pushing to a registry is nice (~>10% reduction).