### PR TITLE
Parallelize image generation to speed up CI process

### DIFF
--- a/.github/workflows/cgmanifest.yml
+++ b/.github/workflows/cgmanifest.yml
@@ -2,8 +2,8 @@ name: Update CG Manifest
 
 on:
   repository_dispatch:
-  #schedule: 
-  #  - cron: '0 22 * * *'
+  release: 
+    types: [created]
 
 jobs:
   cgmanifest:

--- a/.github/workflows/cgmanifest.yml
+++ b/.github/workflows/cgmanifest.yml
@@ -1,0 +1,46 @@
+name: Update CG Manifest
+
+on:
+  #repository_dispatch:
+  schedule: 
+    - '0 22 * * *'
+
+jobs:
+  cgmanifest:
+    name: Generate cgmanifest.json
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    steps:
+
+    - name: Container Registry Login
+      id: docker_login
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.REGISTRY }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
+
+    - name: Update CG Manifest
+      id: update_cg_manifest
+      run: |
+        set -e
+        yarn install
+        GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
+        if [ "$GIT_BRANCH" == "" ]; then 
+            GIT_BRANCH=master
+        fi
+        build/vscdc cg  --no-build \
+                        --release $GIT_BRANCH \
+                        --github-repo ${{ github.repository }} \
+                        --registry ${{ secrets.REGISTRY }} \
+                        --registry-path ${{ secrets.REGISTRY_BASE_PATH }}
+        git config --global user.email "vscr-feedback@microsoft.com"
+        git config --global user.name "CI"
+        git add cgmanifest.json
+        git commit -m 'Automated update' \
+          && git push "https://ci:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}" "HEAD:${{ github.ref }}" \
+          || echo 'No updates to cgmanifest.json'

--- a/.github/workflows/cgmanifest.yml
+++ b/.github/workflows/cgmanifest.yml
@@ -1,9 +1,9 @@
 name: Update CG Manifest
 
 on:
-  #repository_dispatch:
-  schedule: 
-    - cron: '0 22 * * *'
+  repository_dispatch:
+  #schedule: 
+  #  - cron: '0 22 * * *'
 
 jobs:
   cgmanifest:

--- a/.github/workflows/cgmanifest.yml
+++ b/.github/workflows/cgmanifest.yml
@@ -2,8 +2,6 @@ name: Update CG Manifest
 
 on:
   repository_dispatch:
-  release: 
-    types: [created]
 
 jobs:
   cgmanifest:

--- a/.github/workflows/cgmanifest.yml
+++ b/.github/workflows/cgmanifest.yml
@@ -3,7 +3,7 @@ name: Update CG Manifest
 on:
   #repository_dispatch:
   schedule: 
-    - '0 22 * * *'
+    - cron: '0 22 * * *'
 
 jobs:
   cgmanifest:

--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -7,8 +7,13 @@ on:
     - 'v*'
 
 jobs:
-  build-page-1:
-    name: Build and push (page 1/3)
+  build-and-push:
+    name: Build and push
+    strategy:
+      matrix:
+        page: [1, 2, 3]
+        page-total: [3]
+      fail-fast: true
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -33,78 +38,8 @@ jobs:
         set -e
         # Push images and package
         yarn install
-        build/vscdc push  --page 1 \
-                          --pageTotal 3 \
-                          --release ${{ steps.get_tag_name.outputs.tag }} \
-                          --github-repo ${{ github.repository }} \
-                          --registry ${{ secrets.REGISTRY }} \
-                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
-                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
-                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
-
-  build-page-2:
-    name: Build and push (page 2/3)
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
-
-    - name: Get Tag Name
-      id: get_tag_name  
-      uses: olegtarasov/get-tag@v1
-
-    - name: Container Registry Login
-      id: docker_login
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-      
-    - name: Build and push
-      id: build_and_push
-      run: |
-        set -e
-        # Push images and package
-        yarn install
-        build/vscdc push  --page 2 \
-                          --pageTotal 3 \
-                          --release ${{ steps.get_tag_name.outputs.tag }} \
-                          --github-repo ${{ github.repository }} \
-                          --registry ${{ secrets.REGISTRY }} \
-                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
-                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
-                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
-
-  build-page-3:
-    name: Build and push (page 3/3)
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
-
-    - name: Get Tag Name
-      id: get_tag_name  
-      uses: olegtarasov/get-tag@v1
-
-    - name: Container Registry Login
-      id: docker_login
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-      
-    - name: Build and push
-      id: build_and_push
-      run: |
-        set -e
-        # Push images and package
-        yarn install
-        build/vscdc push  --page 3 \
-                          --pageTotal 3 \
+        build/vscdc push  --page ${{ matrix.page }} \
+                          --pageTotal ${{ matrix.page-total }} \
                           --release ${{ steps.get_tag_name.outputs.tag }} \
                           --github-repo ${{ github.repository }} \
                           --registry ${{ secrets.REGISTRY }} \
@@ -114,7 +49,7 @@ jobs:
 
   package:
     name: Package and release
-    needs: [build-page-1, build-page-2, build-page-3]
+    needs: [build-and-push]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     steps:

--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -7,11 +7,13 @@ on:
     - 'v*'
 
 jobs:
-  build:
-    
+  build-page-1:
+    name: Build and push (page 1/3)
     runs-on: ubuntu-latest
-    
     steps:
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
 
     - name: Get Tag Name
       id: get_tag_name  
@@ -24,23 +26,114 @@ jobs:
         login-server: ${{ secrets.REGISTRY }}
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
-
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
       
-    - name: Push and Package
-      id: push_and_package
+    - name: Build and push
+      id: build_and_push
       run: |
+        set -e
         # Push images and package
         yarn install
-        build/vscdc pack  --release ${{ steps.get_tag_name.outputs.tag }} \
+        build/vscdc push  --page 1 \
+                          --pageTotal 3 \
+                          --release ${{ steps.get_tag_name.outputs.tag }} \
                           --github-repo ${{ github.repository }} \
                           --registry ${{ secrets.REGISTRY }} \
                           --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
                           --stub-registry ${{ secrets.STUB_REGISTRY }} \
                           --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
 
+  build-page-2:
+    name: Build and push (page 2/3)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
+
+    - name: Get Tag Name
+      id: get_tag_name  
+      uses: olegtarasov/get-tag@v1
+
+    - name: Container Registry Login
+      id: docker_login
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.REGISTRY }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+      
+    - name: Build and push
+      id: build_and_push
+      run: |
+        set -e
+        # Push images and package
+        yarn install
+        build/vscdc push  --page 2 \
+                          --pageTotal 3 \
+                          --release ${{ steps.get_tag_name.outputs.tag }} \
+                          --github-repo ${{ github.repository }} \
+                          --registry ${{ secrets.REGISTRY }} \
+                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
+                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
+                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
+
+  build-page-3:
+    name: Build and push (page 3/3)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
+
+    - name: Get Tag Name
+      id: get_tag_name  
+      uses: olegtarasov/get-tag@v1
+
+    - name: Container Registry Login
+      id: docker_login
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.REGISTRY }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+      
+    - name: Build and push
+      id: build_and_push
+      run: |
+        set -e
+        # Push images and package
+        yarn install
+        build/vscdc push  --page 3 \
+                          --pageTotal 3 \
+                          --release ${{ steps.get_tag_name.outputs.tag }} \
+                          --github-repo ${{ github.repository }} \
+                          --registry ${{ secrets.REGISTRY }} \
+                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
+                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
+                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
+
+  package:
+    name: Package and release
+    needs: [build-page-1, build-page-2, build-page-3]
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    steps:
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
+
+    - name: Package
+      id: package
+      run: |
+        set -e
+        yarn install
+        build/vscdc pack  --prep-and-package-only \
+                          --release ${{ steps.get_tag_name.outputs.tag }} \
+                          --github-repo ${{ github.repository }} \
+                          --registry ${{ secrets.REGISTRY }} \
+                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
+                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
+                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
         # Set an output with the resulting package name for upload
         PKG_PREFIX=$(node -p "require('./package.json').name")
         echo "::set-output name=package_name::$(ls $PKG_PREFIX-*.tgz)"
@@ -63,6 +156,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./${{ steps.push_and_package.outputs.package_name }}
-        asset_name: ${{ steps.push_and_package.outputs.package_name }}
+        asset_path: ./${{ steps.package.outputs.package_name }}
+        asset_name: ${{ steps.package.outputs.package_name }}
         asset_content_type: application/gzip 

--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -57,6 +57,10 @@ jobs:
       id: checkout
       uses: actions/checkout@v1
 
+    - name: Get Tag Name
+      id: get_tag_name  
+      uses: olegtarasov/get-tag@v1
+
     - name: Package
       id: package
       run: |

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -137,7 +137,7 @@ jobs:
         if [ "$GIT_BRANCH" == "" ]; then 
             GIT_BRANCH=master
         fi
-        build/vscdc pack  --no-push-images \
+        build/vscdc pack  --prep-only \
                           --release $GIT_BRANCH \
                           --github-repo ${{ github.repository }} \
                           --registry ${{ secrets.REGISTRY }} \

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -9,12 +9,10 @@ on:
       - 'script-library/**'
 
 jobs:
-  build:
-    
+  build-page-1:
+    name: Build and push (page 1 of 3)
     runs-on: ubuntu-latest
-
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
-    
     steps:
 
     - name: Container Registry Login
@@ -28,42 +26,172 @@ jobs:
     - name: Checkout
       id: checkout
       uses: actions/checkout@v1
-      
-    - name: Push "dev", Package, update CG manifest
-      id: push_and_package
+
+    - name: Build and push dev tags (page 1 of 3)
+      id: build_and_push
       run: |
-        # Push dev images and package
         set -e
-
         yarn install
-
         GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
         if [ "$GIT_BRANCH" == "" ]; then 
             GIT_BRANCH=master
         fi
-        build/vscdc pack  --release $GIT_BRANCH \
+        build/vscdc push  --page 1 \
+                          --pageTotal 3 \
+                          --release $GIT_BRANCH \
                           --github-repo ${{ github.repository }} \
                           --registry ${{ secrets.REGISTRY }} \
                           --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
                           --stub-registry ${{ secrets.STUB_REGISTRY }} \
                           --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
 
+  build-page-2:
+    name: Build and push (page 2 of 3)
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    steps:
+
+    - name: Container Registry Login
+      id: docker_login
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.REGISTRY }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
+
+    - name: Build and push dev tags (page 2 of 3)
+      id: build_and_push
+      run: |
+        set -e
+        yarn install
+        GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
+        if [ "$GIT_BRANCH" == "" ]; then 
+            GIT_BRANCH=master
+        fi
+        build/vscdc push  --page 2 \
+                          --pageTotal 3 \
+                          --release $GIT_BRANCH \
+                          --github-repo ${{ github.repository }} \
+                          --registry ${{ secrets.REGISTRY }} \
+                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
+                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
+                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
+
+  build-page-3:
+    name: Build and push (page 3 of 3)
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    steps:
+
+    - name: Container Registry Login
+      id: docker_login
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.REGISTRY }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
+
+    - name: Build and push dev tags (page 3 of 3)
+      id: build_and_push
+      run: |
+        set -e
+        yarn install
+        GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
+        if [ "$GIT_BRANCH" == "" ]; then 
+            GIT_BRANCH=master
+        fi
+        build/vscdc push  --page 3 \
+                          --pageTotal 3 \
+                          --release "$GIT_BRANCH" \
+                          --github-repo ${{ github.repository }} \
+                          --registry ${{ secrets.REGISTRY }} \
+                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
+                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
+                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
+
+  package:
+    name: Package
+    needs: [build-page-1, build-page-2, build-page-3]
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    steps:
+
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
+
+    - name: Package
+      id: package
+      run: |
+        set -e
+        yarn install
+        GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
+        if [ "$GIT_BRANCH" == "" ]; then 
+            GIT_BRANCH=master
+        fi
+        build/vscdc pack  --no-push-images
+                          --release $GIT_BRANCH \
+                          --github-repo ${{ github.repository }} \
+                          --registry ${{ secrets.REGISTRY }} \
+                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
+                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
+                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }} \
+
         # Set an output with the resulting package name for upload
         PKG_PREFIX=$(node -p "require('./package.json').name")
         mv ./$PKG_PREFIX-*.tgz ./$PKG_PREFIX-${{ github.sha }}.tgz
         echo "::set-output name=package_name::$PKG_PREFIX-${{ github.sha }}.tgz"
 
-        # Update CG manifest
-        build/vscdc cg --no-build --release $BRANCH --github-repo ${{ github.repository }} --registry ${{ secrets.REGISTRY }} --registry-path ${{ secrets.REGISTRY_BASE_PATH }}
+    - name: Upload Package
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: ${{ steps.package.outputs.package_name }}
+        path: ./${{ steps.package.outputs.package_name }}
+
+  cgmanifest:
+    name: Generate cgmanifest.json
+    needs: [build-page-1, build-page-2, build-page-3]
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    steps:
+
+    - name: Container Registry Login
+      id: docker_login
+      uses: azure/docker-login@v1
+      with:
+        login-server: ${{ secrets.REGISTRY }}
+        username: ${{ secrets.REGISTRY_USERNAME }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
+
+    - name: Update CG Manifest
+      id: update_cg_manifest
+      run: |
+        set -e
+        yarn install
+        GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
+        if [ "$GIT_BRANCH" == "" ]; then 
+            GIT_BRANCH=master
+        fi
+        build/vscdc cg  --no-build 
+                        --release $GIT_BRANCH 
+                        --github-repo ${{ github.repository }} 
+                        --registry ${{ secrets.REGISTRY }} 
+                        --registry-path ${{ secrets.REGISTRY_BASE_PATH }}
         git config --global user.email "vscr-feedback@microsoft.com"
         git config --global user.name "CI"
         git add cgmanifest.json
         git commit -m 'Automated update' \
           && git push "https://ci:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}" "HEAD:${{ github.ref }}" \
           || echo 'No updates to cgmanifest.json'
-
-    - name: Upload Package
-      uses: actions/upload-artifact@v1.0.0
-      with:
-        name: ${{ steps.push_and_package.outputs.package_name }}
-        path: ./${{ steps.push_and_package.outputs.package_name }}

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -1,7 +1,7 @@
 name: CI & Push "dev"
 
 on: 
-  repository_dispatch:
+  #repository_dispatch:
   push:
     branches: [master]
     paths:
@@ -160,20 +160,18 @@ jobs:
         path: ./${{ steps.package.outputs.package_name }}
 
   cgmanifest:
-    name: Generate cgmanifest.json
+    name: Trigger CG manifest generation
     needs: [build-page-1, build-page-2, build-page-3]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     steps:
-
-    - name: Container Registry Login
-      id: docker_login
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
+    - name: Trigger CG manifest generation 
+      id: cgmanifest
+      run: |
+        set -e
+        curl -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.everest-preview+json" \
+          -H "Content-Type: application/json" \
+          https://api.github.com/repos/${{ github.repository }}/dispatches \
+          --data '{"event_type":"manual_oss_cg_trigger"}'

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -177,24 +177,3 @@ jobs:
     - name: Checkout
       id: checkout
       uses: actions/checkout@v1
-
-    - name: Update CG Manifest
-      id: update_cg_manifest
-      run: |
-        set -e
-        yarn install
-        GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
-        if [ "$GIT_BRANCH" == "" ]; then 
-            GIT_BRANCH=master
-        fi
-        build/vscdc cg  --no-build \
-                        --release $GIT_BRANCH \
-                        --github-repo ${{ github.repository }} \
-                        --registry ${{ secrets.REGISTRY }} \
-                        --registry-path ${{ secrets.REGISTRY_BASE_PATH }}
-        git config --global user.email "vscr-feedback@microsoft.com"
-        git config --global user.name "CI"
-        git add cgmanifest.json
-        git commit -m 'Automated update' \
-          && git push "https://ci:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}" "HEAD:${{ github.ref }}" \
-          || echo 'No updates to cgmanifest.json'

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -172,7 +172,7 @@ jobs:
         echo '(*) Triggering CG manifest generation using repository_dispatch'
 
         # Use alternate GitHub token due to https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676
-        echo curl -X POST \
+        curl -X POST \
           -H "Authorization: token ${{ secrets.ALTERNATE_GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" \

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -9,10 +9,15 @@ on:
       - 'script-library/**'
 
 jobs:
-  build-page-1:
-    name: Build and push (page 1/3)
-    runs-on: ubuntu-latest
+  build-and-push:
+    name: Build and push
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    strategy:
+      matrix:
+        page: [1, 2, 3]
+        page-total: [3]
+      fail-fast: true
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       id: checkout
@@ -35,78 +40,8 @@ jobs:
         if [ "$GIT_BRANCH" == "" ]; then 
             GIT_BRANCH=master
         fi
-        build/vscdc push  --page 1 \
-                          --pageTotal 3 \
-                          --release $GIT_BRANCH \
-                          --github-repo ${{ github.repository }} \
-                          --registry ${{ secrets.REGISTRY }} \
-                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
-                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
-                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
-
-  build-page-2:
-    name: Build and push (page 2/3)
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
-    steps:
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
-
-    - name: Container Registry Login
-      id: docker_login
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-
-    - name: Build and push dev tags
-      id: build_and_push
-      run: |
-        set -e
-        yarn install
-        GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
-        if [ "$GIT_BRANCH" == "" ]; then 
-            GIT_BRANCH=master
-        fi
-        build/vscdc push  --page 2 \
-                          --pageTotal 3 \
-                          --release $GIT_BRANCH \
-                          --github-repo ${{ github.repository }} \
-                          --registry ${{ secrets.REGISTRY }} \
-                          --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
-                          --stub-registry ${{ secrets.STUB_REGISTRY }} \
-                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
-
-  build-page-3:
-    name: Build and push (page 3/3)
-    runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
-    steps:
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
-
-    - name: Container Registry Login
-      id: docker_login
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-
-    - name: Build and push dev tags
-      id: build_and_push
-      run: |
-        set -e
-        yarn install
-        GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
-        if [ "$GIT_BRANCH" == "" ]; then 
-            GIT_BRANCH=master
-        fi
-        build/vscdc push  --page 3 \
-                          --pageTotal 3 \
+        build/vscdc push  --page ${{ matrix.page }} \
+                          --pageTotal ${{ matrix.page-total }} \
                           --release $GIT_BRANCH \
                           --github-repo ${{ github.repository }} \
                           --registry ${{ secrets.REGISTRY }} \
@@ -116,11 +51,10 @@ jobs:
 
   package:
     name: Package
-    needs: [build-page-1, build-page-2, build-page-3]
-    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    needs: [build-and-push]
+    runs-on: ubuntu-latest
     steps:
-
     - name: Checkout
       id: checkout
       uses: actions/checkout@v1
@@ -155,9 +89,9 @@ jobs:
 
   cgmanifest:
     name: Trigger CG generation
-    needs: [build-page-1, build-page-2, build-page-3]
-    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
+    needs: [build-and-push]
+    runs-on: ubuntu-latest
     steps:
     - name: Trigger CG generation 
       id: cgmanifest

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -165,13 +165,18 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     steps:
-    - name: Trigger CG manifest generation 
+    - name: Trigger CG generation 
       id: cgmanifest
       run: |
         set -e
-        curl -X POST \
-          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+        echo '(*) Triggering CG manifest generation using repository_dispatch'
+
+        # Use alternate GitHub token due to https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676
+        echo curl -X POST \
+          -H "Authorization: token ${{ secrets.ALTERNATE_GITHUB_TOKEN }}" \
           -H "Accept: application/vnd.github.everest-preview+json" \
           -H "Content-Type: application/json" \
           https://api.github.com/repos/${{ github.repository }}/dispatches \
-          --data '{"event_type":"manual_oss_cg_trigger"}'
+          --data '{"event_type":"oss_cg_trigger"}'
+
+

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -137,7 +137,7 @@ jobs:
         if [ "$GIT_BRANCH" == "" ]; then 
             GIT_BRANCH=master
         fi
-        build/vscdc pack  --prep-only \
+        build/vscdc pack  --prep-and-package-only \
                           --release $GIT_BRANCH \
                           --github-repo ${{ github.repository }} \
                           --registry ${{ secrets.REGISTRY }} \

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -110,7 +110,7 @@ jobs:
         fi
         build/vscdc push  --page 3 \
                           --pageTotal 3 \
-                          --release "$GIT_BRANCH" \
+                          --release $GIT_BRANCH \
                           --github-repo ${{ github.repository }} \
                           --registry ${{ secrets.REGISTRY }} \
                           --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
@@ -137,18 +137,21 @@ jobs:
         if [ "$GIT_BRANCH" == "" ]; then 
             GIT_BRANCH=master
         fi
-        build/vscdc pack  --no-push-images
+        build/vscdc pack  --no-push-images \
                           --release $GIT_BRANCH \
                           --github-repo ${{ github.repository }} \
                           --registry ${{ secrets.REGISTRY }} \
                           --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
                           --stub-registry ${{ secrets.STUB_REGISTRY }} \
-                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }} \
+                          --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
 
         # Set an output with the resulting package name for upload
         PKG_PREFIX=$(node -p "require('./package.json').name")
-        mv ./$PKG_PREFIX-*.tgz ./$PKG_PREFIX-${{ github.sha }}.tgz
-        echo "::set-output name=package_name::$PKG_PREFIX-${{ github.sha }}.tgz"
+        PKG_NAME=$PKG_PREFIX-${{ github.sha }}.tgz
+        mv ./$PKG_PREFIX-*.tgz ./$PKG_NAME
+
+        echo 
+        echo "::set-output name=package_name::$PKG_NAME"
 
     - name: Upload Package
       uses: actions/upload-artifact@v1.0.0
@@ -184,10 +187,10 @@ jobs:
         if [ "$GIT_BRANCH" == "" ]; then 
             GIT_BRANCH=master
         fi
-        build/vscdc cg  --no-build 
-                        --release $GIT_BRANCH 
-                        --github-repo ${{ github.repository }} 
-                        --registry ${{ secrets.REGISTRY }} 
+        build/vscdc cg  --no-build \
+                        --release $GIT_BRANCH \
+                        --github-repo ${{ github.repository }} \
+                        --registry ${{ secrets.REGISTRY }} \
                         --registry-path ${{ secrets.REGISTRY_BASE_PATH }}
         git config --global user.email "vscr-feedback@microsoft.com"
         git config --global user.name "CI"

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -3,7 +3,7 @@ name: CI & Push "dev"
 on: 
   repository_dispatch:
   push:
-    branches: master
+    branches: [master]
     paths:
       - 'containers/**'
       - 'script-library/**'

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -10,10 +10,13 @@ on:
 
 jobs:
   build-page-1:
-    name: Build and push (page 1 of 3)
+    name: Build and push (page 1/3)
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     steps:
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
 
     - name: Container Registry Login
       id: docker_login
@@ -23,11 +26,7 @@ jobs:
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
-
-    - name: Build and push dev tags (page 1 of 3)
+    - name: Build and push dev tags
       id: build_and_push
       run: |
         set -e
@@ -46,10 +45,13 @@ jobs:
                           --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
 
   build-page-2:
-    name: Build and push (page 2 of 3)
+    name: Build and push (page 2/3)
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     steps:
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
 
     - name: Container Registry Login
       id: docker_login
@@ -59,11 +61,7 @@ jobs:
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
-
-    - name: Build and push dev tags (page 2 of 3)
+    - name: Build and push dev tags
       id: build_and_push
       run: |
         set -e
@@ -82,10 +80,13 @@ jobs:
                           --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
 
   build-page-3:
-    name: Build and push (page 3 of 3)
+    name: Build and push (page 3/3)
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     steps:
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@v1
 
     - name: Container Registry Login
       id: docker_login
@@ -95,11 +96,7 @@ jobs:
         username: ${{ secrets.REGISTRY_USERNAME }}
         password: ${{ secrets.REGISTRY_PASSWORD }}
 
-    - name: Checkout
-      id: checkout
-      uses: actions/checkout@v1
-
-    - name: Build and push dev tags (page 3 of 3)
+    - name: Build and push dev tags
       id: build_and_push
       run: |
         set -e
@@ -144,13 +141,10 @@ jobs:
                           --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
                           --stub-registry ${{ secrets.STUB_REGISTRY }} \
                           --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
-
         # Set an output with the resulting package name for upload
         PKG_PREFIX=$(node -p "require('./package.json').name")
         PKG_NAME=$PKG_PREFIX-${{ github.sha }}.tgz
         mv ./$PKG_PREFIX-*.tgz ./$PKG_NAME
-
-        echo 
         echo "::set-output name=package_name::$PKG_NAME"
 
     - name: Upload Package
@@ -160,7 +154,7 @@ jobs:
         path: ./${{ steps.package.outputs.package_name }}
 
   cgmanifest:
-    name: Trigger CG manifest generation
+    name: Trigger CG generation
     needs: [build-page-1, build-page-2, build-page-3]
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
 			"program": "${workspaceFolder}/build/vscdc",
 			"args": [
 				"push",
-				"--release", "clantz/image-generation",
+				"--release", "master",
+				"--page", "3",
+				"--pageTotal", "3",
 				"--github-repo", "microsoft/vscode-dev-containers",
 				"--registry", "clantz.azurecr.io",
 				"--registryPath", "vscode/devcontainers",
@@ -27,7 +29,7 @@
 			"args": [
 				"pack",
 				"--no-clean",
-				"--release", "clantz/image-generation",
+				"--release", "master",
 				"--github-repo", "microsoft/vscode-dev-containers",
 				"--registry", "clantz.azurecr.io",
 				"--registryPath", "vscode/devcontainers",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
     "cSpell.words": [
         "Distro",
         "Dockerfiles",
+        "cgmanifest",
         "copyfiles",
         "devcontainer",
         "devcontainers",

--- a/build/src/cgmanifest.js
+++ b/build/src/cgmanifest.js
@@ -107,6 +107,9 @@ async function generatePackageComponentList(config, packageList, imageTag, alrea
     const componentList = [];
     console.log(`(*) Generating Linux package registrations for ${imageTag}...`);
 
+    console.log(`(*) Pulling image...`);
+    await asyncUtils.spawn('docker', ['pull', imageTag]);
+
     // Generate and exec command to get installed package versions
     console.log('(*) Getting package versions...');
     const packageVersionListCommand = packageList.reduce((prev, current) => {

--- a/build/src/cgmanifest.js
+++ b/build/src/cgmanifest.js
@@ -45,9 +45,9 @@ async function generateComponentGovernanceManifest(repo, release, registry, regi
     await configUtils.loadConfig();
 
     if (buildFirst) {
-        // Simulate the build and push process, but don't actually push 
-        console.log('(*) Simulating push process to trigger image builds...');
-        await push(repo, release, false, registry, registryPath, registry, registryPath, true);
+        // Build but don't push images
+        console.log('(*) Building images...');
+        await push(repo, release, false, registry, registryPath, registry, registryPath, false);
     } else {
         console.log('(*) Using existing local images...');
     }

--- a/build/src/package.js
+++ b/build/src/package.js
@@ -23,7 +23,7 @@ async function package(repo, release, updateLatest, registry, registryPath, stub
 
     if (pushImages) {
         // First, push images, update content
-        await push(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, simulate);
+        await push(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, simulate, 1, 1);
     }
 
     // Then package

--- a/build/src/package.js
+++ b/build/src/package.js
@@ -10,7 +10,13 @@ const asyncUtils = require('./utils/async');
 const configUtils = require('./utils/config');
 const packageJson = require('../../package.json');
 
-async function package(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, packageOnly, cleanWhenDone, prepOnly) {
+async function package(repo, release, updateLatest, registry, registryPath, 
+    stubRegistry, stubRegistryPath, prepAndPackageOnly, packageOnly, cleanWhenDone) {
+
+    // Optional argument defaults
+    packageOnly = typeof packageOnly === 'undefined' ? false : packageOnly;
+    prepAndPackageOnly = typeof prepAndPackageOnly === 'undefined' ? false : prepAndPackageOnly;
+    cleanWhenDone = typeof cleanWhenDone === 'undefined' ? true : cleanWhenDone;
     stubRegistry = stubRegistry || registry;
     stubRegistryPath = stubRegistryPath || registryPath;
 
@@ -23,7 +29,7 @@ async function package(repo, release, updateLatest, registry, registryPath, stub
 
     if (!packageOnly) {
         // First, push images, update content
-        await push(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, prepOnly, 1, 1);
+        await push(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, true, prepAndPackageOnly);
     }
 
     // Then package
@@ -51,13 +57,9 @@ async function package(repo, release, updateLatest, registry, registryPath, stub
     await asyncUtils.spawn('npm', ['pack'], opts); // Need to use npm due to https://github.com/yarnpkg/yarn/issues/685
 
     let outputPath = null;
-    if (simulate) {
-        console.log('(*) Simulating: Skipping package move.');
-    } else {
-        console.log('(*) Moving package...');
-        outputPath = path.join(__dirname, '..', '..', `${packageJson.name}-${packageJsonVersion}.tgz`);
-        await asyncUtils.rename(path.join(stagingFolder, `${packageJson.name}-${packageJsonVersion}.tgz`), outputPath);
-    }
+    console.log('(*) Moving package...');
+    outputPath = path.join(__dirname, '..', '..', `${packageJson.name}-${packageJsonVersion}.tgz`);
+    await asyncUtils.rename(path.join(stagingFolder, `${packageJson.name}-${packageJsonVersion}.tgz`), outputPath);
 
     if (cleanWhenDone) {
         // And finally clean up

--- a/build/src/package.js
+++ b/build/src/package.js
@@ -10,7 +10,7 @@ const asyncUtils = require('./utils/async');
 const configUtils = require('./utils/config');
 const packageJson = require('../../package.json');
 
-async function package(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, pushImages, cleanWhenDone, simulate) {
+async function package(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, packageOnly, cleanWhenDone, prepOnly) {
     stubRegistry = stubRegistry || registry;
     stubRegistryPath = stubRegistryPath || registryPath;
 
@@ -21,9 +21,9 @@ async function package(repo, release, updateLatest, registry, registryPath, stub
     const stagingFolder = await configUtils.getStagingFolder(release);
     const definitionStagingFolder = path.join(stagingFolder, 'containers');
 
-    if (pushImages) {
+    if (!packageOnly) {
         // First, push images, update content
-        await push(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, simulate, 1, 1);
+        await push(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, prepOnly, 1, 1);
     }
 
     // Then package

--- a/build/src/push.js
+++ b/build/src/push.js
@@ -9,7 +9,7 @@ const asyncUtils = require('./utils/async');
 const configUtils = require('./utils/config');
 const prep = require('./prep');
 
-async function push(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, simulate, page, pageTotal, definitionId) {
+async function push(repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, prepOnly, page, pageTotal, definitionId) {
     stubRegistry = stubRegistry || registry;
     stubRegistryPath = stubRegistryPath || registryPath;
 
@@ -26,13 +26,13 @@ async function push(repo, release, updateLatest, registry, registryPath, stubReg
         console.log(`**** Pushing ${currentDefinitionId} ${release} ****`);
         await pushImage(
             path.join(definitionStagingFolder, currentDefinitionId),
-            currentDefinitionId, repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, simulate);
+            currentDefinitionId, repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, prepOnly);
     });
 
     return stagingFolder;
 }
 
-async function pushImage(definitionPath, definitionId, repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, simulate) {
+async function pushImage(definitionPath, definitionId, repo, release, updateLatest, registry, registryPath, stubRegistry, stubRegistryPath, prepOnly) {
     const dotDevContainerPath = path.join(definitionPath, '.devcontainer');
     // Use base.Dockerfile for image build if found, otherwise use Dockerfile
     const baseDockerFileExists = await asyncUtils.exists(path.join(dotDevContainerPath, 'base.Dockerfile'));
@@ -59,7 +59,7 @@ async function pushImage(definitionPath, definitionId, repo, release, updateLate
         definitionId, repo, release, registry, registryPath, stubRegistry, stubRegistryPath, true);
 
 
-    if (simulate) {
+    if (prepOnly) {
         console.log(`(*) Simulating: Skipping build and push to registry.`);
     } else {
         // Build image

--- a/build/vscdc
+++ b/build/vscdc
@@ -48,7 +48,7 @@ require('yargs')
                     default: false
                 },
                 'prep-only': {
-                    describe: 'whether to only prepare content, but ',
+                    describe: 'prep the containers for packaging, but do not build/push',
                     type: 'boolean',
                     default: false
                 },
@@ -100,8 +100,8 @@ require('yargs')
                     type: 'boolean',
                     default: true
                 },
-                'simulate': {
-                    describe: 'whether to simulate a push instead of doing it',
+                'prep-only': {
+                    describe: 'whether to just prepare the containers to build/push',
                     type: 'boolean',
                     default: false
                 },
@@ -170,7 +170,7 @@ require('yargs')
                     default: configUtils.getConfig('vscodeDevContainersRepo', 'https://github.com/microsoft/vscode-dev-containers')
                 },
                 'build': {
-                    describe: 'whether to skip the image build step',
+                    describe: 'whether to to build the image first step',
                     default: true
                 }
             })
@@ -197,7 +197,7 @@ require('yargs')
     .argv;
 
 function pushCommand(argv) {
-    push(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.simulate, argv.page, argv.pageTotal, argv.devcontainer)
+    push(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.prepOnly, argv.page, argv.pageTotal, argv.devcontainer)
         .catch((reason) => {
             console.error(`(!) Push failed - ${reason}`);
             process.exit(1);

--- a/build/vscdc
+++ b/build/vscdc
@@ -47,8 +47,8 @@ require('yargs')
                     type: 'boolean',
                     default: false
                 },
-                'prep-only': {
-                    describe: 'prep the containers for packaging, but do not build/push',
+                'prep-and-package-only': {
+                    describe: 'prep and package, but do not build/push',
                     type: 'boolean',
                     default: false
                 },
@@ -101,9 +101,14 @@ require('yargs')
                     default: true
                 },
                 'prep-only': {
-                    describe: 'whether to just prepare the containers to build/push',
+                    describe: 'prep the containers for build/push, but do not actually do it',
                     type: 'boolean',
                     default: false
+                },
+                'push': {
+                    describe: 'whether to push after prep/build',
+                    type: 'boolean',
+                    default: true
                 },
                 'page': {
                     describe: 'Page number (of total) to push',
@@ -197,7 +202,7 @@ require('yargs')
     .argv;
 
 function pushCommand(argv) {
-    push(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.prepOnly, argv.page, argv.pageTotal, argv.devcontainer)
+    push(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.push, argv.prepOnly, argv.page, argv.pageTotal, argv.devcontainer)
         .catch((reason) => {
             console.error(`(!) Push failed - ${reason}`);
             process.exit(1);
@@ -205,7 +210,7 @@ function pushCommand(argv) {
 }
 
 function packCommand(argv) {
-    package(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.packageOnly, argv.clean, argv.prepOnly)
+    package(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.prepAndPackageOnly, argv.packageOnly, argv.clean)
         .catch((reason) => {
             console.error(`(!) Packaging failed - ${reason}`);
             process.exit(1);

--- a/build/vscdc
+++ b/build/vscdc
@@ -42,10 +42,15 @@ require('yargs')
                     describe: 'vscode-dev-containers repo name',
                     default: configUtils.getConfig('githubRepoName', 'microsoft/vscode-dev-containers')
                 },
-                'push-images': {
-                    describe: 'whether to push before packaging',
+                'package-only': {
+                    describe: 'whether to prep/build/push before packaging',
                     type: 'boolean',
-                    default: true
+                    default: false
+                },
+                'prep-only': {
+                    describe: 'whether to only prepare content, but ',
+                    type: 'boolean',
+                    default: false
                 },
                 'update-latest': {
                     describe: 'whether to tag latest and {MAJOR}',
@@ -56,11 +61,6 @@ require('yargs')
                     describe: 'whether to clean up staging folder when done',
                     type: 'boolean',
                     default: true
-                },
-                'simulate': {
-                    describe: 'whether to simulate a push instead of doing it',
-                    type: 'boolean',
-                    default: false
                 }
             })
     }, packCommand)
@@ -104,6 +104,16 @@ require('yargs')
                     describe: 'whether to simulate a push instead of doing it',
                     type: 'boolean',
                     default: false
+                },
+                'page': {
+                    describe: 'Page number (of total) to push',
+                    type: 'integer',
+                    default: 1
+                },
+                'page-total': {
+                    describe: 'Total number of pages to use when parallelizing builds',
+                    type: 'integer',
+                    default: 1
                 }
             })
     }, pushCommand)
@@ -187,7 +197,7 @@ require('yargs')
     .argv;
 
 function pushCommand(argv) {
-    push(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.simulate, argv.devcontainer)
+    push(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.simulate, argv.page, argv.pageTotal, argv.devcontainer)
         .catch((reason) => {
             console.error(`(!) Push failed - ${reason}`);
             process.exit(1);
@@ -195,7 +205,7 @@ function pushCommand(argv) {
 }
 
 function packCommand(argv) {
-    package(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.pushImages, argv.clean, argv.simulate)
+    package(argv.githubRepo, argv.release, argv.updateLatest, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, argv.packageOnly, argv.clean, argv.prepOnly)
         .catch((reason) => {
             console.error(`(!) Packaging failed - ${reason}`);
             process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vscode-dev-containers",
-	"version": "0.99.2",
+	"version": "0.100.0",
 	"description": "VS Code Dev Containers: Definitions and Templates",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This implements #223. The core build time is now approx 2-3 mins with three "pages" that are built concurrently.  As we onboard more images, we can add more pages to speed things up further. Packaging then happens after all the builds have completed though in concept it could happen in parallel.

The logic uses one level of image dependencies to do the paging so that, if an image depends on another image, the parent image is built first.  This logic does not extend to multiple parents currently. (Parents can't have parents yet, but we have no definitions in this scenario today.)

All of this required some refactoring of the build CLI commands to get working.

cgmanifest.json generation is also automatically triggered once the build completes but as a separate workflow via the repository_dispatch event. The manifest generation has to be across all images and therefore will generally be slower because, as a separate job, it has to download all built images before inspecting their contents.  By having it as a separate workflow, this allows the CI build to complete quickly.

See the following runs for examples of results:
Release: https://github.com/Chuxel/vscode-dev-containers/actions/runs/35231514
CI: https://github.com/Chuxel/vscode-dev-containers/actions/runs/35228630
CG Manifest triggered by CI: https://github.com/Chuxel/vscode-dev-containers/actions/runs/35229616

//cc: @chrmarti @egamma 