### PR TITLE
helm 3 support for kubernetes-helm template

### DIFF
--- a/containers/kubernetes-helm/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm/.devcontainer/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update \
     && chmod +x /usr/local/bin/kubectl \
     #
     # Install Helm
-    && curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash - \
+    && curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash - \
     #
     # Copy localhost's ~/.kube/config file into the container and swap out localhost
     # for host.docker.internal whenever a new shell starts to keep them in sync.

--- a/containers/kubernetes-helm/README.md
+++ b/containers/kubernetes-helm/README.md
@@ -86,7 +86,7 @@ You can adapt your own existing development container Dockerfile to support this
         && chmod +x /usr/local/bin/kubectl \
         #
         # Install Helm
-        curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash -
+        curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -
     ```
 
 4. Press <kbd>F1</kbd> and run **Remote-Containers: Rebuild Container** so the changes take effect.
@@ -135,12 +135,6 @@ See the section below for your operating system for more detailed setup instruct
 
 7. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
 
-8. [Optional] If you want to use [Helm](https://helm.sh), open a VS Code terminal and run:
-
-    ```
-    helm init
-    ```
-
 ## Linux / Minikube Setup
 
 1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
@@ -172,11 +166,6 @@ See the section below for your operating system for more detailed setup instruct
     ```
 
 8. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
-
-9. [Optional] If you want to use [Helm](https://helm.sh), open a VS Code terminal and run:
-    ```
-    helm init
-    ```
 
 ## License
 


### PR DESCRIPTION
The container template `kubernetes-helm` is still using helm 2. I changed it using helm 3 and deleted the optional steps from the docu where it says to call `helm init` which was needed to setup the tiller in the K8s cluster