### PR TITLE
Use an alternate location for node's global packages

### DIFF
--- a/containers/javascript-node-10/.devcontainer/Dockerfile
+++ b/containers/javascript-node-10/.devcontainer/Dockerfile
@@ -26,6 +26,8 @@ ARG COMMON_SCRIPT_SHA="dev-mode"
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 
+ENV PATH=${PATH}:/usr/local/share/npm-global/bin
+
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog wget ca-certificates 2>&1 \
@@ -52,7 +54,6 @@ RUN apt-get update \
     && chown ${USERNAME}:root /usr/local/share/npm-global \
     && npm config -g set prefix /usr/local/share/npm-global \
     && sudo -u ${USERNAME} npm config -g set prefix /usr/local/share/npm-global \
-    && echo "export PATH=$PATH:/usr/local/share/npm-global/bin" | tee -a /etc/bash.bashrc /root/.zshrc /home/${USERNAME}/.zshrc \
     #
     # Install eslint globally
     && npm install -g eslint \

--- a/containers/javascript-node-10/.devcontainer/Dockerfile
+++ b/containers/javascript-node-10/.devcontainer/Dockerfile
@@ -47,6 +47,13 @@ RUN apt-get update \
     && apt-get update \
     && apt-get -y install --no-install-recommends yarn \
     #
+    # Set alternate global install location that both uses have rights to access
+    && mkdir -p /usr/local/share/npm-global \
+    && chown ${USERNAME}:root /usr/local/share/npm-global \
+    && npm config -g set prefix /usr/local/share/npm-global \
+    && sudo -u ${USERNAME} npm config -g set prefix /usr/local/share/npm-global \
+    && echo "export PATH=$PATH:/usr/local/share/npm-global/bin" | tee -a /etc/bash.bashrc /root/.zshrc /home/${USERNAME}/.zshrc \
+    #
     # Install eslint globally
     && npm install -g eslint \
     #

--- a/containers/javascript-node-12/.devcontainer/Dockerfile
+++ b/containers/javascript-node-12/.devcontainer/Dockerfile
@@ -26,6 +26,8 @@ ARG COMMON_SCRIPT_SHA="dev-mode"
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 
+ENV PATH=${PATH}:/usr/local/share/npm-global/bin
+
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog wget ca-certificates 2>&1 \
@@ -52,7 +54,6 @@ RUN apt-get update \
     && chown ${USERNAME}:root /usr/local/share/npm-global \
     && npm config -g set prefix /usr/local/share/npm-global \
     && sudo -u ${USERNAME} npm config -g set prefix /usr/local/share/npm-global \
-    && echo "export PATH=$PATH:/usr/local/share/npm-global/bin" | tee -a /etc/bash.bashrc /root/.zshrc /home/${USERNAME}/.zshrc \
     #
     # Install eslint globally
     && npm install -g eslint \

--- a/containers/javascript-node-12/.devcontainer/Dockerfile
+++ b/containers/javascript-node-12/.devcontainer/Dockerfile
@@ -47,6 +47,13 @@ RUN apt-get update \
     && apt-get update \
     && apt-get -y install --no-install-recommends yarn \
     #
+    # Set alternate global install location that both uses have rights to access
+    && mkdir -p /usr/local/share/npm-global \
+    && chown ${USERNAME}:root /usr/local/share/npm-global \
+    && npm config -g set prefix /usr/local/share/npm-global \
+    && sudo -u ${USERNAME} npm config -g set prefix /usr/local/share/npm-global \
+    && echo "export PATH=$PATH:/usr/local/share/npm-global/bin" | tee -a /etc/bash.bashrc /root/.zshrc /home/${USERNAME}/.zshrc \
+    #
     # Install eslint globally
     && npm install -g eslint \
     #


### PR DESCRIPTION
This PR updates the location of globally installed packages in the containers so `npm install -g` can be used with the `vscode` non-root user without sudo. 