### PR TITLE
docker-in-docker: add missing "\" in README.md

### DIFF
--- a/containers/docker-in-docker/README.md
+++ b/containers/docker-in-docker/README.md
@@ -32,7 +32,7 @@ You can adapt your own existing development container Dockerfile to support this
         && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
         && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
         && apt-get update \
-        && apt-get install -y docker-ce-cli
+        && apt-get install -y docker-ce-cli \
         #
         # Install Docker Compose
         && curl -sSL "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \


### PR DESCRIPTION
Without the `\`, "docker build" will fail since it thinks that `&&` is a directive on its own (instead of being a part of the previous `RUN` directive).