### PR TITLE
dotnetcore-3.1: Update URL to nvm install script

### DIFF
--- a/containers/dotnetcore-3.1/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-3.1/.devcontainer/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
         #
         # Install nvm and Node
         mkdir ${NVM_DIR} \
-        && curl -so- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash 2>&1 \
+        && curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash 2>&1 \
         && chown -R vscode:vscode ${NVM_DIR} \
         && /bin/bash -c "source $NVM_DIR/nvm.sh \
             && nvm install ${NODE_VERSION} \


### PR DESCRIPTION
update nvm install script url to the latest one (listed here: https://github.com/nvm-sh/nvm#install--update-script).