### PR TITLE
Migrate publish to service principal, only update MCR if version updates

### DIFF
--- a/.github/workflows/cgmanifest.yml
+++ b/.github/workflows/cgmanifest.yml
@@ -10,22 +10,26 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     steps:
 
-    - name: Container Registry Login
-      id: docker_login
-      uses: azure/docker-login@v1
-      with:
-        login-server: ${{ secrets.REGISTRY }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-
     - name: Checkout
       id: checkout
       uses: actions/checkout@v1
+
+    - name: Azure CLI login
+      id: az_login
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZ_ACR_CREDS }}
 
     - name: Update CG Manifest
       id: update_cg_manifest
       run: |
         set -e
+
+        # ACR login
+        ACR_REGISTRY_NAME=$(echo ${{ secrets.REGISTRY }} | grep -oP '(.+)(?=\.azurecr\.io)')
+        az acr login --name $ACR_REGISTRY_NAME
+
+        # Pull images and update cgmanifest.json
         yarn install
         GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
         if [ "$GIT_BRANCH" == "" ]; then 
@@ -36,6 +40,8 @@ jobs:
                         --github-repo ${{ github.repository }} \
                         --registry ${{ secrets.REGISTRY }} \
                         --registry-path ${{ secrets.REGISTRY_BASE_PATH }}
+
+        # Push updated cgmnaifest.json to source control
         git config --global user.email "vscr-feedback@microsoft.com"
         git config --global user.name "CI"
         git add cgmanifest.json

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -27,12 +27,17 @@ jobs:
       id: run_all_patches
       run: |
         set -e
-        yarn install
+
+        # ACR login
         ACR_REGISTRY_NAME=$(echo ${{ secrets.REGISTRY }} | grep -oP '(.+)(?=\.azurecr\.io)')
         az acr login --name $ACR_REGISTRY_NAME
+
+        # Execute patching
+        yarn install
         build/vscdc patch --all \
                           --registry ${{ secrets.REGISTRY }} \
                           --registry-path ${{ secrets.REGISTRY_BASE_PATH }}
+
         # Add resulting status.json file back to source control
         git config --global user.email "vscr-feedback@microsoft.com"
         git config --global user.name "CI"

--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -24,22 +24,24 @@ jobs:
       id: get_tag_name  
       uses: olegtarasov/get-tag@v1
 
-    - name: Container registry login
-      id: docker_login
-      uses: azure/docker-login@v1
+    - name: Azure CLI login
+      id: az_login
+      uses: azure/login@v1
       with:
-        login-server: ${{ secrets.REGISTRY }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        creds: ${{ secrets.AZ_ACR_CREDS }}
       
     - name: Build and push
       id: build_and_push
       run: |
         set -e
-        # Push images and package
+        
+        # ACR login
+        ACR_REGISTRY_NAME=$(echo ${{ secrets.REGISTRY }} | grep -oP '(.+)(?=\.azurecr\.io)')
+        az acr login --name $ACR_REGISTRY_NAME
+
+        # Build and push images
         yarn install
-        build/vscdc push  --replace-images \
-                          --page ${{ matrix.page }} \
+        build/vscdc push  --page ${{ matrix.page }} \
                           --pageTotal ${{ matrix.page-total }} \
                           --release ${{ steps.get_tag_name.outputs.tag }} \
                           --github-repo ${{ github.repository }} \
@@ -66,9 +68,11 @@ jobs:
       id: update_script_source
       run: |
         set -e
-        yarn install
+
         # Update common script source URLs in all dev containers and and set SHA hash
+        yarn install
         build/vscdc update-script-sources ${{ steps.get_tag_name.outputs.tag }} --github-repo ${{ github.repository }}
+
         # Commit to a new tag specific branch
         git config --global user.email "vscr-feedback@microsoft.com"
         git config --global user.name "CI"
@@ -76,6 +80,7 @@ jobs:
         git branch ${{ steps.get_tag_name.outputs.tag }}-temp-branch
         git add -u
         git commit -m 'Automated update of common script sources and hash'
+
         # Re-tag and push to origin
         git tag -d ${{ steps.get_tag_name.outputs.tag }}
         git tag ${{ steps.get_tag_name.outputs.tag }}
@@ -94,6 +99,7 @@ jobs:
                           --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
                           --stub-registry ${{ secrets.STUB_REGISTRY }} \
                           --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
+
         # Set an output with the resulting package name for upload
         PKG_PREFIX=$(node -p "require('./package.json').name")
         echo "::set-output name=package_name::$(ls $PKG_PREFIX-*.tgz)"

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -23,25 +23,28 @@ jobs:
       id: checkout
       uses: actions/checkout@v1
 
-    - name: Container registry login
-      id: docker_login
-      uses: azure/docker-login@v1
+    - name: Azure CLI login
+      id: az_login
+      uses: azure/login@v1
       with:
-        login-server: ${{ secrets.REGISTRY }}
-        username: ${{ secrets.REGISTRY_USERNAME }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
+        creds: ${{ secrets.AZ_ACR_CREDS }}
 
     - name: Build and push dev tags
       id: build_and_push
       run: |
         set -e
+
+        # ACR login
+        ACR_REGISTRY_NAME=$(echo ${{ secrets.REGISTRY }} | grep -oP '(.+)(?=\.azurecr\.io)')
+        az acr login --name $ACR_REGISTRY_NAME
+
+        # Build and push dev images
         yarn install
         GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
         if [ "$GIT_BRANCH" == "" ]; then 
             GIT_BRANCH=master
         fi
-        build/vscdc push  --replace-images \
-                          --page ${{ matrix.page }} \
+        build/vscdc push  --page ${{ matrix.page }} \
                           --pageTotal ${{ matrix.page-total }} \
                           --release $GIT_BRANCH \
                           --github-repo ${{ github.repository }} \
@@ -76,6 +79,7 @@ jobs:
                           --registry-path ${{ secrets.REGISTRY_BASE_PATH }} \
                           --stub-registry ${{ secrets.STUB_REGISTRY }} \
                           --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }}
+
         # Set an output with the resulting package name for upload
         PKG_PREFIX=$(node -p "require('./package.json').name")
         PKG_NAME=$PKG_PREFIX-${{ github.sha }}.tgz


### PR DESCRIPTION
PR switches to a service principal to interact with ACR and enables ACR lookups to see if something is already published. If a version is already published, skip it (though this does not apply to dev tag).