### PR TITLE
Fix duplicate ENV statement in several dockerfiles

### DIFF
--- a/container-templates/docker-compose/.devcontainer/Dockerfile
+++ b/container-templates/docker-compose/.devcontainer/Dockerfile
@@ -28,9 +28,6 @@ ARG INSTALL_ZSH="true"
 ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog wget ca-certificates 2>&1 \

--- a/container-templates/dockerfile/.devcontainer/Dockerfile
+++ b/container-templates/dockerfile/.devcontainer/Dockerfile
@@ -22,9 +22,6 @@ ARG INSTALL_ZSH="true"
 ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog wget ca-certificates 2>&1 \

--- a/containers/debian-10-git/.devcontainer/Dockerfile
+++ b/containers/debian-10-git/.devcontainer/Dockerfile
@@ -22,9 +22,6 @@ ARG INSTALL_ZSH="true"
 ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog wget ca-certificates 2>&1 \

--- a/containers/debian-9-git/.devcontainer/Dockerfile
+++ b/containers/debian-9-git/.devcontainer/Dockerfile
@@ -22,9 +22,6 @@ ARG INSTALL_ZSH="true"
 ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
 # Configure apt and install packages
 RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog wget ca-certificates 2>&1 \

--- a/containers/javascript-node-10/.devcontainer/Dockerfile
+++ b/containers/javascript-node-10/.devcontainer/Dockerfile
@@ -23,9 +23,6 @@ ARG INSTALL_ZSH="true"
 ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
 ENV PATH=${PATH}:/usr/local/share/npm-global/bin
 
 # Configure apt and install packages

--- a/containers/javascript-node-12/.devcontainer/Dockerfile
+++ b/containers/javascript-node-12/.devcontainer/Dockerfile
@@ -23,9 +23,6 @@ ARG INSTALL_ZSH="true"
 ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
-
 ENV PATH=${PATH}:/usr/local/share/npm-global/bin
 
 # Configure apt and install packages


### PR DESCRIPTION
Several of the Dockerfiles contained the following line in duplicate:
```
ENV DEBIAN_FRONTEND=noninteractive
```
As such, I removed the second instance of each line, including the preceding comment.
I think this occurred because the mistake was included in the template Dockerfile.