### PR TITLE
Update Puppet Extension Identifier and Dockerfile

### DIFF
--- a/containers/puppet/.devcontainer/Dockerfile
+++ b/containers/puppet/.devcontainer/Dockerfile
@@ -1,31 +1,13 @@
-FROM ruby:2
+FROM puppet/pdk:latest
 
-# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
-# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
-# will be updated to match your local UID/GID (when using the dockerFile property).
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN gem install ruby-debug-ide
-RUN gem install debase
-
-ADD https://apt.puppetlabs.com/puppet6-release-xenial.deb /puppet6-release-xenial.deb
-RUN dpkg -i /puppet6-release-xenial.deb
-
-RUN apt-get update \
-    && apt-get -y install git openssh-client less iproute2 procps pdk \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+# [Optional] Uncomment this section to install additional packages.
+#
+# ENV DEBIAN_FRONTEND=noninteractive
+# RUN apt-get update \
+#    && apt-get -y install --no-install-recommends <your-package-list-here> \
+#    #
+#    # Clean up
+#    && apt-get autoremove -y \
+#    && apt-get clean -y \
+#    && rm -rf /var/lib/apt/lists/*
+# ENV DEBIAN_FRONTEND=dialog

--- a/containers/puppet/.devcontainer/devcontainer.json
+++ b/containers/puppet/.devcontainer/devcontainer.json
@@ -3,13 +3,13 @@
 	"dockerFile": "Dockerfile",
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
+	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"jpogran.puppet-vscode",
+		"puppet.puppet-vscode",
 		"rebornix.Ruby"
 	]
 


### PR DESCRIPTION
This PR updates the VS Code Extension ID from `jpogran.puppet-vscode` to `puppet.puppet-vscode` in the official Puppet namespace.