### PR TITLE
Missing multi-line continuation characters

### DIFF
--- a/containers/docker-in-docker/README.md
+++ b/containers/docker-in-docker/README.md
@@ -43,8 +43,8 @@ You can adapt your own existing development container Dockerfile to support this
         && apt-get install -y docker-ce-cli \
         #
         # Install Docker Compose
-        LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")')
-        curl -sSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+        LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")') \
+        curl -sSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose \
         chmod +x /usr/local/bin/docker-compose
     ```
 


### PR DESCRIPTION
The last part of the command fails due to missing back-slashes