### PR TITLE
Resolve #361

### DIFF
--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -67,7 +67,7 @@ RUN apt-get update \
     && export PYTHONUSERBASE=/tmp/pip-tmp \
     && pip3 install --disable-pip-version-check --no-warn-script-location --no-cache-dir --user pipx \
     && /tmp/pip-tmp/bin/pipx install --pip-args=--no-cache-dir pipx \
-    && echo "${DEFAULT_UTILS}" | xargs -n 1 /tmp/pip-tmp/bin/pipx install --system-site-packages --pip-args=--no-cache-dir \
+    && echo "${DEFAULT_UTILS}" | xargs -n 1 /tmp/pip-tmp/bin/pipx install --system-site-packages --pip-args=--no-cache-dir --pip-args=--force-reinstall \
     && chown -R ${USER_UID}:${USER_GID} ${PIPX_HOME} \
     && rm -rf /tmp/pip-tmp \
     #


### PR DESCRIPTION
A temporary copy of pipx can result in missing dependencies when installing other packages (in this case `black`). Force reinstalling resolves the problem. 