### PR TITLE
Switch from tagging stubs with MAJOR.MINOR to just MAJOR

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -180,7 +180,7 @@ Since the images would continue to exist after this point and the source code is
 When a release is cut, there are a few things that need to happen. One is obviously releasing the appropriate image. However, to continue to help customers understand how to customize their images, we would want to reference a user modifiable "stub" Dockerfile instead of an image directly. This also is important to help deal with shortcomings and workarounds that require something like specifying a build argument. For example:
 
 ```Dockerfile
-FROM mcr.microsoft.com/vscode/devcontainer/javascript-node:0.35-10
+FROM mcr.microsoft.com/vscode/devcontainer/javascript-node:0-10
 
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -210,7 +210,7 @@ ENV DEBIAN_FRONTEND=dialog
 
 This retains its value as a sample but minimizes the number of actual build steps. This template would **evolve over time as new features are added**. For example, the above Dockerfile includes a way to make sure the user's GID/UID matches the local operating system - which is critical for Linux users. However, if we introduce a `user` concept in `devcontainer.json`, the template would no longer need to include this part of the file.
 
-Referencing The MAJOR.MINOR version in this Dockerfile allows us to push fixes or upstream updates that do not materially change the definition.
+Referencing The MAJOR version in this Dockerfile allows us to push fixes or upstream updates that do not materially change the definition.
 
 ### Repository contents
 
@@ -237,7 +237,7 @@ FROM mcr.microsoft.com/vs/devcontainer/javascript-node:dev-10
 
 #### Automated updates of other Dockerfiles
 
-The process also automatically swaps out referenced MCR images for MAJOR.MINOR versions of built images in any Dockerfile that is added to the package. This allows us to push break fix and or security patches as break fix releases and people will get them. The build supports an option to not update `latest` and MAJOR versions, so we can also rev old MAJOR.MINOR versions if we have to, but normally we'd roll forward instead.
+The process also automatically swaps out referenced MCR images for MAJOR versions of built images in any Dockerfile that is added to the package. This allows us to push break fix and or security patches as break fix releases and people will get them. The build supports an option to not update `latest` and MAJOR versions, so we can also rev old MAJOR versions if we have to, but normally we'd roll forward instead.
 
 #### Common scripts
 
@@ -251,12 +251,12 @@ When a release is cut, the contents of vscode-dev-containers repo would staged. 
 
 2. After the image is built and pushed, `base.Dockerfile` is deleted from staging.
 
-3. Next, `Dockerfile` is updated to point to the correct MAJOR.MINOR version. If no Dockerfile is found, a stub is used based on the root image (Alpine vs Debian).
+3. Next, `Dockerfile` is updated to point to the correct MAJOR version. If no Dockerfile is found, a stub is used based on the root image (Alpine vs Debian).
 
     ```Dockerfile
     # For information on the contents of the image referenced below, see the Dockerfile at
     # https://github.com/microsoft/vscode-dev-containers/tree/v0.35.0/containers/javascript-node-10/.devcontainer/base.Dockerfile
-    FROM mcr.microsoft.com/vs/devcontainer/javascript-node:0.35-10
+    FROM mcr.microsoft.com/vs/devcontainer/javascript-node:0-10
     ```
 
 4. `devcontainer.json` is updated to point to `Dockerfile` instead of `base.Dockerfile` (if required) and add a comment to the source code README for this specific version.

--- a/build/src/prep.js
+++ b/build/src/prep.js
@@ -20,7 +20,7 @@ const containersPathInRepo = configUtils.getConfig('containersPathInRepo');
 const scriptLibraryPathInRepo = configUtils.getConfig('scriptLibraryPathInRepo');
 
 async function prepDockerFile(devContainerDockerfilePath, definitionId, repo, release, registry, registryPath, stubRegistry, stubRegistryPath, isForBuild) {
-    // Use exact version of building, MAJOR.MINOR if not
+    // Use exact version of building, MAJOR if not
     const version = isForBuild ? configUtils.getVersionFromRelease(release) : configUtils.majorMinorFromRelease(release);
 
     // Read Dockerfile
@@ -51,7 +51,7 @@ async function prepDockerFile(devContainerDockerfilePath, definitionId, repo, re
         }
     } else {
         // Otherwise update any Dockerfiles that refer to an un-versioned tag of another dev container
-        // to the MAJOR.MINOR version from this release.
+        // to the MAJOR version from this release.
         const expectedRegistry = configUtils.getConfig('stubRegistry', 'mcr.microsoft.com');
         const expectedRegistryPath = configUtils.getConfig('stubRegistryPath', 'vscode/devcontainers');
         const fromCaptureGroups = new RegExp(`FROM (${expectedRegistry}/${expectedRegistryPath}/.+:.+)`).exec(devContainerDockerfileRaw);

--- a/build/src/prep.js
+++ b/build/src/prep.js
@@ -21,7 +21,7 @@ const scriptLibraryPathInRepo = configUtils.getConfig('scriptLibraryPathInRepo')
 
 async function prepDockerFile(devContainerDockerfilePath, definitionId, repo, release, registry, registryPath, stubRegistry, stubRegistryPath, isForBuild) {
     // Use exact version of building, MAJOR if not
-    const version = isForBuild ? configUtils.getVersionFromRelease(release) : configUtils.majorMinorFromRelease(release);
+    const version = isForBuild ? configUtils.getVersionFromRelease(release) : configUtils.majorFromRelease(release);
 
     // Read Dockerfile
     const devContainerDockerfileRaw = await asyncUtils.readFile(devContainerDockerfilePath);
@@ -81,8 +81,8 @@ async function createStub(dotDevContainerPath, definitionId, repo, release, base
     const userDockerFilePath = path.join(dotDevContainerPath, 'Dockerfile');
     console.log('(*) Generating user Dockerfile...');
     const templateDockerfile = await configUtils.objectByDefinitionLinuxDistro(definitionId, stubPromises);
-    const majorMinor = configUtils.majorMinorFromRelease(release);
-    const imageTag = configUtils.getTagsForVersion(definitionId, majorMinor, stubRegistry, stubRegistryPath)[0];
+    const devContainerImageVersion = configUtils.majorFromRelease(release);
+    const imageTag = configUtils.getTagsForVersion(definitionId, devContainerImageVersion, stubRegistry, stubRegistryPath)[0];
     const userDockerFile = templateDockerfile.replace(
         'FROM REPLACE-ME', getFromSnippet(definitionId, imageTag, repo, release, baseDockerFileExists));
     await asyncUtils.writeFile(userDockerFilePath, userDockerFile);
@@ -93,8 +93,8 @@ async function updateStub(dotDevContainerPath, definitionId, repo, release, base
     const userDockerFilePath = path.join(dotDevContainerPath, 'Dockerfile');
     const userDockerFile = await asyncUtils.readFile(userDockerFilePath);
 
-    const majorMinor = configUtils.majorMinorFromRelease(release);
-    const imageTag = configUtils.getTagsForVersion(definitionId, majorMinor, registry, registryPath)[0];
+    const devContainerImageVersion = configUtils.majorFromRelease(release);
+    const imageTag = configUtils.getTagsForVersion(definitionId, devContainerImageVersion, registry, registryPath)[0];
     const userDockerFileModified = userDockerFile.replace(/FROM .+:.+/,
         getFromSnippet(definitionId, imageTag, repo, release, baseDockerFileExists));
     await asyncUtils.writeFile(userDockerFilePath, userDockerFileModified);

--- a/build/src/utils/config.js
+++ b/build/src/utils/config.js
@@ -190,8 +190,8 @@ function getUpdatedTag(currentTag, currentRegistry, currentRegistryPath, updated
     return currentTag;
 }
 
-// Return just the manor and minor version of a release number
-function majorMinorFromRelease(release) {
+// Return just the major version of a release number
+function majorFromRelease(release) {
     const version = getVersionFromRelease(release);
 
     if (version === 'dev') {
@@ -199,7 +199,7 @@ function majorMinorFromRelease(release) {
     }
 
     const versionParts = version.split('.');
-    return `${versionParts[0]}.${versionParts[1]}`;
+    return versionParts[0];
 }
 
 // Return an object from a map based on the linux distro for the definition
@@ -239,7 +239,7 @@ module.exports = {
     getSortedDefinitionBuildList: getSortedDefinitionBuildList,
     getParentTagForVersion: getParentTagForVersion,
     getUpdatedTag: getUpdatedTag,
-    majorMinorFromRelease: majorMinorFromRelease,
+    majorMinorFromRelease: majorFromRelease,
     objectByDefinitionLinuxDistro: objectByDefinitionLinuxDistro,
     getDefinitionDependencies: getDefinitionDependencies,
     getAllDependencies: getAllDependencies,

--- a/build/src/utils/config.js
+++ b/build/src/utils/config.js
@@ -239,7 +239,7 @@ module.exports = {
     getSortedDefinitionBuildList: getSortedDefinitionBuildList,
     getParentTagForVersion: getParentTagForVersion,
     getUpdatedTag: getUpdatedTag,
-    majorMinorFromRelease: majorFromRelease,
+    majorFromRelease: majorFromRelease,
     objectByDefinitionLinuxDistro: objectByDefinitionLinuxDistro,
     getDefinitionDependencies: getDefinitionDependencies,
     getAllDependencies: getAllDependencies,


### PR DESCRIPTION
Currently the build tagging process for pre-built images updates dockerfiles to reference the MAJOR.MINOR version of the dev container.  

This is likely too restrictive as a starting point.  This PR updates the build script to instead use just the MAJOR version of the image by default. 

While we could drop the version entirely, this could complicate situations where the image gets out of sync with a breaking update to devcontainer.json.