### PR TITLE
Add PHP 7 & MariaDB

### DIFF
--- a/containers/php-7-mariadb/.devcontainer/Dockerfile
+++ b/containers/php-7-mariadb/.devcontainer/Dockerfile
@@ -1,0 +1,52 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+FROM php:7-cli
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
+    #
+    # [Optional] Install MariaDB client to manage database directly from dev container's shell
+    && apt-get install -y mariadb-client \
+    #
+    # install git iproute2, procps, lsb-release (useful for CLI installs)
+    && apt-get -y install git openssh-client less iproute2 procps iproute2 lsb-release \
+    #
+    # Install xdebug
+    && yes | pecl install xdebug \
+    && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.remote_autostart=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    #
+    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
+    && groupadd --gid $USER_GID $USERNAME \
+    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    # [Optional] Add sudo support for the non-root user
+    && apt-get install -y sudo \
+    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    #
+    # [Optional] Install NPM to assist with frontend development (Dramatically increases build time on slower connections)
+    && apt-get install -y npm \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/containers/php-7-mariadb/.devcontainer/devcontainer.json
+++ b/containers/php-7-mariadb/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.112.0/containers/php-7
+{
+	"name": "PHP 7 & MariaDB",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "php",
+	
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"felixfbecker.php-debug",
+		"felixfbecker.php-intellisense",
+		"mtxr.sqltools"
+	],
+
+	"workspaceFolder": "/workspace",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode",
+}

--- a/containers/php-7-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/php-7-mariadb/.devcontainer/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3"
+
+services: 
+    php:
+        build: .
+        volumes:
+            - ..:/workspace:cached
+        ports:
+            # For use with PHP (e.g. `php -S localhost:8080`)
+            - "8080:8080"
+        command: sleep infinity
+    mariadb:
+        image: mariadb:10.4
+        expose:
+            # Expose mariadb port to php service (Access as hostname "mariadb" from within php container)
+            - "3306"
+        # Uncomment to allow access to mariadb from external tools
+        # ports:
+        #     - "3306:3306"
+        environment:
+            MYSQL_ROOT_PASSWORD: just-for-testing
+            MYSQL_DATABASE: VscodeDev
+

--- a/containers/php-7-mariadb/.npmignore
+++ b/containers/php-7-mariadb/.npmignore
@@ -1,0 +1,5 @@
+README.md
+test-project
+definition-build.json
+.vscode
+.npmignore

--- a/containers/php-7-mariadb/.vscode/settings.json
+++ b/containers/php-7-mariadb/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "sqltools.connections": [
+        {
+            "database": "VscodeDev",
+            "dialect": "MariaDB",
+            "name": "Docker-Compose MariaDB",
+            "password": "just-for-testing",
+            "port": 3306,
+            "server": "mariadb",
+            "username": "root"
+        }
+    ]
+}

--- a/containers/php-7-mariadb/README.md
+++ b/containers/php-7-mariadb/README.md
@@ -5,7 +5,7 @@
 Develop PHP 7 based applications with MariaDB (MySQL Compatible).  Includes necessary extensions and tools for both PHP and Mariadb.
 | Metadata | Value |  
 |----------|-------|
-| *Contributors* | Richard Morrill |
+| *Contributors* | Richard Morrill [github.com/ThoolooExpress](https://github.com/ThoolooExpress) |
 | *Definition type* | Docker Compose |
 | *Languages, platforms* | PHP, MariaDB (MySQL Compatible) |
 

--- a/containers/php-7-mariadb/README.md
+++ b/containers/php-7-mariadb/README.md
@@ -1,0 +1,57 @@
+# PHP 7 & MariaDB
+
+## Summary
+
+Develop PHP 7 based applications with MariaDB (MySQL Compatible).  Includes necessary extensions and tools for both PHP and Mariadb.
+| Metadata | Value |  
+|----------|-------|
+| *Contributors* | Richard Morrill |
+| *Definition type* | Docker Compose |
+| *Languages, platforms* | PHP, MariaDB (MySQL Compatible) |
+
+## Description
+
+This definition creates two containers, one for PHP and one for MariaDB.  Code will attach to the PHP container, and from within that container the
+MariaDB container will be availible with the hostname `mariadb`.  The MariaDB instance can be managed via the automatically installed SQLTools extension,
+or from the container's command line with
+
+```$ mariadb -h mariadb -u root -p```
+
+the password is defined by default as `just-for-testing`, and if desired this may be changed in docker-compose.yml.
+
+## Using this definition with an existing folder
+
+Just follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the Php 7 & Mariadb definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## Testing the definition
+
+This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Clone this repository.
+3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
+4. Select this folder from the cloned repository.
+5. Run the script `test-project/test.sh`
+
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).

--- a/containers/php-7-mariadb/test-project/test.sh
+++ b/containers/php-7-mariadb/test-project/test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+cd $(dirname "$0")
+
+# -- Utility functions --
+if [ -z $HOME ]; then
+    HOME="/root"
+fi
+
+FAILED=()
+
+check() {
+    LABEL=$1
+    shift
+    echo -e "\n🧪  Testing $LABEL: $@"
+    if $@; then 
+        echo "🏆  Passed!"
+    else
+        echo "💥  $LABEL check failed."
+        FAILED+=("$LABEL")
+    fi
+}
+
+checkMultiple() {
+    PASSED=0
+    LABEL="$1"
+    shift; MINIMUMPASSED=$1
+    shift; EXPRESSION="$1"
+    while [ "$EXPRESSION" != "" ]; do
+        if $EXPRESSION; then ((PASSED++)); fi
+        shift; EXPRESSION=$1
+    done
+    check "$LABEL" [ $PASSED -ge $MINIMUMPASSED ]
+}
+
+checkExtension() {
+    checkMultiple "$1" 1 "[ -d ""$HOME/.vscode-server/extensions/$1*"" ]" "[ -d ""$HOME/.vscode-server-insiders/extensions/$1*"" ]" "[ -d ""$HOME/.vscode-test-server/extensions/$1*"" ]"
+}
+
+# -- Actual tests - add more here --
+checkMultiple "vscode-server" 1 "[ -d ""$HOME/.vscode-server/bin"" ]" "[ -d ""$HOME/.vscode-server-insiders/bin"" ]" "[ -d ""$HOME/.vscode-test-server/bin"" ]"
+check "non-root-user" "id vscode"
+check "/home/vscode" [ -d "/home/vscode" ]
+check "sudo" sudo -u vscode echo "sudo works."
+check "git" git --version
+check "command-line-tools" which top ip lsb_release
+check "php" php --version
+check "mariadb" mariadb -h mariadb -P 3306 -u root --password=just-for-testing -Bse exit
+
+# -- Report results --
+if [ ${#FAILED[@]} -ne 0 ]; then
+    echo -e "\n💥  Failed tests: ${FAILED[@]}"
+    exit 1
+else 
+    echo -e "\n💯  All passed!"
+    exit 0
+fi


### PR DESCRIPTION
Add a devcontainer definition for PHP 7 and MariaDB.  This is in response to #253, which requested a PHP and MySQL definition.

This definition is using MariaDB instead of MySQL because it is based off of a configuration I'd already been using, and because the version of default-mysql-client supplied by PHP 7's version of Debian is not compatible with the authentication plugin used by the latest version of MySQL.  The PHP MySQL drivers are also compatible with MariaDB so this shouldn't matter from the PHP side.