### PR TITLE
Added write permission for /go/pkg in go container.

### DIFF
--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -67,6 +67,8 @@ RUN apt-get update \
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
+    # Add write permission for /go/pkg
+    && chmod -R a+w /go/pkg \
     #
     # Clean up
     && apt-get autoremove -y \


### PR DESCRIPTION
This tries to solve the problem of not being able to run go mod init as a non-root-user in the go dev container.

See github [issue](https://github.com/microsoft/vscode-dev-containers/issues/226).

This is my first pull request. Not sure if I am doing it correctly...