### PR TITLE
Azure Functions Python 3 - Remove unnecessary apt source

### DIFF
--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -28,10 +28,12 @@ RUN \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /home/vscode/.local/share \
+    && chown -R vscode /home/vscode
 
 # Azure Functions Core Tools needs a place to save data
-ENV XDG_DATA_HOME=/usr/local/share
+ENV XDG_DATA_HOME=/home/vscode/.local/share
 
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog

--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -14,7 +14,6 @@ RUN \
     # Install Azure Functions, .NET Core, and Azure CLI
     echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \
-    && echo "deb [arch=amd64] https://packages.microsoft.com/debian/10/prod/ buster main" > /etc/apt/sources.list.d/azure-functions-core-tools.list \
     && curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
     && apt-get update \
     && apt-get install -y azure-cli dotnet-sdk-3.1 azure-functions-core-tools-3 \
@@ -30,6 +29,9 @@ RUN \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-        
+
+# Azure Functions Core Tools needs a place to save data
+ENV XDG_DATA_HOME=/usr/local/share
+
 # Switch back to dialog for any ad-hoc use of apt-get
 ENV DEBIAN_FRONTEND=dialog

--- a/containers/azure-functions-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-python-3/.devcontainer/devcontainer.json
@@ -14,11 +14,11 @@
 		"ms-azuretools.vscode-azurefunctions",
 		"ms-azuretools.vscode-docker",
 		"ms-python.python"
-	]
+	],
 	
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "npm install",
 
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	"remoteUser": "vscode"
 }


### PR DESCRIPTION
Turns out there's no need to add the extra apt-get source.