### PR TITLE
Add Dapr extension to default remote extensions

### DIFF
--- a/containers/dapr-dotnetcore-3.1/.devcontainer/devcontainer.json
+++ b/containers/dapr-dotnetcore-3.1/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
+		"ms-azuretools.vscode-dapr",
 		"ms-azuretools.vscode-docker",
 		"ms-dotnettools.csharp"
 	]

--- a/containers/dapr-typescript-node-12/.devcontainer/devcontainer.json
+++ b/containers/dapr-typescript-node-12/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint",
+		"ms-azuretools.vscode-dapr",
 		"ms-azuretools.vscode-docker",
 		"ms-vscode.vscode-typescript-tslint-plugin"
 	]

--- a/containers/dapr-typescript-node-12/test-project/components/redis.yaml
+++ b/containers/dapr-typescript-node-12/test-project/components/redis.yaml
@@ -9,3 +9,5 @@ spec:
     value: dapr_redis:6379
   - name: redisPassword
     value: ""
+  - name: actorStateStore
+    value: "true"

--- a/containers/dapr-typescript-node-12/test-project/src/accounts.ts
+++ b/containers/dapr-typescript-node-12/test-project/src/accounts.ts
@@ -9,11 +9,12 @@ import DaprClient from './daprClient';
 const router = express.Router();
 
 const daprClient = new DaprClient();
+const store = 'statestore';
 
 router.use(express.json({ strict: false }));
 
 router.get('/:id', async (req, res) => {
-    const balance = await daprClient.getState<number>(req.params.id);
+    const balance = await daprClient.getState<number>(store, req.params.id);
 
     if (balance !== undefined) {
         res.status(200).header('Content-Type', 'application/json').send(JSON.stringify(balance));
@@ -23,21 +24,21 @@ router.get('/:id', async (req, res) => {
 });
 
 router.post('/:id/deposit', async (req, res) => {
-    let balance = await daprClient.getState<number>(req.params.id) ?? 0;
+    let balance = await daprClient.getState<number>(store, req.params.id) ?? 0;
 
     balance += req.body as number;
 
-    await daprClient.setState(req.params.id, balance);
+    await daprClient.setState(store, req.params.id, balance);
 
     res.status(200).header('Content-Type', 'application/json').send(JSON.stringify(balance));
 });
 
 router.post('/:id/withdraw', async (req, res) => {
-    let balance = await daprClient.getState<number>(req.params.id) ?? 0;
+    let balance = await daprClient.getState<number>(store, req.params.id) ?? 0;
 
     balance -= req.body as number;
 
-    await daprClient.setState(req.params.id, balance);
+    await daprClient.setState(store, req.params.id, balance);
 
     res.status(200).header('Content-Type', 'application/json').send(JSON.stringify(balance));
 });

--- a/containers/dapr-typescript-node-12/test-project/src/daprClient.ts
+++ b/containers/dapr-typescript-node-12/test-project/src/daprClient.ts
@@ -12,8 +12,8 @@ export default class DaprClient {
         this.daprEndpoint = daprEndpoint ?? `http://localhost:${process.env.DAPR_HTTP_PORT ?? 3500 }/v1.0`;
     }
 
-    public async getState<T>(key: string): Promise<T | undefined> {
-        const response = await fetch(`${this.daprEndpoint}/state/${key}`);
+    public async getState<T>(store: string, key: string): Promise<T | undefined> {
+        const response = await fetch(`${this.daprEndpoint}/state/${store}/${key}`);
 
         if (!response.ok) {
             throw new Error('Could not get state.');
@@ -30,9 +30,9 @@ export default class DaprClient {
         return JSON.parse(value);
     }
 
-    public async setState<T>(key: string, value: T): Promise<void> {
+    public async setState<T>(store: string, key: string, value: T): Promise<void> {
         const response = await fetch(
-            `${this.daprEndpoint}/state`,
+            `${this.daprEndpoint}/state/${store}`,
             {
                 body: JSON.stringify([{ key, value }]),
                 headers: {


### PR DESCRIPTION
Add the Dapr extension as a default remote extension for the Dapr-related templates.  Update the Node.js with Dapr template based on breaking changes in recent Dapr runtimes.

Resolves [vscode-dapr#86](https://github.com/microsoft/vscode-dapr/issues/86).