### PR TITLE
Add Azure CAF rover to build terraform landingzones

### DIFF
--- a/containers/azure-caf-terraform-rover/.devcontainer/devcontainer.json
+++ b/containers/azure-caf-terraform-rover/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+    "name": "Azure CAF rover",
+ 
+    // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+    "dockerComposeFile": "docker-compose.yml",
+ 
+    // The 'service' property is the name of the service for the container that VS Code should
+    // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+    "service": "rover",
+ 
+    // The optional 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. This is typically a volume mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/tf/private",
+ 
+    // Use 'settings' to set *default* container specific settings.json values on container create. 
+    // You can edit these settings after create using File > Preferences > Settings > Remote.
+    "settings": { 
+        // If you are using an Alpine-based image, change this to /bin/ash
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+ 
+    // Uncomment the next line if you want start specific services in your Docker Compose config.
+    // "runServices": [],
+ 
+    // Uncomment this like if you want to keep your containers running after VS Code shuts down.
+    // "shutdownAction": "none",
+ 
+    // Uncomment the next line to run commands after the container is created.
+    "postCreateCommand": "mkdir -p /root/.ssh && cp -r /root/.ssh-localhost/* /root/.ssh && chmod 700 /root/.ssh && chmod 600 /root/.ssh/*",
+ 
+    // Add the IDs of extensions you want installed when the container is created in the array below.
+    "extensions": [
+        "mauve.terraform",
+        "mutantdino.resourcemonitor"
+    ]
+}

--- a/containers/azure-caf-terraform-rover/.devcontainer/docker-compose.yml
+++ b/containers/azure-caf-terraform-rover/.devcontainer/docker-compose.yml
@@ -1,0 +1,31 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+ 
+version: '3.7'
+services:
+  rover:
+    image: aztfmod/rover:latest
+ 
+    volumes:
+      # This is where VS Code should expect to find your project's source code
+      # and the value of "workspaceFolder" in .devcontainer/devcontainer.json
+      - ..:/tf/private
+      - volume-caf-ssh:/root/.shh
+      - volume-caf-cache:/root/.azure
+      - volume-caf-cache1:/root/.terraform.d
+      - volume-caf-vscode-server:/root/.vscode-server
+      - volume-caf-vscode-server-insiders:/.vscode-server-insiders
+      - ~/.ssh:/root/.ssh-localhost:ro
+ 
+ 
+    # Overrides default command so things don't shut down after the process ends.
+    command: /bin/sh -c "while sleep 1000; do :; done" 
+ 
+volumes:
+  volume-caf-ssh:
+  volume-caf-cache:
+  volume-caf-cache1:
+  volume-caf-vscode-server:
+  volume-caf-vscode-server-insiders:

--- a/containers/azure-caf-terraform-rover/.gitignore
+++ b/containers/azure-caf-terraform-rover/.gitignore
@@ -1,0 +1,9 @@
+**/.terraform
+**/*.tfstate
+**/*.tfplan
+.DS_Store
+**/terraform.tfstate.d
+**/terraform.tfstate.backup
+**/.terraform.tfstate.lock.info
+**/~*.*
+**/*.log

--- a/containers/azure-caf-terraform-rover/readme.md
+++ b/containers/azure-caf-terraform-rover/readme.md
@@ -1,0 +1,3 @@
+This repository host the code to add the Azure CAF rover into an existing git repository.
+
+More documentation on https://aka.ms/tf-landingzones

--- a/containers/azure-caf-terraform-rover/readme.md
+++ b/containers/azure-caf-terraform-rover/readme.md
@@ -1,3 +1,38 @@
-This repository host the code to add the Azure CAF rover into an existing git repository.
+# Azure CAF rover
 
-More documentation on https://aka.ms/tf-landingzones
+## Summary
+
+*Install the latest Azure CAF rover to start building terraform landing zones on Azure*
+
+| Metadata | Value |  
+|----------|-------|
+| *Contributors* | [aztfmod](https://github.com/aztfmod) |
+| *Definition type* | Docker Compose |
+| *Languages, platforms* | Terraform |
+
+## Using this definition with an existing folder
+
+Follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the Azure CAF rover definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of `containers/azure-caf-terraform-rover/.devcontainer` to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+

--- a/containers/azure-caf-terraform-rover/workspace.code-workspace
+++ b/containers/azure-caf-terraform-rover/workspace.code-workspace
@@ -1,0 +1,11 @@
+{
+    "folders": [
+        {
+            "path": "./"
+        }
+    ],
+    "settings": {
+        "files.eol": "\n"
+    },
+    
+}


### PR DESCRIPTION
This PR adds support to build Azure CAF Terraform landing zones.

https://docs.microsoft.com/en-us/azure/cloud-adoption-framework/ready/expanded-scope/terraform-landing-zone

https://github.com/aztfmod/rover/tree/vscode-remote-container