### PR TITLE
Change the Functions 3.1 dev container to pull from apt-get

### DIFF
--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
@@ -39,24 +39,24 @@ RUN apt-get update \
     # [Optional] Add sudo support for the non-root user
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME 
-
-# Install Azure Functions Core Tools v3
-RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # Install Azure Functions Core Tools v3
+    && wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg \
     && mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ \
     && wget -q https://packages.microsoft.com/config/debian/9/prod.list \
     && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list \
     && chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg \
-    && chown root:root /etc/apt/sources.list.d/microsoft-prod.list
-RUN apt-get update \
-    && apt-get install -y azure-functions-core-tools-3
-
-# Clean up
-RUN apt-get autoremove -y \
+    && chown root:root /etc/apt/sources.list.d/microsoft-prod.list \
+    && apt-get update \
+    && apt-get -y install azure-functions-core-tools-3 \
+    #
+    # Clean up
+    && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-    
-# Opt out of Func CLI telemetry gathering
+
+# Uncomment to opt out of Func CLI telemetry gathering
 #ENV FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT=true
 
 # Switch back to dialog for any ad-hoc use of apt-get

--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
@@ -39,21 +39,23 @@ RUN apt-get update \
     # [Optional] Add sudo support for the non-root user
     && apt-get install -y sudo \
     && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    && chmod 0440 /etc/sudoers.d/$USERNAME 
 
 # Install Azure Functions Core Tools v3
-ARG CORE_TOOLS_VERSION=3.0.2009
-RUN curl -s -L https://github.com/Azure/azure-functions-core-tools/releases/download/${CORE_TOOLS_VERSION}/Azure.Functions.Cli.linux-x64.${CORE_TOOLS_VERSION}.zip -o /tmp/afct3.zip
-RUN unzip -qq -d ~/azure-functions-core-tools /tmp/afct3.zip \
-    && rm /tmp/afct3.zip
-RUN cd ~/azure-functions-core-tools \
-    && chmod +x func \
-    && ln -s ~/azure-functions-core-tools/func /usr/bin/func
+RUN wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg \
+    && mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ \
+    && wget -q https://packages.microsoft.com/config/debian/9/prod.list \
+    && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list \
+    && chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg \
+    && chown root:root /etc/apt/sources.list.d/microsoft-prod.list
+RUN apt-get update \
+    && apt-get install -y azure-functions-core-tools-3
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+    
 # Opt out of Func CLI telemetry gathering
 #ENV FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT=true
 


### PR DESCRIPTION
Functions PG recently started pushing the v3 core tools to apt-get so we can pull from there now! :)