### PR TITLE
Move Azure Functions container to Azure Functions Official Images

### DIFF
--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
@@ -3,56 +3,23 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+# Find the Dockerfile for mcr.microsoft.com/azure-functions/dotnet:3.0-dotnet3-core-tools at this URL
+# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0-dotnet3-core-tools
 
-# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
-# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
-# will be updated to match your local UID/GID (when using the dockerFile property).
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+# Uncomment following lines If you want to enable Development Container Script
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
 
-# Configure apt and install packages
-RUN apt-get update \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    #
-    # Verify git and needed tools are installed
-    && apt-get -y install \
-        git \
-        openssh-client \
-        less \
-        unzip \
-        iproute2 \
-        procps \
-        curl \
-        apt-transport-https \
-        gnupg2 \
-        lsb-release \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # Install Azure Functions Core Tools v3
-    && wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg \
-    && mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ \
-    && wget -q https://packages.microsoft.com/config/debian/9/prod.list \
-    && mv prod.list /etc/apt/sources.list.d/microsoft-prod.list \
-    && chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg \
-    && chown root:root /etc/apt/sources.list.d/microsoft-prod.list \
-    && apt-get update \
-    && apt-get -y install azure-functions-core-tools-3 \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+# Avoid warnings by switching to noninteractive
+# ENV DEBIAN_FRONTEND=noninteractive
 
-# Uncomment to opt out of Func CLI telemetry gathering
-#ENV FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT=true
+# # Comment out these lines if you want to use zsh.
+
+# ARG INSTALL_ZSH=true
+# ARG USERNAME=vscode
+# ARG USER_UID=1000
+# ARG USER_GID=$USER_UID
+
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
+#     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-node-10/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-10/.devcontainer/Dockerfile
@@ -6,20 +6,3 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/node:3.0-node10-core-tools at this URL
 # https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/node:3.0-node10-core-tools
-
-# Uncomment following lines If you want to enable Development Container Script
-# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
-
-# Avoid warnings by switching to noninteractive
-# ENV DEBIAN_FRONTEND=noninteractive
-
-# # Comment out these lines if you want to use zsh.
-
-# ARG INSTALL_ZSH=true
-# ARG USERNAME=vscode
-# ARG USER_UID=1000
-# ARG USER_GID=$USER_UID
-
-# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
-#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
-#     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-node-10/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-10/.devcontainer/Dockerfile
@@ -3,39 +3,23 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:10
+# Find the Dockerfile for mcr.microsoft.com/azure-functions/node:3.0-node10-core-tools at this URL
+# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile
+FROM mcr.microsoft.com/azure-functions/node:3.0-node10-core-tools
 
-# The javascript-node image includes a non-root user with sudo access. Use the "remoteUser"
-# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
-# will be updated to match your local UID/GID (when using the dockerFile property).
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=node
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+# Uncomment following lines If you want to enable Development Container Script
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
 
-# Configure apt and install packages
-RUN apt-get update \
-    && export DEBIAN_FRONTEND=noninteractive \
-    #
-    # Install Azure Functions, .NET Core, and Azure CLI
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \
-    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
-    && apt-get update \
-    && apt-get install -y azure-cli dotnet-sdk-3.1 azure-functions-core-tools-3 \
-    #
-    # [Optional] Update a non-root user to UID/GID if needed.
-    && if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
-        groupmod --gid $USER_GID $USERNAME \
-        && usermod --uid $USER_UID --gid $USER_GID $USERNAME; \
-    fi \
-    && mkdir -p /home/$USERNAME/.local/share \
-    && chown -R $USER_UID:$USER_GID /home/$USERNAME \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+# Avoid warnings by switching to noninteractive
+# ENV DEBIAN_FRONTEND=noninteractive
 
-# Azure Functions Core Tools needs a place to save data
-ENV XDG_DATA_HOME=/home/$USERNAME/.local/share
+# # Comment out these lines if you want to use zsh.
+
+# ARG INSTALL_ZSH=true
+# ARG USERNAME=vscode
+# ARG USER_UID=1000
+# ARG USER_GID=$USER_UID
+
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
+#     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-node-12/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-12/.devcontainer/Dockerfile
@@ -6,20 +6,3 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/node:3.0-node12-core-tools at this URL
 # https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/node:3.0-node12-core-tools
-
-# Uncomment following lines If you want to enable Development Container Script
-# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
-
-# Avoid warnings by switching to noninteractive
-# ENV DEBIAN_FRONTEND=noninteractive
-
-# # Comment out these lines if you want to use zsh.
-
-# ARG INSTALL_ZSH=true
-# ARG USERNAME=vscode
-# ARG USER_UID=1000
-# ARG USER_GID=$USER_UID
-
-# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
-#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
-#     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-node-12/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node-12/.devcontainer/Dockerfile
@@ -3,39 +3,23 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:12
+# Find the Dockerfile for mcr.microsoft.com/azure-functions/node:3.0-node12-core-tools at this URL
+# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile
+FROM mcr.microsoft.com/azure-functions/node:3.0-node12-core-tools
 
-# The javascript-node image includes a non-root user with sudo access. Use the "remoteUser"
-# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
-# will be updated to match your local UID/GID (when using the dockerFile property).
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=node
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+# Uncomment following lines If you want to enable Development Container Script
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
 
-# Configure apt and install packages
-RUN apt-get update \
-    && export DEBIAN_FRONTEND=noninteractive \
-    #
-    # Install Azure Functions, .NET Core, and Azure CLI
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \
-    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
-    && apt-get update \
-    && apt-get install -y azure-cli dotnet-sdk-3.1 azure-functions-core-tools-3 \
-    #
-    # [Optional] Update a non-root user to UID/GID if needed.
-    && if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
-        groupmod --gid $USER_GID $USERNAME \
-        && usermod --uid $USER_UID --gid $USER_GID $USERNAME; \
-    fi \
-    && mkdir -p /home/$USERNAME/.local/share \
-    && chown -R $USER_UID:$USER_GID /home/$USERNAME \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+# Avoid warnings by switching to noninteractive
+# ENV DEBIAN_FRONTEND=noninteractive
 
-# Azure Functions Core Tools needs a place to save data
-ENV XDG_DATA_HOME=/home/$USERNAME/.local/share
+# # Comment out these lines if you want to use zsh.
+
+# ARG INSTALL_ZSH=true
+# ARG USERNAME=vscode
+# ARG USER_UID=1000
+# ARG USER_GID=$USER_UID
+
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
+#     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -6,20 +6,3 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools at this URL
 # https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools
-
-# Uncomment following lines If you want to enable Development Container Script
-# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
-
-# Avoid warnings by switching to noninteractive
-# ENV DEBIAN_FRONTEND=noninteractive
-
-# # Comment out these lines if you want to use zsh.
-
-# ARG INSTALL_ZSH=true
-# ARG USERNAME=vscode
-# ARG USER_UID=1000
-# ARG USER_GID=$USER_UID
-
-# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
-#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
-#     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -3,31 +3,23 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.8
+# Find the Dockerfile for mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools at this URL
+# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
+FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools
 
-# Configure apt and install packages
-RUN export DEBIAN_FRONTEND=noninteractive \
-    #
-    # Install Azure Functions, .NET Core, and Azure CLI
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list \
-    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
-    && apt-get update \
-    && apt-get install -y azure-cli dotnet-sdk-3.1 azure-functions-core-tools-3 \
-    #
-    # Install Docker CE CLI (needed for publish with --build-native-deps)
-    && apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common lsb-release \
-    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get install -y docker-ce-cli \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p /home/vscode/.local/share \
-    && chown -R vscode /home/vscode
+# Uncomment following lines If you want to enable Development Container Script
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
 
-# Azure Functions Core Tools needs a place to save data
-ENV XDG_DATA_HOME=/home/vscode/.local/share
+# Avoid warnings by switching to noninteractive
+# ENV DEBIAN_FRONTEND=noninteractive
+
+# # Comment out these lines if you want to use zsh.
+
+# ARG INSTALL_ZSH=true
+# ARG USERNAME=vscode
+# ARG USER_UID=1000
+# ARG USER_GID=$USER_UID
+
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
+#     && rm /tmp/common-script.sh 


### PR DESCRIPTION
Hi @Chuxel , 

I published the following Azure Functions images. So I switch to the Azure Functions Docker images. 

* Dotnet Core 3.1
* Node 10
* Node 12
* Python 3.8

These images are tested by running the Readme process.  (Open the DevContainer then, create project, then debug run. check if the break point works if I send a request). 

I also add a comment of  Development Container Script. It is the same as the Java one.  
https://github.com/microsoft/vscode-dev-containers/pull/332
