### PR TITLE
Add Ubuntu 20.04 container

### DIFF
--- a/containers/ubuntu-20.04/.devcontainer/Dockerfile
+++ b/containers/ubuntu-20.04/.devcontainer/Dockerfile
@@ -1,0 +1,41 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+FROM buildpack-deps:focal
+
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Set to false to skip installing zsh and Oh My ZSH!
+ARG INSTALL_ZSH="true"
+
+# Location and expected SHA for common setup script - SHA generated on release
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SHA="dev-mode"
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Configure apt and install packages
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends apt-utils dialog wget ca-certificates 2>&1 \
+    #
+    # Verify git, common tools / libs installed, add/modify non-root user, optionally install zsh
+    && wget -q -O /tmp/common-setup.sh $COMMON_SCRIPT_SOURCE \
+    && if [ "$COMMON_SCRIPT_SHA" != "dev-mode" ]; then echo "$COMMON_SCRIPT_SHA /tmp/common-setup.sh" | sha256sum -c - ; fi \
+    && /bin/bash /tmp/common-setup.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
+    && rm /tmp/common-setup.sh \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog

--- a/containers/ubuntu-20.04/.devcontainer/devcontainer.json
+++ b/containers/ubuntu-20.04/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "Ubuntu 20.04",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/zsh"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	// "extensions": []
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Uncomment to use the Docker CLI from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/containers/ubuntu-20.04/.npmignore
+++ b/containers/ubuntu-20.04/.npmignore
@@ -1,0 +1,5 @@
+README.md
+test-project
+definition-build.json
+.vscode
+.npmignore

--- a/containers/ubuntu-20.04/README.md
+++ b/containers/ubuntu-20.04/README.md
@@ -1,0 +1,61 @@
+# Ubuntu 20.04
+
+## Summary
+
+*Simple Ubuntu 20.04 container.*
+
+| Metadata | Value |  
+|----------|-------|
+| *Contributors* | The VS Code Team |
+| *Definition type* | Dockerfile |
+| *Published image* | mcr.microsoft.com/vscode/devcontainers/base:ubuntu-20.04 |
+| *Published image architecture(s)* | x86-64 |
+| *Container host OS support* | Linux, macOS, Windows |
+| *Languages, platforms* | Any |
+
+## Using this definition with an existing folder
+
+While the definition itself works unmodified, you can also directly reference pre-built versions of `.devcontainer/Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to:
+
+`mcr.microsoft.com/vscode/devcontainers/base:ubuntu-20.04`
+
+Alternatively, you can use the contents of the `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+
+Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
+
+### Adding the definition to your project
+
+Just follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the Ubuntu 20.04 definition.
+
+3. To use the Dockerfile for this definition (*rather than the pre-built image*):
+   1. Clone this repository.
+   2. Copy the contents of `containers/ubuntu-20.04/.devcontainer` to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## Testing the definition
+
+This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Clone this repository.
+3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
+4. Select the `containers/ubuntu-20.04` folder.
+5. Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> and type the following command to verify installation: `apt-get update && apt-get install -y lsb-release && git --version && lsb_release -a`
+6. After lsb_release installs, you should see the Git version and details about the version of Linux in the container.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)

--- a/containers/ubuntu-20.04/definition-build.json
+++ b/containers/ubuntu-20.04/definition-build.json
@@ -1,0 +1,25 @@
+{
+	"build": {
+		"rootDistro": "debian",
+		"tags": [
+			"base:${VERSION}-ubuntu-20.04",
+			"base:${VERSION}-focal"
+		]
+	},
+	"dependencies": {
+		"image": "buildpack-deps:focal",
+		"imageLink": "https://hub.docker.com/_/buildpack-deps",
+		"manual": [
+			{
+				"Component": {
+					"Type": "git",
+					"git": {
+						"Name": "Oh My Zsh!",
+						"repositoryUrl": "https://github.com/robbyrussell/oh-my-zsh",
+						"commitHash": "c130aadb6a66aa680a322c08d87ad773316f713d"
+					}
+				}
+			}
+		]
+	}
+}

--- a/containers/ubuntu-20.04/test-project/test.sh
+++ b/containers/ubuntu-20.04/test-project/test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+cd $(dirname "$0")
+
+if [ -z $HOME ]; then
+    HOME="/root"
+fi
+
+FAILED=()
+
+check() {
+    LABEL=$1
+    shift
+    echo -e "\n🧪  Testing $LABEL: $@"
+    if $@; then 
+        echo "🏆  Passed!"
+    else
+        echo "💥  $LABEL check failed."
+        FAILED+=("$LABEL")
+    fi
+}
+
+checkMultiple() {
+    PASSED=0
+    LABEL="$1"
+    shift; MINIMUMPASSED=$1
+    shift; EXPRESSION="$1"
+    while [ "$EXPRESSION" != "" ]; do
+        if $EXPRESSION; then ((PASSED++)); fi
+        shift; EXPRESSION=$1
+    done
+    check "$LABEL" [ $PASSED -ge $MINIMUMPASSED ]
+}
+
+checkExtension() {
+    checkMultiple "$1" 1 "[ -d ""$HOME/.vscode-server/extensions/$1*"" ]" "[ -d ""$HOME/.vscode-server-insiders/extensions/$1*"" ]" "[ -d ""$HOME/.vscode-test-server/extensions/$1*"" ]"
+}
+
+# Actual tests
+checkMultiple "vscode-server" 1 "[ -d ""$HOME/.vscode-server/bin"" ]" "[ -d ""$HOME/.vscode-server-insiders/bin"" ]" "[ -d ""$HOME/.vscode-test-server/bin"" ]"
+check "non-root-user" "id vscode"
+check "/home/vscode" [ -d "/home/vscode" ]
+check "sudo" sudo -u vscode echo "sudo works."
+check "git" git --version
+check "command-line-tools" which top ip lsb_release
+
+# Report result
+if [ ${#FAILED[@]} -ne 0 ]; then
+    echo -e "\n💥  Failed tests: ${FAILED[@]}"
+    exit 1
+else 
+    echo -e "\n💯  All passed!"
+    exit 0
+fi


### PR DESCRIPTION
This new container uses `buildpack-deps:focal` as base, and this
commit duplicates the `ubuntu-18.04-git` folder and rename every
reference of the old container. Plus, it also rebrand the image
without the `-git`, because is more than obvious that it will have
git installed.

Fixes #303 