### PR TITLE
Remove vscode user from Puppet devcontainer

### DIFF
--- a/containers/puppet/.devcontainer/devcontainer.json
+++ b/containers/puppet/.devcontainer/devcontainer.json
@@ -18,7 +18,4 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pdk --version",
-
-	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
 }


### PR DESCRIPTION
This PR removes the reference to the vscode user from the devcontainer, as the [`puppet/pdk`](https://github.com/puppetlabs/pdk-docker/blob/cc4ff84497432057d4ae4a5b2e8f45206b26f4e7/Dockerfile) docker image does not have such a user.

At the time of this commit, the [`puppet/pdk`](https://github.com/puppetlabs/pdk-docker/blob/cc4ff84497432057d4ae4a5b2e8f45206b26f4e7/Dockerfile) image does not create a
non-root user. If/when it does, this can be re-added.
