### PR TITLE
Implement image / dev container specific versioning

### DIFF
--- a/build/src/prep.js
+++ b/build/src/prep.js
@@ -21,7 +21,7 @@ const scriptLibraryPathInRepo = configUtils.getConfig('scriptLibraryPathInRepo')
 
 async function prepDockerFile(devContainerDockerfilePath, definitionId, repo, release, registry, registryPath, stubRegistry, stubRegistryPath, isForBuild, variant) {
     // Use exact version of building, MAJOR if not
-    const version = isForBuild ? configUtils.getVersionFromRelease(release) : configUtils.majorFromRelease(release);
+    const version = isForBuild ? configUtils.getVersionFromRelease(release, definitionId) : configUtils.majorFromRelease(release, definitionId);
 
     // Read Dockerfile
     const devContainerDockerfileRaw = await asyncUtils.readFile(devContainerDockerfilePath);
@@ -67,7 +67,7 @@ async function createStub(dotDevContainerPath, definitionId, repo, release, base
     const userDockerFilePath = path.join(dotDevContainerPath, 'Dockerfile');
     console.log('(*) Generating user Dockerfile...');
     const templateDockerfile = await configUtils.objectByDefinitionLinuxDistro(definitionId, stubPromises);
-    const devContainerImageVersion = configUtils.majorFromRelease(release);
+    const devContainerImageVersion = configUtils.majorFromRelease(release, definitionId);
     const imageTag = configUtils.getTagsForVersion(definitionId, devContainerImageVersion, stubRegistry, stubRegistryPath)[0];
     const userDockerFile = templateDockerfile.replace(
         'FROM REPLACE-ME', getFromSnippet(definitionId, imageTag, repo, release, baseDockerFileExists));
@@ -79,7 +79,7 @@ async function updateStub(dotDevContainerPath, definitionId, repo, release, base
     const userDockerFilePath = path.join(dotDevContainerPath, 'Dockerfile');
     const userDockerFile = await asyncUtils.readFile(userDockerFilePath);
 
-    const devContainerImageVersion = configUtils.majorFromRelease(release);
+    const devContainerImageVersion = configUtils.majorFromRelease(release, definitionId);
     const imageTag = configUtils.getTagsForVersion(definitionId, devContainerImageVersion, registry, registryPath)[0];
     const userDockerFileModified = userDockerFile.replace(/FROM .+:.+/,
         getFromSnippet(definitionId, imageTag, repo, release, baseDockerFileExists));

--- a/containers/typescript-node-10/definition-build.json
+++ b/containers/typescript-node-10/definition-build.json
@@ -1,6 +1,5 @@
 {
 	"build": {
-		"latest": true,
 		"rootDistro": "debian",
 		"parent": "javascript-node-10",
 		"tags": [

--- a/containers/typescript-node-12/definition-build.json
+++ b/containers/typescript-node-12/definition-build.json
@@ -1,4 +1,5 @@
 {
+	"latest": true,
 	"build": {
 		"rootDistro": "debian",
 		"parent": "javascript-node-12",


### PR DESCRIPTION
Implements https://github.com/microsoft/vscode-dev-containers/issues/209 which is required for https://github.com/microsoft/vscode-dev-containers/issues/155 (VS Online image).

This adds a `definitionVersion` property into `definition-build.json` that, if specified, is used for the version of the image that is generated whenever a release is specified.  (Specifying a branch like master still results in the 'dev' version.)

If no `definitionVersion` is specified, the release version is used instead. All current definitions will behave this way since #155 is the first one that would use definition specific versioning and that will be a separate PR.