### PR TITLE
Fix missing URL and update comment Development Container Script

### DIFF
--- a/containers/azure-functions-java-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-8/.devcontainer/Dockerfile
@@ -3,5 +3,23 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-# ImageURL: https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/java/java8-core-tools.Dockerfile
+# Find the Dockerfile for mcr.microsoft.com/azure-functions/java:3.0-java8-core-tools at this URL
+# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/java/java8/java8-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/java:3.0-java8-core-tools
+
+# Uncomment following lines If you want to enable Development Container Script
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
+
+# Avoid warnings by switching to noninteractive
+# ENV DEBIAN_FRONTEND=noninteractive
+
+# # Comment out these lines if you want to use zsh.
+
+# ARG INSTALL_ZSH=true
+# ARG USERNAME=vscode
+# ARG USER_UID=1000
+# ARG USER_GID=$USER_UID
+
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
+#     && rm /tmp/common-script.sh 


### PR DESCRIPTION
Hi @Chuxel 

I update the java8 one with two things. 

* Fix missing URL for the Dockerfile (someone change the URL for the target repo)
* Add comment for the Development Container Script 

Our base image is for Azure Functions Core Tools and Azure CLI.  I wanted to separate the concern. 
I just add the comment for the Development Container Script so that  customer can comment out. 

I also consider if we can do it with a switch instead of the comment. However, it can hit a cache and ignore it. For this reason, I make it as comment. 

Any feedback is welcome. 

# I'll update the azure functions images one by one. :)  Node, Python, Dotnet 3 will be updated by the other PRs. Java11 coming soon as well. :) 