### PR TITLE
Automatically update tags to use version specific script source

### DIFF
--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -18,13 +18,13 @@ jobs:
     steps:
     - name: Checkout
       id: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
-    - name: Get Tag Name
+    - name: Get tag name
       id: get_tag_name  
       uses: olegtarasov/get-tag@v1
 
-    - name: Container Registry Login
+    - name: Container registry login
       id: docker_login
       uses: azure/docker-login@v1
       with:
@@ -55,11 +55,31 @@ jobs:
     steps:
     - name: Checkout
       id: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
 
-    - name: Get Tag Name
+    - name: Get tag name
       id: get_tag_name  
       uses: olegtarasov/get-tag@v1
+
+    - name: Update Dockerfile common script sources and re-tag
+      id: update_script_source
+      run: |
+        set -e
+        yarn install
+        # Update common script source URLs in all dev containers and and set SHA hash
+        build/vscdc update-script-sources ${{ steps.get_tag_name.outputs.tag }} --github-repo ${{ github.repository }}
+        # Commit to a new tag specific branch
+        git config --global user.email "vscr-feedback@microsoft.com"
+        git config --global user.name "CI"
+        git fetch --tags
+        git branch ${{ steps.get_tag_name.outputs.tag }}-temp-branch
+        git add -u
+        git commit -m 'Automated update of common script sources and hash'
+        # Re-tag and push to origin
+        git tag -d ${{ steps.get_tag_name.outputs.tag }}
+        git tag ${{ steps.get_tag_name.outputs.tag }}
+        git push --delete origin ${{ steps.get_tag_name.outputs.tag }}
+        git push origin ${{ steps.get_tag_name.outputs.tag }}
 
     - name: Package
       id: package
@@ -77,18 +97,18 @@ jobs:
         PKG_PREFIX=$(node -p "require('./package.json').name")
         echo "::set-output name=package_name::$(ls $PKG_PREFIX-*.tgz)"
 
-    - name: Create Release
+    - name: Create release
       id: create_release
       uses: actions/create-release@v1.0.0
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
+        tag_name: ${{ steps.get_tag_name.outputs.tag }}
+        release_name:  ${{ steps.get_tag_name.outputs.tag }}
         draft: false
         prerelease: false
 
-    - name: Upload NPM Package as Release Asset
+    - name: Upload package as release asset
       id: upload_release_asset 
       uses: actions/upload-release-asset@v1.0.1
       env:

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -23,7 +23,7 @@ jobs:
       id: checkout
       uses: actions/checkout@v1
 
-    - name: Container Registry Login
+    - name: Container registry login
       id: docker_login
       uses: azure/docker-login@v1
       with:
@@ -81,7 +81,7 @@ jobs:
         mv ./$PKG_PREFIX-*.tgz ./$PKG_NAME
         echo "::set-output name=package_name::$PKG_NAME"
 
-    - name: Upload Package
+    - name: Upload package
       uses: actions/upload-artifact@v1.0.0
       with:
         name: ${{ steps.package.outputs.package_name }}
@@ -106,5 +106,4 @@ jobs:
           -H "Content-Type: application/json" \
           https://api.github.com/repos/${{ github.repository }}/dispatches \
           --data '{"event_type":"oss_cg_trigger"}'
-
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -53,14 +53,13 @@
 		{
 			"type": "node",
 			"request": "launch",
-			"name": "Run Patch",
+			"name": "Run Update Script URLs",
 			"program": "${workspaceFolder}/build/vscdc",
 			"cwd": "${workspaceFolder}/build",
 			"args": [
-				"patch",
-				"--patchPath", "patch/sample",
-				"--registry", "clantz.azurecr.io",
-				"--registryPath", "vscode/devcontainers"
+				"update-script-urls",
+				"v0.100.0",
+				"--github-repo", "microsoft/vscode-dev-containers"
 			]
 		}
 	]

--- a/build/src/prep.js
+++ b/build/src/prep.js
@@ -27,7 +27,7 @@ async function prepDockerFile(devContainerDockerfilePath, definitionId, repo, re
     const devContainerDockerfileRaw = await asyncUtils.readFile(devContainerDockerfilePath);
     
     // Replace script URL and generate SHA if applicable
-    let devContainerDockerfileModified = await lockScriptVersion(devContainerDockerfileRaw, repo, release, true);
+    let devContainerDockerfileModified = await updateScriptUrl(devContainerDockerfileRaw, repo, release, true);
 
     if (isForBuild) {
         // If building, update FROM to target registry and version if definition has a parent
@@ -105,8 +105,8 @@ async function updateConfigForRelease(definitionPath, definitionId, repo, releas
 }
 
 // Replace script URL and generate SHA if applicable
-async function lockScriptVersion(devContainerDockerfileRaw, repo, release, lockSha) {
-    lockSha = typeof lockSha === 'undefined' ? true : lockSha;
+async function updateScriptUrl(devContainerDockerfileRaw, repo, release, updateScriptSha) {
+    updateScriptSha = typeof updateScriptSha === 'undefined' ? true : updateScriptSha;
     
     // Replace script URL and generate SHA if applicable
     const scriptCaptureGroups = new RegExp(`COMMON_SCRIPT_SOURCE="(.+)/${scriptLibraryPathInRepo.replace('.', '\\.')}/(.+)"`).exec(devContainerDockerfileRaw);
@@ -114,23 +114,34 @@ async function lockScriptVersion(devContainerDockerfileRaw, repo, release, lockS
         const scriptName = scriptCaptureGroups[2];
         const scriptSource = `https://raw.githubusercontent.com/${repo}/${release}/${scriptLibraryPathInRepo}/${scriptName}`;
         let sha = scriptSHA[scriptName];
-        if (lockSha && typeof sha === 'undefined') {
+        if (updateScriptSha && typeof sha === 'undefined') {
             const scriptRaw = await asyncUtils.getUrlAsString(scriptSource);
             sha = await asyncUtils.shaForString(scriptRaw);
             scriptSHA[scriptName] = sha;
         }
         return devContainerDockerfileRaw
-            .replace(/COMMON_SCRIPT_SHA=".+"/, `COMMON_SCRIPT_SHA="${lockSha ? sha : 'dev-mode'}"`)
+            .replace(/COMMON_SCRIPT_SHA=".+"/, `COMMON_SCRIPT_SHA="${updateScriptSha ? sha : 'dev-mode'}"`)
             .replace(/COMMON_SCRIPT_SOURCE=".+"/, `COMMON_SCRIPT_SOURCE="${scriptSource}"`);
 
     }
     return devContainerDockerfileRaw;
 }
 
-async function lockScriptVersionInDockerfile(devContainerDockerfilePath, repo, release, lockSha) {
+// Update script URL in a Dockerfile to be release specific (or not) and optionally update the SHA to lock to this version
+async function updateScriptUrlInDockerfile(devContainerDockerfilePath, repo, release, updateScriptSha) {
     const devContainerDockerfileRaw = await asyncUtils.readFile(devContainerDockerfilePath);
-    const devContainerDockerfileModified = await lockScriptVersion(devContainerDockerfileRaw, repo, release, lockSha);
+    const devContainerDockerfileModified = await updateScriptUrl(devContainerDockerfileRaw, repo, release, updateScriptSha);
     await asyncUtils.writeFile(devContainerDockerfilePath, devContainerDockerfileModified);
+}
+
+// Update all script URLS in the entire repo (not staging folder)
+async function updateAllScriptUrlsInRepo(repo, release, updateScriptSha) {
+    const definitionFolder = path.join(__dirname, '..', '..', 'containers');
+    // Update script versions in definition Dockerfiles for release
+    const allDefinitions = await asyncUtils.readdir(definitionFolder);
+    await asyncUtils.forEach(allDefinitions, async (currentDefinitionId) => {
+        await updateScriptUrlInDockerfile(path.join(definitionFolder, currentDefinitionId), repo, release, updateScriptSha);
+    });
 }
 
 module.exports = {
@@ -138,5 +149,6 @@ module.exports = {
     updateStub: updateStub,
     updateConfigForRelease: updateConfigForRelease,
     prepDockerFile: prepDockerFile,
-    lockScriptVersionInDockerfile: lockScriptVersionInDockerfile
+    updateScriptUrlInDockerfile: updateScriptUrlInDockerfile,
+    updateAllScriptUrlsInRepo: updateAllScriptUrlsInRepo
 }

--- a/build/src/prep.js
+++ b/build/src/prep.js
@@ -27,7 +27,7 @@ async function prepDockerFile(devContainerDockerfilePath, definitionId, repo, re
     const devContainerDockerfileRaw = await asyncUtils.readFile(devContainerDockerfilePath);
     
     // Replace script URL and generate SHA if applicable
-    let devContainerDockerfileModified = await updateScriptUrl(devContainerDockerfileRaw, repo, release, true);
+    let devContainerDockerfileModified = await updateScriptSource(devContainerDockerfileRaw, repo, release, true);
 
     if (isForBuild) {
         // If building, update FROM to target registry and version if definition has a parent
@@ -105,20 +105,23 @@ async function updateConfigForRelease(definitionPath, definitionId, repo, releas
 }
 
 // Replace script URL and generate SHA if applicable
-async function updateScriptUrl(devContainerDockerfileRaw, repo, release, updateScriptSha) {
+async function updateScriptSource(devContainerDockerfileRaw, repo, release, updateScriptSha) {
     updateScriptSha = typeof updateScriptSha === 'undefined' ? true : updateScriptSha;
     
     // Replace script URL and generate SHA if applicable
     const scriptCaptureGroups = new RegExp(`COMMON_SCRIPT_SOURCE="(.+)/${scriptLibraryPathInRepo.replace('.', '\\.')}/(.+)"`).exec(devContainerDockerfileRaw);
     if (scriptCaptureGroups) {
+        console.log(`(*) Common script source found.`);
         const scriptName = scriptCaptureGroups[2];
         const scriptSource = `https://raw.githubusercontent.com/${repo}/${release}/${scriptLibraryPathInRepo}/${scriptName}`;
+        console.log(`    New common script source URL: ${scriptSource}`);
         let sha = scriptSHA[scriptName];
         if (updateScriptSha && typeof sha === 'undefined') {
             const scriptRaw = await asyncUtils.getUrlAsString(scriptSource);
             sha = await asyncUtils.shaForString(scriptRaw);
             scriptSHA[scriptName] = sha;
         }
+        console.log(`    Script SHA: ${sha}`);
         return devContainerDockerfileRaw
             .replace(/COMMON_SCRIPT_SHA=".+"/, `COMMON_SCRIPT_SHA="${updateScriptSha ? sha : 'dev-mode'}"`)
             .replace(/COMMON_SCRIPT_SOURCE=".+"/, `COMMON_SCRIPT_SOURCE="${scriptSource}"`);
@@ -128,25 +131,27 @@ async function updateScriptUrl(devContainerDockerfileRaw, repo, release, updateS
 }
 
 // Update script URL in a Dockerfile to be release specific (or not) and optionally update the SHA to lock to this version
-async function updateScriptUrlInDockerfile(devContainerDockerfilePath, repo, release, updateScriptSha) {
+async function updateScriptSourcesInDockerfile(devContainerDockerfilePath, repo, release, updateScriptSha) {
     const devContainerDockerfileRaw = await asyncUtils.readFile(devContainerDockerfilePath);
-    const devContainerDockerfileModified = await updateScriptUrl(devContainerDockerfileRaw, repo, release, updateScriptSha);
+    const devContainerDockerfileModified = await updateScriptSource(devContainerDockerfileRaw, repo, release, updateScriptSha);
     await asyncUtils.writeFile(devContainerDockerfilePath, devContainerDockerfileModified);
 }
 
 // Update all script URLS in the entire repo (not staging folder)
-async function updateAllScriptUrlsInRepo(repo, release, updateScriptSha) {
+async function updateAllScriptSourcesInRepo(repo, release, updateScriptSha) {
     const definitionFolder = path.join(__dirname, '..', '..', 'containers');
     // Update script versions in definition Dockerfiles for release
     const allDefinitions = await asyncUtils.readdir(definitionFolder);
     await asyncUtils.forEach(allDefinitions, async (currentDefinitionId) => {
-        const dockerFileBasePath = path.join(definitionFolder, currentDefinitionId, '.devcontainer', 'Dockerfile');
+        const dockerFileBasePath = path.join(definitionFolder, currentDefinitionId, '.devcontainer', 'base.Dockerfile');
         if (await asyncUtils.exists(dockerFileBasePath)) {
-            await updateScriptUrlInDockerfile(dockerFileBasePath, repo, release, updateScriptSha);
+            console.log('(*) Looking for script source in base.Dockerfile for ${currentDefinitionId}.');
+            await updateScriptSourcesInDockerfile(dockerFileBasePath, repo, release, updateScriptSha);
         }
         const dockerFilePath = path.join(definitionFolder, currentDefinitionId, '.devcontainer', 'Dockerfile');
         if (await asyncUtils.exists(dockerFilePath)) {
-            await updateScriptUrlInDockerfile(dockerFilePath, repo, release, updateScriptSha);
+            console.log('(*) Looking for script source in Dockerfile for ${currentDefinitionId}.');
+            await updateScriptSourcesInDockerfile(dockerFilePath, repo, release, updateScriptSha);
         }
     });
 }
@@ -156,6 +161,6 @@ module.exports = {
     updateStub: updateStub,
     updateConfigForRelease: updateConfigForRelease,
     prepDockerFile: prepDockerFile,
-    updateScriptUrlInDockerfile: updateScriptUrlInDockerfile,
-    updateAllScriptUrlsInRepo: updateAllScriptUrlsInRepo
+    updateScriptSourcesInDockerfile: updateScriptSourcesInDockerfile,
+    updateAllScriptSourcesInRepo: updateAllScriptSourcesInRepo
 }

--- a/build/src/prep.js
+++ b/build/src/prep.js
@@ -140,7 +140,14 @@ async function updateAllScriptUrlsInRepo(repo, release, updateScriptSha) {
     // Update script versions in definition Dockerfiles for release
     const allDefinitions = await asyncUtils.readdir(definitionFolder);
     await asyncUtils.forEach(allDefinitions, async (currentDefinitionId) => {
-        await updateScriptUrlInDockerfile(path.join(definitionFolder, currentDefinitionId), repo, release, updateScriptSha);
+        const dockerFileBasePath = path.join(definitionFolder, currentDefinitionId, '.devcontainer', 'Dockerfile');
+        if (await asyncUtils.exists(dockerFileBasePath)) {
+            await updateScriptUrlInDockerfile(dockerFileBasePath, repo, release, updateScriptSha);
+        }
+        const dockerFilePath = path.join(definitionFolder, currentDefinitionId, '.devcontainer', 'Dockerfile');
+        if (await asyncUtils.exists(dockerFilePath)) {
+            await updateScriptUrlInDockerfile(dockerFilePath, repo, release, updateScriptSha);
+        }
     });
 }
 

--- a/build/vscdc
+++ b/build/vscdc
@@ -7,7 +7,7 @@
 const push = require('./src/push').push;
 const patch = require('./src/patch').patch;
 const package = require('./src/package').package;
-const updateAllScriptUrlsInRepo = require('./src/prep').updateAllScriptUrlsInRepo;
+const updateAllScriptSourcesInRepo = require('./src/prep').updateAllScriptSourcesInRepo;
 const generateComponentGovernanceManifest = require('./src/cgmanifest').generateComponentGovernanceManifest;
 const configUtils = require('./src/utils/config');
 const packageJson = require('../package.json');
@@ -122,7 +122,7 @@ require('yargs')
                 }
             })
     }, pushCommand)
-    .command('update-script-urls <release>', 'updates all script URLs in Dockerfiles to a tag or branch', (yargs) => {
+    .command('update-script-sources <release>', 'updates all script source URLs in Dockerfiles to a tag or branch', (yargs) => {
         yargs
             .positional('release', {
                 describe: 'release tag to branch use for script URLs',
@@ -138,7 +138,7 @@ require('yargs')
                     default: true
                 }
             })
-    }, updateScriptUrlsCommand)
+    }, updateScriptSourcesCommand)
     .command('cg', 'generate cgmanifest.json', (yargs) => {
         yargs
             .options({
@@ -201,8 +201,8 @@ function packCommand(argv) {
         });
 }
 
-function updateScriptUrlsCommand(argv) {
-    updateAllScriptUrlsInRepo(argv.githubRepo, argv.release, argv.updateSha)
+function updateScriptSourcesCommand(argv) {
+    updateAllScriptSourcesInRepo(argv.githubRepo, argv.release, argv.updateSha)
         .catch((reason) => {
             console.error(`(!) Stub generation failed - ${reason}`);
             process.exit(1);

--- a/build/vscdc
+++ b/build/vscdc
@@ -7,7 +7,7 @@
 const push = require('./src/push').push;
 const patch = require('./src/patch').patch;
 const package = require('./src/package').package;
-const createStub = require('./src/prep').createStub;
+const updateAllScriptUrlsInRepo = require('./src/prep').updateAllScriptUrlsInRepo;
 const generateComponentGovernanceManifest = require('./src/cgmanifest').generateComponentGovernanceManifest;
 const configUtils = require('./src/utils/config');
 const packageJson = require('../package.json');
@@ -122,39 +122,23 @@ require('yargs')
                 }
             })
     }, pushCommand)
-    .command('stub <devcontainer> [path]', 'generates a stub user.Dockerfile', (yargs) => {
+    .command('update-script-urls <release>', 'updates all script URLs in Dockerfiles to a tag or branch', (yargs) => {
         yargs
-            .positional('devcontainer', {
-                describe: 'ID of dev container to stub',
-            })
-            .positional('path', {
-                describe: 'path to .devcontainer folder',
-                default: '.'
+            .positional('release', {
+                describe: 'release tag to branch use for script URLs',
             })
             .options({
-                'release': {
-                    describe: 'vscode-dev-containers release tag or branch',
-                    default: 'dev'
-                },
-                'stub-registry': {
-                    describe: 'registry to add to stub',
-                    default: configUtils.getConfig('stubRegistry', configUtils.getConfig('containerRegistry', 'docker.io'))
-                },
-                'stub-registry-path': {
-                    describe: 'stub registry path',
-                    default: configUtils.getConfig('stubRegistryPath', configUtils.getConfig('containerRegistryPath', ''))
-                },
                 'github-repo': {
                     describe: 'vscode-dev-containers repo name',
                     default: configUtils.getConfig('githubRepoName', 'microsoft/vscode-dev-containers')
                 },
-                'has-base-dockerfile': {
-                    describe: 'whether base.Dockerfile exists',
+                'update-sha': {
+                    describe: 'update script SHAs to match file',
                     type: 'boolean',
                     default: true
                 }
             })
-    }, stubCommand)
+    }, updateScriptUrlsCommand)
     .command('cg', 'generate cgmanifest.json', (yargs) => {
         yargs
             .options({
@@ -218,8 +202,8 @@ function packCommand(argv) {
 }
 
 
-function stubCommand(argv) {
-    createStub(argv.devcontainer, argv.path, argv.githubRepo, argv.release, argv.hasBaseDockerfile, argv.stubRegistry, argv.stubRegistryPath)
+function updateScriptUrlsCommand(argv) {
+    updateAllScriptUrlsInRepo(argv.githubRepo, argv.release, argv.updateSha)
         .catch((reason) => {
             console.error(`(!) Stub generation failed - ${reason}`);
             process.exit(1);

--- a/build/vscdc
+++ b/build/vscdc
@@ -201,7 +201,6 @@ function packCommand(argv) {
         });
 }
 
-
 function updateScriptUrlsCommand(argv) {
     updateAllScriptUrlsInRepo(argv.githubRepo, argv.release, argv.updateSha)
         .catch((reason) => {


### PR DESCRIPTION
This PR resolves a current issue where Dockerfiles tied to a release tag do not reference version specific links to common scripts.  The resulting `.tgz` package does, however, so this is not P0.  However, this update makes it easier to reproduce a build from a tag.

One downside of the approach, however, is that it deletes and updates an existing tag to maintain the current workflow where just tagging triggers a release.  As a result, whoever triggers a release will need to do a `git fetch --tags --force` to get the updated tag. Otherwise Git will complain about clobbering an existing local one.