### PR TITLE
install `less` to do `git log` without error msg

### DIFF
--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git openssh-client iproute2 procps lsb-release \
+    && apt-get -y install git less openssh-client iproute2 procps lsb-release \
     #
     # Install pylint
     && pip --disable-pip-version-check --no-cache-dir install pylint \


### PR DESCRIPTION
Currently when I am attached to the `python-3` container perform a `git log`, the
command complains that `less` is not available.
So I added it to the same `apt-get` where `git` is installed as well.