### PR TITLE
Added dev-container definition for dart+flutter+android

### DIFF
--- a/containers/dart-flutter-android/.devcontainer/Dockerfile
+++ b/containers/dart-flutter-android/.devcontainer/Dockerfile
@@ -8,9 +8,9 @@ RUN mkdir -p /usr/share/man/man1 \
 RUN apt update && apt install -y curl wget git xz-utils lib32stdc++6 unzip openjdk-8-jdk-headless
 
 # Android SDK
-RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip 
-RUN mkdir android-sdk && unzip /sdk-tools-linux-4333796.zip -d android-sdk
-RUN rm /sdk-tools-linux-4333796.zip
+RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip \
+ &&  mkdir android-sdk && unzip /sdk-tools-linux-4333796.zip -d android-sdk \
+ && rm /sdk-tools-linux-4333796.zip
 ENV ANDROID_HOME="/android-sdk"
 ENV PATH="/android-sdk/tools/bin:/android-sdk/build-tools:/android-sdk/platform-tools:${PATH}"
 
@@ -19,13 +19,20 @@ RUN yes | sdkmanager --licenses
 RUN sdkmanager "platforms;android-28" "platform-tools" "build-tools;28.0.3"
 
 # Flutter
-RUN wget https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_v1.5.4-hotfix.2-stable.tar.xz
-RUN tar xf flutter_linux_v1.5.4-hotfix.2-stable.tar.xz 
-RUN rm flutter_linux_v1.5.4-hotfix.2-stable.tar.xz
+RUN wget https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_v1.5.4-hotfix.2-stable.tar.xz \
+ && tar xf flutter_linux_v1.5.4-hotfix.2-stable.tar.xz \
+ && rm flutter_linux_v1.5.4-hotfix.2-stable.tar.xz
 ENV PATH="/flutter/bin:${PATH}"
-
 RUN flutter config --no-analytics
 
-# Set a useful default shell
-ENV SHELL /bin/bash
-
+# Create a non-root default user
+ARG USERNAME=some-user
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME
+USER $USERNAME

--- a/containers/dart-flutter-android/.devcontainer/Dockerfile
+++ b/containers/dart-flutter-android/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p /usr/share/man/man1 \
     && mkdir -p /usr/share/man/man7
 
 # Apt
-RUN apt update && apt install -y curl wget git xz-utils lib32stdc++6 unzip openjdk-8-jdk-headless
+RUN apt-get update && apt-get install -y curl wget git xz-utils lib32stdc++6 unzip openjdk-8-jdk-headless
 
 # Android SDK
 RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip \

--- a/containers/dart-flutter-android/.devcontainer/Dockerfile
+++ b/containers/dart-flutter-android/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+FROM debian:stretch-slim
+
+# Hack to get openjdk to install in a container
+RUN mkdir -p /usr/share/man/man1 \
+    && mkdir -p /usr/share/man/man7
+
+# Apt
+RUN apt update && apt install -y curl wget git xz-utils lib32stdc++6 unzip openjdk-8-jdk-headless
+
+# Android SDK
+RUN wget https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip 
+RUN mkdir android-sdk && unzip /sdk-tools-linux-4333796.zip -d android-sdk
+RUN rm /sdk-tools-linux-4333796.zip
+ENV ANDROID_HOME="/android-sdk"
+ENV PATH="/android-sdk/tools/bin:/android-sdk/build-tools:/android-sdk/platform-tools:${PATH}"
+
+# SDK manager
+RUN yes | sdkmanager --licenses
+RUN sdkmanager "platforms;android-28" "platform-tools" "build-tools;28.0.3"
+
+# Flutter
+RUN wget https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_v1.5.4-hotfix.2-stable.tar.xz
+RUN tar xf flutter_linux_v1.5.4-hotfix.2-stable.tar.xz 
+RUN rm flutter_linux_v1.5.4-hotfix.2-stable.tar.xz
+ENV PATH="/flutter/bin:${PATH}"
+
+RUN flutter config --no-analytics
+
+# Set a useful default shell
+ENV SHELL /bin/bash
+

--- a/containers/dart-flutter-android/.devcontainer/Dockerfile
+++ b/containers/dart-flutter-android/.devcontainer/Dockerfile
@@ -34,5 +34,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && apt-get update \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && chown -R $USERNAME:$USERNAME /flutter \
+    && chown -R $USERNAME:$USERNAME /android-sdk
 USER $USERNAME

--- a/containers/dart-flutter-android/.devcontainer/devcontainer.json
+++ b/containers/dart-flutter-android/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+	"name": "flutter",
+	"dockerFile": "Dockerfile",
+	"extensions": [
+		"dart-code.dart-code",
+		"dart-code.flutter"
+	],
+	"runArgs": ["--privileged", "-v", "/dev/bus/usb:/dev/bus/usb"]
+}

--- a/containers/dart-flutter-android/.devcontainer/devcontainer.json
+++ b/containers/dart-flutter-android/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "flutter",
+	"name": "Dart & Flutter & Android",
 	"dockerFile": "Dockerfile",
 	"extensions": [
 		"dart-code.dart-code",

--- a/containers/dart-flutter-android/README.md
+++ b/containers/dart-flutter-android/README.md
@@ -40,3 +40,9 @@ Please also note when you use this container you're automatically agreeing to th
 5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
 
 6. Once the container has started, you can run `flutter create my_project` to create a new project
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).

--- a/containers/dart-flutter-android/README.md
+++ b/containers/dart-flutter-android/README.md
@@ -1,0 +1,42 @@
+# dart-flutter-android
+
+## Summary
+
+*Develop Flutter applications for Android devices.*
+
+| Metadata | Value |  
+|----------|-------|
+| *Contributors* | [Martin Ashby](github.com/MFAshby) |
+| *Definition type* | Dockerfile |
+| *Languages, platforms* | Dart, Flutter, Android |
+
+Running on a physical device is supported with `flutter run`, make sure you click the 
+dialog on the device in order to trust the computer you are connecting from!
+
+Please note that this container is set to run in 
+[privileged mode](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) 
+in order to access USB devices on the host machine. You should be aware of the security 
+implications of this. 
+
+Please also note when you use this container you're automatically agreeing to the 
+[Android SDK terms & conditions](https://developer.android.com/studio/terms)
+
+## Using this definition with an existing folder
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the dart-flutter-android definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of `containers/dart-flutter-android/.devcontainer` to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+6. Once the container has started, you can run `flutter create my_project` to create a new project


### PR DESCRIPTION
Adds a dev container for developing mobile apps with dart+flutter+android SDK

Resolves #162 

I copied the format of other containers for README.md, but I'm unsure what I need to add to the license section.