### PR TITLE
Ensure openssh-client is available for git SSH support

### DIFF
--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
     # Verify git, required tools installed
     && apt-get install -y \
         git \
+        openssh-client \
         iproute2 \
         curl \
         procps \

--- a/containers/azure-blockchain/.devcontainer/Dockerfile
+++ b/containers/azure-blockchain/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git iproute2 procps \
+    && apt-get -y install git openssh-client iproute2 procps \
     #
     # Install nodejs
     && curl -sL https://deb.nodesource.com/setup_10.x | bash - \

--- a/containers/azure-cli/.devcontainer/Dockerfile
+++ b/containers/azure-cli/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git iproute2 procps \
+    && apt-get -y install git openssh-client iproute2 procps \
     #
     # Install the Azure CLI
     && apt-get install -y apt-transport-https curl gnupg2 lsb-release \

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        openssh-client \
         iproute2 \
         procps \
         curl \

--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
@@ -23,7 +23,8 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
-	unzip \
+        openssh-client \
+        unzip \
         iproute2 \
         procps \
         curl \

--- a/containers/azure-functions-java-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-8/.devcontainer/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        openssh-client \
         iproute2 \
         procps \
         curl \

--- a/containers/azure-functions-pwsh-6/.devcontainer/Dockerfile
+++ b/containers/azure-functions-pwsh-6/.devcontainer/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
     git \
+    openssh-client \
     iproute2 \
     procps \
     curl \

--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
     # Verify git and needed tools are installed
     && apt-get -y install \
         git \
+        openssh-client \
         iproute2 \
         procps \
         curl \

--- a/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update \
     # Verify git, required tools installed
     && apt-get install -y \
         git \
+        openssh-client \
         curl \
         procps \
         iproute2 \

--- a/containers/azure-terraform-0.11/.devcontainer/Dockerfile
+++ b/containers/azure-terraform-0.11/.devcontainer/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     # install git iproute2, required tools installed
     && apt-get install -y \
         git \
+        openssh-client \
         curl \
         procps \
         unzip \

--- a/containers/azure-terraform-0.12/.devcontainer/Dockerfile
+++ b/containers/azure-terraform-0.12/.devcontainer/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
     # install git iproute2, required tools installed
     && apt-get install -y \
     git \
+    openssh-client \
     curl \
     procps \
     unzip \

--- a/containers/dapr-dotnetcore-3.0/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnetcore-3.0/.devcontainer/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps apt-transport-https gnupg2 curl lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps apt-transport-https gnupg2 curl lsb-release \
     #
     # Install Docker CE CLI
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/containers/dapr-typescript-node-12/.devcontainer/Dockerfile
+++ b/containers/dapr-typescript-node-12/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \ 
     #
     # Verify git and needed tools are installed
-    && apt-get -y install git iproute2 procps \
+    && apt-get -y install git openssh-client iproute2 procps \
     #
     # Install Docker CE CLI
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/containers/dart/.devcontainer/Dockerfile
+++ b/containers/dart/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/docker-in-docker-compose/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker-compose/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git iproute2 procps \
+    && apt-get -y install git openssh-client iproute2 procps \
     #
     # Install Docker CE CLI
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/containers/docker-in-docker/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git iproute2 procps \
+    && apt-get -y install git openssh-client iproute2 procps \
     #
     # Install Docker CE CLI
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1-fsharp/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs)
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Install F#
     && apt-get install -y fsharp \

--- a/containers/dotnetcore-2.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-2.1/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps apt-transport-https gnupg2 curl lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps apt-transport-https gnupg2 curl lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/dotnetcore-3.0-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-3.0-fsharp/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/dotnetcore-3.0/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-3.0/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps apt-transport-https gnupg2 curl lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps apt-transport-https gnupg2 curl lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/dotnetcore-3.1-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-3.1-fsharp/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/dotnetcore-3.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-3.1/.devcontainer/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps apt-transport-https gnupg2 curl lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps apt-transport-https gnupg2 curl lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Install Go tools w/module support
     && mkdir -p /tmp/gotools \

--- a/containers/java-11/.devcontainer/Dockerfile
+++ b/containers/java-11/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git iproute2 procps curl lsb-release
+    && apt-get -y install git openssh-client iproute2 procps curl lsb-release
 
 #-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
 # ARG MAVEN_VERSION=3.6.3

--- a/containers/java-12/.devcontainer/Dockerfile
+++ b/containers/java-12/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME 
 
 # Verify git, needed tools installed
-RUN yum install -y git net-tools which curl procps unzip
+RUN yum install -y git openssh-client net-tools which curl procps unzip
 
 #-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
 # ARG MAVEN_VERSION=3.6.3

--- a/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
+++ b/containers/java-8-tomcat-8.5/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git iproute2 procps curl lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps curl lsb-release \
     #
     # Install openjdk 8
     && apt-get -y install --no-install-recommends openjdk-8-jdk \

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git iproute2 procps curl lsb-release
+    && apt-get -y install git openssh-client iproute2 procps curl lsb-release
 
 #-------------------Uncomment the following steps to install Maven CLI Tools----------------------------------
 # ARG MAVEN_VERSION=3.6.3

--- a/containers/jekyll/.devcontainer/Dockerfile
+++ b/containers/jekyll/.devcontainer/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
     # Install vim, git, process tools, lsb-release
     && apt-get install -y \
         git \
+        openssh-client \
     #
     # Install ruby
     && apt-get install -y \

--- a/containers/kubernetes-helm/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm/.devcontainer/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools installed
-    && apt-get -y install git iproute2 procps \
+    && apt-get -y install git openssh-client iproute2 procps \
     #
     # Install Docker CE CLI
     && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \

--- a/containers/perl/.devcontainer/Dockerfile
+++ b/containers/perl/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/php-7/.devcontainer/Dockerfile
+++ b/containers/php-7/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # install git iproute2, procps, lsb-release (useful for CLI installs)
-    && apt-get -y install git iproute2 procps iproute2 lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps iproute2 lsb-release \
     #
     # Install xdebug
     && yes | pecl install xdebug \

--- a/containers/plantuml/.devcontainer/Dockerfile
+++ b/containers/plantuml/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Install GraphViz
     && apt-get install -y graphviz \

--- a/containers/powershell/.devcontainer/Dockerfile
+++ b/containers/powershell/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
 # install git iproute2, process tools
-RUN apt-get update && apt-get -y install git iproute2 procps \
+RUN apt-get update && apt-get -y install git openssh-client iproute2 procps \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/puppet/.devcontainer/Dockerfile
+++ b/containers/puppet/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ ADD https://apt.puppetlabs.com/puppet6-release-xenial.deb /puppet6-release-xenia
 RUN dpkg -i /puppet6-release-xenial.deb
 
 RUN apt-get update \
-    && apt-get -y install git iproute2 procps pdk \
+    && apt-get -y install git openssh-client iproute2 procps pdk \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \

--- a/containers/python-3-anaconda/.devcontainer/Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps iproute2 lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps iproute2 lsb-release \
     #
     # Install pylint
     && /opt/conda/bin/pip install pylint \

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps iproute2 lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps iproute2 lsb-release \
     #
     # Install pylint
     && /opt/conda/bin/pip install pylint \

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Install pylint
     && pip install pylint \

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Install pylint
     && pip --disable-pip-version-check --no-cache-dir install pylint \

--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # install git iproute2, process tools, lsb-release (common in install instructions for CLIs) and libzip for R Tools extension
-    && apt-get -y install git iproute2 procps lsb-release libzip-dev \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release libzip-dev \
     #
     # Register Microsoft key and feed
     && wget -q https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb \

--- a/containers/ruby-2-rails-5/.devcontainer/Dockerfile
+++ b/containers/ruby-2-rails-5/.devcontainer/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
     && apt-get install -y \
         vim \
         git \
+        openssh-client \
         iproute2 \
         procps \
         lsb-release \

--- a/containers/ruby-2-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-2-sinatra/.devcontainer/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
     && apt-get install -y \
         vim \
         git \
+        openssh-client \
         iproute2 \ 
         procps \
         lsb-release \

--- a/containers/ruby-2/.devcontainer/Dockerfile
+++ b/containers/ruby-2/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ ARG USER_GID=$USER_UID
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     # Verify git, process tools installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Install ruby-debug-ide and debase
     && gem install ruby-debug-ide \

--- a/containers/rust/.devcontainer/Dockerfile
+++ b/containers/rust/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Install lldb, vadimcn.vscode-lldb VSCode extension dependencies
     && apt-get install -y lldb python3-minimal libpython3.7 \

--- a/containers/swift-4/.devcontainer/Dockerfile
+++ b/containers/swift-4/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client iproute2 procps lsb-release \
     #
     # Install SourceKite, see https://github.com/vknabel/vscode-swift-development-environment/blob/master/README.md#installation
     && git clone https://github.com/jinmingjian/sourcekite.git \


### PR DESCRIPTION
Related to https://github.com/microsoft/vscode-dev-containers/issues/210.  Add `openssh-client` explicitly to the list of all dev containers (in addition to the "base" containers like debian-9 which are already done). 

SSH support for git depends on this library being present, and it appears that there are scenarios where it is not. This will ensure that the library is installed even if something changes in the base image.