### PR TITLE
Fix variable name typo (DOTNETCORE_VESRION -> DOTNETCORE_VERSION)

### DIFF
--- a/containers/dapr-dotnetcore-3.0/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG DOTNETCORE_VESRION=3.0
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VESRION}
+ARG DOTNETCORE_VERSION=3.0
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VERSION}
 
 # The node image includes a non-root user with sudo access. Use the 
 # "remoteUser" property in devcontainer.json to use it. On Linux, update 

--- a/containers/dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1/.devcontainer/Dockerfile
@@ -2,8 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-ARG DOTNETCORE_VESRION=2.1
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VESRION}
+ARG DOTNETCORE_VERSION=2.1
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VERSION}
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/containers/dotnetcore-2.2/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.2/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG DOTNETCORE_VESRION=2.2
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VESRION}
+ARG DOTNETCORE_VERSION=2.2
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VERSION}
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/containers/dotnetcore-3.0-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-3.0-fsharp/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG DOTNETCORE_VESRION=3.0
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VESRION}
+ARG DOTNETCORE_VERSION=3.0
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VERSION}
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive

--- a/containers/dotnetcore-3.0/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-3.0/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG DOTNETCORE_VESRION=3.0
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VESRION}
+ARG DOTNETCORE_VERSION=3.0
+FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNETCORE_VERSION}
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs


### PR DESCRIPTION
Please propagate this change to the remote dev container extension as well please