### PR TITLE
Updating Core Tools to v3 in PS Functions image

### DIFF
--- a/containers/azure-functions-pwsh-6/.devcontainer/Dockerfile
+++ b/containers/azure-functions-pwsh-6/.devcontainer/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update \
     && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \
     && curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
     && apt-get update \
-    && apt-get install -y azure-cli azure-functions-core-tools \
+    && apt-get install -y azure-cli azure-functions-core-tools-3 \
     #
     # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
     && groupadd --gid $USER_GID $USERNAME \


### PR DESCRIPTION
I noticed an issue when using this devcontainer in VS Codespaces. I created a new Functions project and HTTP-triggered function. The functions worker process gets into a bad state, prompting retries from the host, which eventually gives up can exits: `Exceeded language worker restart retry count for runtime:powershell. Shutting down Functions Host`

Making this change to update to v3 fixes the issue.