### PR TITLE
Use a common Docker network across Dapr Dev Containers.

### DIFF
--- a/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/docker-compose.yml
@@ -19,7 +19,7 @@ services:
 
     environment:
       ASPNETCORE_Kestrel__Endpoints__Http__Url: http://*:5000
-      DAPR_NETWORK: dapr-dotnetcore
+      DAPR_NETWORK: dapr-dev-container
       DAPR_REDIS_HOST: dapr_redis
       DAPR_PLACEMENT_HOST: dapr_placement
 
@@ -45,4 +45,4 @@ services:
 
 networks: 
   default:
-    name: dapr-dotnetcore
+    name: dapr-dev-container

--- a/containers/dapr-typescript-node-12/.devcontainer/docker-compose.yml
+++ b/containers/dapr-typescript-node-12/.devcontainer/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       dockerfile: Dockerfile
 
     environment:
-      DAPR_NETWORK: dapr-typescript
+      DAPR_NETWORK: dapr-dev-container
       DAPR_REDIS_HOST: dapr_redis
       DAPR_PLACEMENT_HOST: dapr_placement
 
@@ -44,4 +44,4 @@ services:
 
 networks: 
   default:
-    name: dapr-typescript
+    name: dapr-dev-container


### PR DESCRIPTION
Currently, each Dapr Dev Container for a given platform use a platform-specific Docker network, the thinking being that developers would want a completely isolated Dapr development environment.  However, in multi-service application scenarios, developers are likely to want the services to interact, even if developed across different platforms.

This change makes Dapr Dev Containers use a common Docker network by default, to enable such scenarios without additional configuration.  In practice, even for users *not* requiring interacting services (e.g. those new to Dapr), using a common network likely has no real impact on their development.  (And, if it does the user can always change the configuration to use a unique network.)