### PR TITLE
Use pre-built Python images in python-3-postgres

### DIFF
--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -3,52 +3,43 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM python:3
-
-# Avoid warnings by switching to noninteractive
-ENV DEBIAN_FRONTEND=noninteractive
+# Update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.8, 3.7, 3.6 
+ARG VARIANT=3
+FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 ENV PYTHONUNBUFFERED 1
 
-# The node image includes a non-root user with sudo access. Use the 
-# "remoteUser" property in devcontainer.json to use it. On Linux, update 
-# these values to ensure the container user's UID/GID matches your local values.
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+# This image includes a non-root user with sudo access. Use the "remoteUser" 
+# property in devcontainer.json to use it. On Linux, update the values below 
+# or in docker-compose.yml to ensure the container user's UID/GID matches your
+# local values. See https://aka.ms/vscode-remote/containers/non-root-user for details.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-# Uncomment the following COPY line and the corresponding lines in the `RUN` command if you wish to
-# include your requirements in the image itself. It is suggested that you only do this if your
-# requirements rarely (if ever) change.
+# [Optional] Update UID/GID if needed
+RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
+        groupmod --gid $USER_GID $USERNAME \
+        && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
+        && chmod -R $USER_UID:$USER_GID /home/$USERNAME; \
+    fi
+
+
+# [Optional] If your requirements rarely change, uncomment this section to add them to the image.
+#
 # COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
 
-# Configure apt and install packages
-RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    #
-    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git openssh-client less iproute2 procps lsb-release \
-    #
-    # Install pylint
-    && pip install pylint \
-    #
-    # Update Python environment based on requirements.txt
-    # && pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
-    # && rm -rf /tmp/pip-tmp \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+# [Optional] Uncomment this section to install additional packages.
+#
+# ENV DEBIAN_FRONTEND=noninteractive
+# RUN apt-get update \
+#    && apt-get -y install --no-install-recommends <your-package-list-here> \
+#    #
+#    # Clean up
+#    && apt-get autoremove -y \
+#    && apt-get clean -y \
+#    && rm -rf /var/lib/apt/lists/*
+# ENV DEBIAN_FRONTEND=dialog
 
-# Switch back to dialog for any ad-hoc use of apt-get
-ENV DEBIAN_FRONTEND=dialog

--- a/containers/python-3-postgres/.devcontainer/devcontainer.json
+++ b/containers/python-3-postgres/.devcontainer/devcontainer.json
@@ -1,4 +1,5 @@
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
+// You can also update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.8, 3.7, 3.6 
 {
 	"name": "Python 3 & PostgreSQL",
 	"dockerComposeFile": "docker-compose.yml",
@@ -11,7 +12,16 @@
 		"python.pythonPath": "/usr/local/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/usr/local/bin/pylint"
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"python.testing.pytestPath": "/usr/local/py-utils/bin/pytest"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -26,7 +36,7 @@
 	// "shutdownAction": "none",
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "pip install -r requirements.txt",
+	// "postCreateCommand": "pip install --user -r requirements.txt",
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"

--- a/containers/python-3-postgres/.devcontainer/docker-compose.yml
+++ b/containers/python-3-postgres/.devcontainer/docker-compose.yml
@@ -5,13 +5,18 @@ services:
     # Uncomment the next line to use a non-root user for all processes. You can also
     # simply use the "remoteUser" property in devcontainer.json if you just want
     # VS Code and its sub-processes (terminals, tasks, debugging) to execute as the user
-    # On Linux, you may need to update the USER_UID and USER_GID in .devcontainer/Dockerfile 
+    # On Linux, you may need to update the args USER_UID and USER_GID the "build" section
     # to match your user if not 1000. See https://aka.ms/vscode-remote/containers/non-root for details.
     # user: vscode
 
     build: 
       context: ..
       dockerfile: .devcontainer/Dockerfile
+      args:
+        #
+        VARIANT: 3
+        USER_UID: 1000
+        USER_GID: 1000
 
     volumes:
       - ..:/workspace:cached

--- a/containers/python-3-postgres/README.md
+++ b/containers/python-3-postgres/README.md
@@ -2,12 +2,12 @@
 
 ## Summary
 
-*Develop applications with Python 3 and PostgreSQL. Includes a Python application container and PostgreSQL server, and a Django test project.*
+*Develop applications with Python 3 and PostgreSQL. Includes a Python application container and PostgreSQL server.*
 
 | Metadata | Value |
 |----------|-------|
 | *Contributors* | The [VS Code Python extension](https://marketplace.visualstudio.com/itemdetails?itemName=ms-python.python) team |
-| *Definition type* | Dockerfile |
+| *Definition type* | Docker Compose |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/python:3 |
 | *Available image variants* |  mcr.microsoft.com/vscode/devcontainers/python:3.8 <br />  mcr.microsoft.com/vscode/devcontainers/python:3.7<br /> mcr.microsoft.com/vscode/devcontainers/python:3.6 |
 | *Languages, platforms* | Python |
@@ -130,6 +130,7 @@ This definition includes some test code that will help you verify it is working 
 5. After the folder has opened in the container, use <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>`</kbd> to open a terminal and run the following commands to initialize the database and create a super user:
     ```bash
     cd test-project
+    pip install --user -r requirements.txt
     python manage.py migrate
     python manage.py createsuperuser
     ```

--- a/containers/python-3-postgres/README.md
+++ b/containers/python-3-postgres/README.md
@@ -8,13 +8,41 @@
 |----------|-------|
 | *Contributors* | The [VS Code Python extension](https://marketplace.visualstudio.com/itemdetails?itemName=ms-python.python) team |
 | *Definition type* | Dockerfile |
+| *Published image* | mcr.microsoft.com/vscode/devcontainers/python:3 |
+| *Available image variants* |  mcr.microsoft.com/vscode/devcontainers/python:3.8 <br />  mcr.microsoft.com/vscode/devcontainers/python:3.7<br /> mcr.microsoft.com/vscode/devcontainers/python:3.6 |
 | *Languages, platforms* | Python |
 
 ## Using this definition with an existing folder
 
-While the definition itself works unmodified, there are some tips that can help you deal with some of common setup issues.
+### Configuration
 
-### Debug Configuration
+While the definition itself works unmodified, you can select the version of Python the container uses by updating the `VARIANT` arg in the included `.devcontainer/docker-compose.yml` (and rebuilding if you've already created the container).
+
+```yaml
+args:
+  VARIANT": 3.7
+```
+
+This allows you to pick from one of the following pre-built images:
+
+- `mcr.microsoft.com/vscode/devcontainers/python:3` (latest)
+- `mcr.microsoft.com/vscode/devcontainers/python:3.6`
+- `mcr.microsoft.com/vscode/devcontainers/python:3.7`
+- `mcr.microsoft.com/vscode/devcontainers/python:3.8`
+
+Alternatively, you can replace `.devcontainer/Dockerfile` in this definition with [`base.Dockerfile` from the Python 3 definition](../python-3/.devcontainer/base.Dockerfile) to fully customize your environment.
+
+#### Installing or updating Python utilities
+
+This container installs all Python development utilities using [pipx](https://pipxproject.github.io/pipx/) to avoid impacting the global Python environment. You can use this same utility add additional utilities in an isolated environment. For example:
+
+```bash
+pipx install prospector
+```
+
+See the [pipx documentation](https://pipxproject.github.io/pipx/docs/) for additional information.
+
+#### Debug Configuration
 
 Note that only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
 
@@ -22,7 +50,7 @@ Note that only the integrated terminal is supported by the Remote - Containers e
 "console": "integratedTerminal"
 ```
 
-### Using the forwardPorts property
+#### Using the forwardPorts property
 
 By default, frameworks like Flask only listens to localhost inside the container. As a result, we recommend using the `forwardPorts` property (available in v0.98.0+) to make these ports available locally.
 
@@ -30,9 +58,48 @@ By default, frameworks like Flask only listens to localhost inside the container
 "forwardPorts": [5000]
 ```
 
-The `appPort` property [publishes](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwards the port, so applications need to listen to `*` or `0.0.0.0` for the application to be accessible externally. This conflicts with the defaults of some Python frameworks, but fortunately the `forwardPorts` property does not have this limitation.
+The `ports` property in `docker-compose.yml` [publishes](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwards the port, so applications need to listen to `*` or `0.0.0.0` for the application to be accessible externally. This conflicts with the defaults of some Python frameworks, but fortunately the `forwardPorts` property does not have this limitation.
 
 If you've already opened your folder in a container, rebuild the container using the **Remote-Containers: Rebuild Container** command from the Command Palette (<kbd>F1</kbd>) so the settings take effect.
+
+#### [Optional] Building your requirements into the container image
+
+If your requirements rarely change, you can include the contents of `requirements.txt` in the container by adding the following to your `Dockerfile`:
+
+```Dockerfile
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && rm -rf /tmp/pip-tmp
+```
+
+Since `requirements.txt` is likely in the folder you opened rather than the `.devcontainer` folder, be sure to include `context: ..` under `build` in `docker-compose.yml`. This allows the Dockerfile to access everything in the opened folder instead of just the contents of the `.devcontainer` folder.
+
+#### [Optional] Allowing the non-root vscode user to pip install globally without sudo
+
+You can opt into using the `vscode` non-root user in the container by adding `"remoteUser": "vscode"` to `devcontainer.json`. However, by default, this you will need to use `sudo` to perform global pip installs.
+
+```bash
+sudo pip install <your-package-here>
+```
+
+Or stick with user installs:
+
+```bash
+pip install --user <your-package-here>
+```
+
+If you prefer, you can add the following to your `Dockerfile` to cause global installs to go into a different folder that the `vscode` user can write to.
+
+```Dockerfile
+ENV PIP_TARGET=/usr/local/pip-global
+ENV PYTHONPATH=${PIP_TARGET}:${PYTHONPATH}
+ENV PATH=${PIP_TARGET}/bin:${PATH}
+RUN mkdir -p ${PIP_TARGET} \
+    && chown vscode:root ${PIP_TARGET} \
+    && export SNIPPET="if [ \"\$(stat -c '%U' ${PIP_TARGET})\" != \"vscode\" ]; then chown -R vscode:root ${PIP_TARGET}; fi" \
+    && echo "$SNIPPET" | tee -a /root/.bashrc >> /home/vscode/.bashrc \
+    && echo "$SNIPPET" | tee -a /root/.zshrc >> /home/vscode/.zshrc
+```
 
 ### Adding the definition to your folder
 

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -22,7 +22,7 @@ While the definition itself works unmodified, you can select the version of Pyth
 "args": { "VARIANT": "3.7" }
 ```
 
-You can also directly reference pre-built versions of `base.Dockerfile` by using the `image` property in `devcontainer.json` or updating the `FROM` statement in your `Dockerfile` with one of the following:
+You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/python:3` (latest)
 - `mcr.microsoft.com/vscode/devcontainers/python:3.6`


### PR DESCRIPTION
This PR updates the Python 3 & PostgresSQL definition to use the new pre-built Python image.