### PR TITLE
Remove imagemagick due to CVE-2019-10131

### DIFF
--- a/containers/javascript-node-10/.devcontainer/Dockerfile
+++ b/containers/javascript-node-10/.devcontainer/Dockerfile
@@ -47,6 +47,9 @@ RUN apt-get update \
     && apt-get update \
     && apt-get -y install --no-install-recommends yarn \
     #
+    # Tactically remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
+    && apt-get purge -y imagemagick imagemagick-6-common \
+    #
     # Install eslint globally
     && npm install -g eslint \
     #

--- a/containers/javascript-node-12/.devcontainer/Dockerfile
+++ b/containers/javascript-node-12/.devcontainer/Dockerfile
@@ -47,6 +47,10 @@ RUN apt-get update \
     && apt-get update \
     && apt-get -y install --no-install-recommends yarn \
     #
+    # Tactically remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
+    # Can leave in image once the CVE is resolved upstream or the node images move to "buster".
+    && apt-get purge -y imagemagick imagemagick-6-common \
+    #
     # Install eslint globally
     && npm install -g eslint \
     #


### PR DESCRIPTION
Aqua security is reporting an issue with imagemagick which is in the default Node.js images.  There is not an upstream patch for Debian stretch currently, so remove the package tactically until the Node image is patched or moves to Debian buster which does not have the issue.

More information here: https://security-tracker.debian.org/tracker/CVE-2019-10131