### PR TITLE
netstandard reference shouldn't be necessary in F# projects

### DIFF
--- a/containers/dotnetcore-2.1-fsharp/test-project/app.fsproj
+++ b/containers/dotnetcore-2.1-fsharp/test-project/app.fsproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <Compile Include="Program.fs" />
-    <Reference Include="netstandard" />
   </ItemGroup>
 
 </Project>

--- a/containers/dotnetcore-2.2-fsharp/test-project/app.fsproj
+++ b/containers/dotnetcore-2.2-fsharp/test-project/app.fsproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <Compile Include="Program.fs" />
-    <Reference Include="netstandard" />
   </ItemGroup>
 
 </Project>

--- a/containers/dotnetcore-3.0-fsharp/test-project/app.fsproj
+++ b/containers/dotnetcore-3.0-fsharp/test-project/app.fsproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <Compile Include="Program.fs" />
-    <Reference Include="netstandard" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This comes in the shared framework pulled in by the SDK in the project file, so it should be fine to remove. We don't include it in new templates in the .NET SDK.