### PR TITLE
Run upgrade when generating images to get security updates not in base image

### DIFF
--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -18,6 +18,10 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
+# Get to latest versions of all packages
+apt-get -y upgrade
+
+# Install common dependencies
 apt-get -y install --no-install-recommends \
     git \
     openssh-client \

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -18,6 +18,10 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
+# Update to latest versions of packages
+yum upgrade -y
+
+# Install common dependencies
 yum install -y \
     git \
     openssh-clients \


### PR DESCRIPTION
For example, CVE-2019-13627 has been patched for Ubuntu, but is not in the base Ubuntu image at this moment.