### PR TITLE
Add dev container for Dapr with C# & .NET Core 3.0

### DIFF
--- a/containers/dapr-dotnetcore-3.0/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/Dockerfile
@@ -1,0 +1,93 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+ARG DOTNETCORE_VESRION=3.0
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VESRION}
+
+# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
+# this user's GID/UID must match your local user UID/GID to avoid permission issues
+# with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
+# https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# [Optional] Version of Node.js to install.
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+ENV NVM_DIR=/home/vscode/.nvm
+
+# [Optional] Install the Azure CLI
+ARG INSTALL_AZURE_CLI="false"
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
+    && apt-get -y install git iproute2 procps apt-transport-https gnupg2 curl lsb-release \
+    #
+    # Install Docker CE CLI
+    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
+    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
+    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y docker-ce-cli \
+    #
+    # Install Docker Compose
+    && curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
+    && chmod +x /usr/local/bin/docker-compose \
+    #
+    # Install Dapr
+    && wget -q https://raw.githubusercontent.com/dapr/cli/master/install/install.sh -O - | /bin/bash \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # [Optional] Install Node.js for ASP.NET Core Web Applicationss
+    && if [ "$INSTALL_NODE" = "true" ]; then \
+        #
+        # Install nvm and Node
+        mkdir ${NVM_DIR} \
+        && curl -so- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash 2>&1 \
+        && chown -R vscode:vscode ${NVM_DIR} \
+        && /bin/bash -c "source $NVM_DIR/nvm.sh \
+            && nvm install ${NODE_VERSION} \
+            && nvm alias default ${NODE_VERSION}" 2>&1 \
+        && INIT_STRING='[ -s "$NVM_DIR/nvm.sh" ] && \\. "$NVM_DIR/nvm.sh"  && [ -s "$NVM_DIR/bash_completion" ] && \\. "$NVM_DIR/bash_completion"' \
+        && echo $INIT_STRING >> /home/vscode/.bashrc \
+        && echo $INIT_STRING >> /home/vscode/.zshrc \
+        && echo $INIT_STRING >> /root/.zshrc \
+        #
+        # Install yarn
+        && curl -sS https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/pubkey.gpg | apt-key add - 2>/dev/null \
+        && echo "deb https://dl.yarnpkg.com/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+        && apt-get update \
+        && apt-get -y install --no-install-recommends yarn; \
+    fi \
+    #
+    # [Optional] Install the Azure CLI
+    && if [ "$INSTALL_AZURE_CLI" = "true" ]; then \
+        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+        && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
+        && apt-get update \
+        && apt-get install -y azure-cli; \
+    fi \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/Dockerfile
@@ -6,10 +6,10 @@
 ARG DOTNETCORE_VESRION=3.0
 FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VESRION}
 
-# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
-# this user's GID/UID must match your local user UID/GID to avoid permission issues
-# with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
-# https://aka.ms/vscode-remote/containers/non-root-user for details.
+# The node image includes a non-root user with sudo access. Use the 
+# "remoteUser" property in devcontainer.json to use it. On Linux, update 
+# these values to ensure the container user's UID/GID matches your local values.
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -24,6 +24,9 @@ ARG INSTALL_AZURE_CLI="false"
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Docker Compose version
+ARG COMPOSE_VERSION=1.24.0
 
 # Configure apt and install packages
 RUN apt-get update \
@@ -90,4 +93,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=
+ENV DEBIAN_FRONTEND=dialog

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/devcontainer.json
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "Dapr with C# (.NET Core 3.0)",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "docker-in-docker",
+	"workspaceFolder": "/workspace",
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "dotnet restore",
+
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [5000, 5001],
+	
+	// Ensure Dapr is running on opening the container
+	"postCreateCommand": "dapr init --network dapr-dotnetcore",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"ms-vscode.csharp"
+	]
+}

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/devcontainer.json
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/devcontainer.json
@@ -10,14 +10,18 @@
 		"terminal.integrated.shell.linux": "/bin/bash"
 	},
 
-	// Uncomment the next line to run commands after the container is created.
-	// "postCreateCommand": "dotnet restore",
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
 
-	// Uncomment the next line if you want to publish any ports.
-	// "appPort": [5000, 5001],
-	
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
 	// Ensure Dapr is running on opening the container
 	"postCreateCommand": "dapr init",
+
+	// Uncomment the next line to have VS Code connect as an existing non-root user in the container. See
+	// https://aka.ms/vscode-remote/containers/non-root for details on adding a non-root user if none exist.
+	// "remoteUser": "vscode",
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/devcontainer.json
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 	// "appPort": [5000, 5001],
 	
 	// Ensure Dapr is running on opening the container
-	"postCreateCommand": "dapr init --network dapr-dotnetcore",
+	"postCreateCommand": "dapr init",
 
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
@@ -6,9 +6,11 @@
 version: '3.5'
 services:
   docker-in-docker:
-    # Uncomment the next line to use a non-root user. On Linux, this will prevent
-    # new files getting created as root, but you may need to update the USER_UID
-    # and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
+    # Uncomment the next line to use a non-root user for all processes. You can also
+    # simply use the "remoteUser" property in devcontainer.json if you just want VS Code
+    # and its sub-processes (terminals, tasks, debugging) to execute as the user. On Linux,
+    # you may need to update USER_UID and USER_GID in .devcontainer/Dockerfile to match your
+    # user if not 1000. See https://aka.ms/vscode-remote/containers/non-root for details.
     # user: vscode
 
     build: 
@@ -21,9 +23,13 @@ services:
       DAPR_REDIS_HOST: dapr_redis
       DAPR_PLACEMENT_HOST: dapr_placement
 
+    # Uncomment the next two lines if you want to publish the application port.
+    # ports:
+    #  - 5000
+
     volumes:
       # Update this to wherever you want VS Code to mount the folder of your project
-      - ..:/workspace
+      - ..:/workspace:cached
 
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker.sock

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
@@ -1,0 +1,39 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+version: '3.5'
+services:
+  docker-in-docker:
+    # Uncomment the next line to use a non-root user. On Linux, this will prevent
+    # new files getting created as root, but you may need to update the USER_UID
+    # and USER_GID in .devcontainer/Dockerfile to match your user if not 1000.
+    # user: vscode
+
+    build: 
+      context: .
+      dockerfile: Dockerfile
+
+    environment:
+      ASPNETCORE_Kestrel__Endpoints__Http__Url: http://*:5000
+
+    volumes:
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - ..:/workspace
+
+      # Forwards the local Docker socket to the container.
+      - /var/run/docker.sock:/var/run/docker.sock
+
+    # Uncomment the next four lines if you will use a ptrace-based debuggers like C++, Go, and Rust.
+    # cap_add:
+    #  - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+networks: 
+  default:
+    name: dapr-dotnetcore

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     environment:
       ASPNETCORE_Kestrel__Endpoints__Http__Url: http://*:5000
       DAPR_NETWORK: dapr-dotnetcore
+      DAPR_REDIS_HOST: dapr_redis
+      DAPR_PLACEMENT_HOST: dapr_placement
 
     volumes:
       # Update this to wherever you want VS Code to mount the folder of your project

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
@@ -17,6 +17,7 @@ services:
 
     environment:
       ASPNETCORE_Kestrel__Endpoints__Http__Url: http://*:5000
+      DAPR_NETWORK: dapr-dotnetcore
 
     volumes:
       # Update this to wherever you want VS Code to mount the folder of your project

--- a/containers/dapr-dotnetcore-3.0/.npmignore
+++ b/containers/dapr-dotnetcore-3.0/.npmignore
@@ -1,0 +1,4 @@
+README.md
+test-project
+.vscode
+.npmignore

--- a/containers/dapr-dotnetcore-3.0/.vscode/launch.json
+++ b/containers/dapr-dotnetcore-3.0/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": ["run"],
+            "cwd": "${workspaceFolder}/test-project",
+        }
+    ]
+}

--- a/containers/dapr-dotnetcore-3.0/.vscode/settings.json
+++ b/containers/dapr-dotnetcore-3.0/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "razor.disabled": true
+}

--- a/containers/dapr-dotnetcore-3.0/.vscode/tasks.json
+++ b/containers/dapr-dotnetcore-3.0/.vscode/tasks.json
@@ -1,0 +1,36 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/test-project/aspnetapp.csproj"
+            ],
+            "problemMatcher": "$tsc"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/test-project/aspnetapp.csproj"
+            ],
+            "problemMatcher": "$tsc"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "${workspaceFolder}/test-project/aspnetapp.csproj"
+            ],
+            "problemMatcher": "$tsc"
+        }
+    ]
+}

--- a/containers/dapr-dotnetcore-3.0/README.md
+++ b/containers/dapr-dotnetcore-3.0/README.md
@@ -6,7 +6,7 @@
 
 | Metadata | Value |  
 |----------|-------|
-| *Contributors* | The VS Code Team |
+| *Contributors* | The Visual Studio Container Tools team |
 | *Definition type* | Docker Compose |
 | *Languages, platforms* | .NET Core, C#, Dapr |
 
@@ -18,9 +18,9 @@ When the dev container is created, the definition automatically initializes Dapr
 
 While the definition itself works unmodified, there are some tips that can help you deal with some of the defaults .NET Core uses.
 
-### Using appPort with ASP.NET Core
+### Using `ports` with ASP.NET Core
 
-By default, ASP.NET Core only listens to localhost. If you use the `appPort` property in `.devcontainer/devcontainer.json`, the port is [published](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwarded. Unfortunately, means that ASP.NET Core only listens to localhost is inside the container itself. It needs to listen to `*` or `0.0.0.0` for the application to be accessible externally.
+By default, ASP.NET Core only listens to localhost. If you use the `ports` property in `.devcontainer/docker-compose.yml`, the port is [published](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwarded. Unfortunately, means that ASP.NET Core only listens to localhost is inside the container itself. It needs to listen to `*` or `0.0.0.0` for the application to be accessible externally.
 
 This container solves that problem by setting the environment variable `ASPNETCORE_Kestrel__Endpoints__Http__Url` to `http://*:5000` in `.devcontainer/docker-compose.yml`. Using an environment variable to override this setting in the container only, which allows you to leave your actual application config as-is for use when running locally.
 
@@ -29,12 +29,8 @@ This container solves that problem by setting the environment variable `ASPNETCO
 ```yaml
 environment:
   ASPNETCORE_Kestrel__Endpoints__Http__Url: http://*:5000
-```
-
-`.devcontainer/devcontainer.json`:
-
-```json
-"appPort": [5000],
+ports:
+  - 5000
 ```
 
 If you've already opened your folder in a container, rebuild the container using the **Remote-Containers: Rebuild Container** command from the Command Palette (<kbd>F1</kbd>) so the settings take effect.

--- a/containers/dapr-dotnetcore-3.0/README.md
+++ b/containers/dapr-dotnetcore-3.0/README.md
@@ -1,0 +1,125 @@
+# C# (.NET Core 3.0)
+
+## Summary
+
+*Develop C# and .NET Core 3.0 based applications. Includes all needed SDKs, extensions, and dependencies.*
+
+| Metadata | Value |  
+|----------|-------|
+| *Contributors* | The VS Code Team |
+| *Definition type* | Dockerfile |
+| *Languages, platforms* | .NET Core, C# |
+
+## Using this definition with an existing folder
+
+While the definition itself works unmodified, there are some tips that can help you deal with some of the defaults .NET Core uses.
+
+### Using appPort with ASP.NET Core
+
+By default, ASP.NET Core only listens to localhost. If you use the `appPort` property in `.devcontainer/devcontainer.json`, the port is [published](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwarded. Unfortunately, means that ASP.NET Core only listens to localhost is inside the container itself. It needs to listen to `*` or `0.0.0.0` for the application to be accessible externally.
+
+This container solves that problem by setting the environment variable `ASPNETCORE_Kestrel__Endpoints__Http__Url` to `http://*:5000` in `.devcontainer/devcontainer.json`. Using an environment variable to override this setting in the container only, which allows you to leave your actual application config as-is for use when running locally.
+
+```json
+"appPort": [5000, 5001],
+"runArgs": [
+    "-e", "ASPNETCORE_Kestrel__Endpoints__Http__Url=http://*:5000"
+]
+```
+
+If you've already opened your folder in a container, rebuild the container using the **Remote-Containers: Rebuild Container** command from the Command Palette (<kbd>F1</kbd>) so the settings take effect.
+
+### Enabling HTTPS in ASP.NET Core
+
+To enable HTTPS in ASP.NET, you can mount an exported copy of your local dev certificate. First, export it using the following command:
+
+**Windows PowerShell**
+
+```powershell
+dotnet dev-certs https --trust; dotnet dev-certs https -ep "$env:USERPROFILE/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+```
+
+**macOS/Linux terminal**
+
+```powershell
+dotnet dev-certs https --trust; dotnet dev-certs https -ep "${HOME}/.aspnet/https/aspnetapp.pfx" -p "SecurePwdGoesHere"
+```
+
+Next, add the following in the `runArgs` array in `.devcontainer/devcontainer.json` (assuming port 5000 and 5001 are the correct ports):
+
+```json
+"appPort": [5000, 5001],
+"runArgs": [
+    "-e", "ASPNETCORE_Kestrel__Endpoints__Http__Url=http://*:5000",
+    "-e", "ASPNETCORE_Kestrel__Endpoints__Https__Url=https://*:5001",
+    "-v", "${env:HOME}${env:USERPROFILE}/.aspnet/https:/home/vscode/.aspnet/https",
+    "-e", "ASPNETCORE_Kestrel__Certificates__Default__Password=SecurePwdGoesHere",
+    "-e", "ASPNETCORE_Kestrel__Certificates__Default__Path=/home/vscode/.aspnet/https/aspnetapp.pfx"
+]
+```
+
+If you've already opened your folder in a container, rebuild the container using the **Remote-Containers: Rebuild Container** command from the Command Palette (<kbd>F1</kbd>) so the settings take effect.
+
+### Debug Configuration
+
+Only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
+
+```json
+"console": "integratedTerminal"
+```
+
+### Installing Node.js or the Azure CLI
+
+Given how frequently ASP.NET applications use Node.js for front end code, this container also includes Node.js. You can change the version of Node.js installed or disable its installation by updating these lines in `.devcontainer/Dockerfile`.
+
+```Dockerfile
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="10"
+```
+
+If you would like to install the Azure CLI update this line in `.devcontainer/Dockerfile`:
+
+```Dockerfile
+ARG INSTALL_AZURE_CLI="true"
+```
+
+If you've already opened your folder in a container, rebuild the container using the **Remote-Containers: Rebuild Container** command from the Command Palette (<kbd>F1</kbd>) so the settings take effect.
+
+### Adding the definition to your folder
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the C# (.NET Core Latest) definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of `containers/dotnetcore-latest/.devcontainer` to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## Testing the definition
+
+This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Clone this repository.
+3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
+4. Select the `containers/dotnetcore-latest` folder.
+5. After the folder has opened in the container, if prompted to restore packages in a notification, click "Restore".
+6. After packages are restored, press <kbd>F5</kbd> to start the project.
+7. Once the project is running, press <kbd>F1</kbd> and select **Remote-Containers: Forward Port from Container...**
+8. Select port 8090 and click the "Open Browser" button in the notification that appears.
+9. You should see "Hello remote world from ASP.NET Core!" after the page loads.
+10. From here, you can add breakpoints or edit the contents of the `test-project` folder to do further testing.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).

--- a/containers/dapr-dotnetcore-3.0/test-project/.gitignore
+++ b/containers/dapr-dotnetcore-3.0/test-project/.gitignore
@@ -1,0 +1,1 @@
+components

--- a/containers/dapr-dotnetcore-3.0/test-project/Controllers/AccountsController.cs
+++ b/containers/dapr-dotnetcore-3.0/test-project/Controllers/AccountsController.cs
@@ -1,0 +1,49 @@
+/*-------------------------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+ *-------------------------------------------------------------------------------------------------------------*/
+
+using System.Threading.Tasks;
+using Dapr;
+using Microsoft.AspNetCore.Mvc;
+
+namespace aspnetapp
+{
+    [ApiController]
+    [Route("[controller]")]
+    public class AccountsController : ControllerBase
+    {
+        [HttpGet("{account}")]
+        public ActionResult<int> GetBalance(StateEntry<int?> account)
+        {
+            if (account.Value is null)
+            {
+                return this.NotFound();
+            }
+
+            return account.Value;
+        }
+
+        [HttpPost("{account}/deposit")]
+        public async Task<ActionResult<int>> Deposit([FromRoute] StateEntry<int?> account, [FromBody] int amount)
+        {
+            account.Value ??= 0;
+            account.Value += amount;
+
+            await account.SaveAsync();
+
+            return account.Value;
+        }
+
+        [HttpPost("{account}/withdraw")]
+        public async Task<ActionResult<int>> Withdraw([FromRoute] StateEntry<int?> account, [FromBody] int amount)
+        {
+            account.Value ??= 0;
+            account.Value -= amount;
+
+            await account.SaveAsync();
+
+            return account.Value;
+        }
+    }
+}

--- a/containers/dapr-dotnetcore-3.0/test-project/Program.cs
+++ b/containers/dapr-dotnetcore-3.0/test-project/Program.cs
@@ -1,0 +1,27 @@
+/*-------------------------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+ *-------------------------------------------------------------------------------------------------------------*/
+
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace aspnetapp
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            var host = new WebHostBuilder()
+                .UseKestrel()
+                .Configure(app => app.Run(async context => {
+                    await context.Response.WriteAsync("Hello remote world from ASP.NET Core!");
+                }))
+                .Build();
+
+            host.Run();
+        }
+
+    }
+}

--- a/containers/dapr-dotnetcore-3.0/test-project/Program.cs
+++ b/containers/dapr-dotnetcore-3.0/test-project/Program.cs
@@ -5,7 +5,7 @@
 
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
 
 namespace aspnetapp
 {
@@ -13,15 +13,15 @@ namespace aspnetapp
     {
         public static void Main(string[] args)
         {
-            var host = new WebHostBuilder()
-                .UseKestrel()
-                .Configure(app => app.Run(async context => {
-                    await context.Response.WriteAsync("Hello remote world from ASP.NET Core!");
-                }))
-                .Build();
-
-            host.Run();
+            Host
+                .CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(
+                    webBuilder =>
+                    {
+                        webBuilder.UseStartup<Startup>();
+                    })
+                .Build()
+                .Run();
         }
-
     }
 }

--- a/containers/dapr-dotnetcore-3.0/test-project/Startup.cs
+++ b/containers/dapr-dotnetcore-3.0/test-project/Startup.cs
@@ -1,0 +1,38 @@
+/*-------------------------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ * Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+ *-------------------------------------------------------------------------------------------------------------*/
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace aspnetapp
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers().AddDapr();
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            app.UseRouting();
+
+            app.UseEndpoints(
+                endpoints =>
+                {
+                    endpoints.MapControllers();
+                });
+        }
+    }
+}

--- a/containers/dapr-dotnetcore-3.0/test-project/aspnetapp.csproj
+++ b/containers/dapr-dotnetcore-3.0/test-project/aspnetapp.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UserSecretsId>31051026529000467138</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+</Project>

--- a/containers/dapr-dotnetcore-3.0/test-project/aspnetapp.csproj
+++ b/containers/dapr-dotnetcore-3.0/test-project/aspnetapp.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Dapr.AspNetCore" Version="0.3.0-preview01" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds a definition for a dev container for using Dapr with C# & .NET Core 3.0.  This definition combines the definition for C# & .NET Core 3.0 with the Docker in Docker Compose definition, plus installs the latest version of the Dapr CLI (which requires the latter).  When started, the dev container automatically initializes the Dapr runtime, using a separate Docker network to isolate it from the local environment.  