### PR TITLE
Non-root Docker in Docker README changes

### DIFF
--- a/containers/docker-in-docker/README.md
+++ b/containers/docker-in-docker/README.md
@@ -80,18 +80,19 @@ Follow these directions to set up non-root access using `socat`:
     ARG NONROOT_USER=vscode
 
     # Default to root only access to the Docker socket, set up non-root init script
-    RUN touch /var/run/docker.socket \
-        && ln -s /var/run/docker-host.socket /var/run/docker.socket
+    RUN touch /var/run/docker-host.sock \
+        && ln -s /var/run/docker-host.sock /var/run/docker.sock
         && apt-get update \
         && apt-get -y install socat
 
     # Create docker-init.sh to spin up socat
     RUN echo '#!/bin/sh\n\
-        sudo rm -rf /var/run/docker-host.socket\n\
-        ((sudo socat UNIX-LISTEN:/var/run/docker.socket,fork,mode=660,user=${NONROOT_USER} UNIX-CONNECT:/var/run/docker-host.socket) 2>&1 >> /tmp/vscr-dind-socat.log) & > /dev/null\n\
+        sudo rm -rf /var/run/docker.sock\n\
+        ((sudo socat UNIX-LISTEN:/var/run/docker.sock,fork,mode=660,user=${NONROOT_USER} UNIX-CONNECT:/var/run/docker-host.sock) 2>&1 >> /tmp/vscr-dind-socat.log) & > /dev/null\n\
         "$@"' >> /usr/local/share/docker-init.sh \
         && chmod +x /usr/local/share/docker-init.sh
 
+    # VS Code by default overrides ENTRYPOINT and CMD with default values when executing `docker run`.
     # Setting the ENTRYPOINT to docker-init.sh will configure non-root access to
     # the Docker socket if "overrideCommand": false is set in devcontainer.json.
     # The script will also execute CMD if you need to alter startup behaviors.


### PR DESCRIPTION
I walked through this tutorial and found that this sample code did not work for me.

`*.socket` should have been `*.sock` 
and
Line 83 is actually ensuring that the `docker-host.sock` file exists before creating a symbolic link.
and
Line 90 is actually removing the symbolic link created above if that script gets executed. `sudo socat` will fail if `docker.sock` already exist.s

Let me know if this is incorrect.

I did not test out the other scenarios (docker compose + kubernetes).