### PR TITLE
Update Docker-in-Docker templates

### DIFF
--- a/containers/docker-in-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-in-docker-compose/.devcontainer/devcontainer.json
@@ -8,10 +8,7 @@
 	// Use 'settings' to set *default* container specific settings.json values on container create. 
 	// You can edit these settings after create using File > Preferences > Settings > Remote.
 	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"remote.extensionKind": {
-			"ms-azuretools.vscode-docker": "workspace"
-		}
+		"terminal.integrated.shell.linux": "/bin/bash"
 	},
 
 	// Uncomment the next line if you want start specific services in your Docker Compose config.

--- a/containers/docker-in-docker-compose/README.md
+++ b/containers/docker-in-docker-compose/README.md
@@ -46,17 +46,7 @@ You can adapt your own existing development container Docker Compose setup to su
       - /var/run/docker.sock:/var/run/docker.sock
     ```
 
-3. Finally, update `devcontainer.json` to force the Docker extension to be installed inside the container instead of locally. From `.devcontainer/devcontainer.json`:
-
-    ```json
-    "settings": {
-        "remote.extensionKind": {
-            "ms-azuretools.vscode-docker": "workspace"
-        }
-    },
-    ```
-
-4. Press <kbd>F1</kbd> and run **Remote-Containers: Rebuild Container** so the changes take effect.
+3. Press <kbd>F1</kbd> and run **Remote-Containers: Rebuild Container** so the changes take effect.
 
 That's it!
 

--- a/containers/docker-in-docker/.devcontainer/devcontainer.json
+++ b/containers/docker-in-docker/.devcontainer/devcontainer.json
@@ -16,10 +16,7 @@
 	// Use 'settings' to set *default* container specific settings.json values on container create. 
 	// You can edit these settings after create using File > Preferences > Settings > Remote.
 	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash",
-	    "remote.extensionKind": {
-			"ms-azuretools.vscode-docker": "workspace"
-		}	
+		"terminal.integrated.shell.linux": "/bin/bash"
 	},
 
 	// Uncomment the next line if you want to publish any ports.

--- a/containers/docker-in-docker/README.md
+++ b/containers/docker-in-docker/README.md
@@ -45,17 +45,7 @@ You can adapt your own existing development container Dockerfile to support this
     "runArgs": ["-v","/var/run/docker.sock:/var/run/docker.sock"]
     ```
 
-3. Finally, update `devcontainer.json` to force the Docker extension to be installed inside the container instead of locally. From `.devcontainer/devcontainer.json`:
-
-    ```json
-    "settings": {
-        "remote.extensionKind": {
-            "ms-azuretools.vscode-docker": "workspace"
-        }
-    },
-    ```
-
-4. Press <kbd>F1</kbd> and run **Remote-Containers: Rebuild Container** so the changes take effect.
+3. Press <kbd>F1</kbd> and run **Remote-Containers: Rebuild Container** so the changes take effect.
 
 That's it!
 


### PR DESCRIPTION
The Docker extension defaults to being a workspace extension now so the previous workaround is unnecessary