### PR TITLE
Work around https://github.com/microsoft/vscode-remote-release/issues/3224

### DIFF
--- a/containers/dapr-dotnetcore-3.1/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnetcore-3.1/.devcontainer/Dockerfile
@@ -17,6 +17,9 @@ ARG USER_GID=$USER_UID
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
 ENV NVM_DIR=/home/vscode/.nvm
+# Have nvm create a "current" symlink and add to path to work around https://github.com/microsoft/vscode-remote-release/issues/3224
+ENV NVM_SYMLINK_CURRENT=true 
+ENV PATH=${NVM_DIR}/current/bin:${PATH}
 
 # [Optional] Install the Azure CLI
 ARG INSTALL_AZURE_CLI="false"

--- a/containers/dotnetcore-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnetcore-fsharp/.devcontainer/Dockerfile
@@ -25,6 +25,9 @@ ARG NODE_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-c
 ARG NODE_SCRIPT_SHA="dev-mode"
 ARG NODE_VERSION="lts/*"
 ENV NVM_DIR=/usr/local/share/nvm
+# Have nvm create a "current" symlink and add to path to work around https://github.com/microsoft/vscode-remote-release/issues/3224
+ENV NVM_SYMLINK_CURRENT=true 
+ENV PATH=${NVM_DIR}/current/bin:${PATH}
 
 # [Optional] Install the Azure CLI
 ARG INSTALL_AZURE_CLI="false"

--- a/containers/dotnetcore/.devcontainer/Dockerfile
+++ b/containers/dotnetcore/.devcontainer/Dockerfile
@@ -25,6 +25,9 @@ ARG NODE_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-c
 ARG NODE_SCRIPT_SHA="dev-mode"
 ARG NODE_VERSION="lts/*"
 ENV NVM_DIR=/usr/local/share/nvm
+# Have nvm create a "current" symlink and add to path to work around https://github.com/microsoft/vscode-remote-release/issues/3224
+ENV NVM_SYMLINK_CURRENT=true
+ENV PATH=${NVM_DIR}/current/bin:${PATH}
 
 # [Optional] Install the Azure CLI
 ARG INSTALL_AZURE_CLI="false"

--- a/containers/javascript-node-10/.devcontainer/Dockerfile
+++ b/containers/javascript-node-10/.devcontainer/Dockerfile
@@ -16,6 +16,9 @@ ARG USER_GID=$USER_UID
 ARG NPM_GLOBAL=/usr/local/share/npm-global
 ENV PATH=${PATH}:${NPM_GLOBAL}/bin
 ENV NVM_DIR=/usr/local/share/nvm
+# Have nvm create a "current" symlink and add to path to work around https://github.com/microsoft/vscode-remote-release/issues/3224
+ENV NVM_SYMLINK_CURRENT=true 
+ENV PATH=${NVM_DIR}/current/bin:${PATH}
 
 # Options for common package install script
 ARG INSTALL_ZSH="true"

--- a/containers/javascript-node-12/.devcontainer/Dockerfile
+++ b/containers/javascript-node-12/.devcontainer/Dockerfile
@@ -16,6 +16,9 @@ ARG USER_GID=$USER_UID
 ARG NPM_GLOBAL=/usr/local/share/npm-global
 ENV PATH=${PATH}:${NPM_GLOBAL}/bin
 ENV NVM_DIR=/usr/local/share/nvm
+# Have nvm create a "current" symlink and add to path to work around https://github.com/microsoft/vscode-remote-release/issues/3224
+ENV NVM_SYMLINK_CURRENT=true 
+ENV PATH=${NVM_DIR}/current/bin:${PATH}
 
 # Options for common package install script
 ARG INSTALL_ZSH="true"

--- a/containers/javascript-node-14/.devcontainer/Dockerfile
+++ b/containers/javascript-node-14/.devcontainer/Dockerfile
@@ -16,6 +16,9 @@ ARG USER_GID=$USER_UID
 ARG NPM_GLOBAL=/usr/local/share/npm-global
 ENV PATH=${PATH}:${NPM_GLOBAL}/bin
 ENV NVM_DIR=/usr/local/share/nvm
+# Have nvm create a "current" symlink and add to path to work around https://github.com/microsoft/vscode-remote-release/issues/3224
+ENV NVM_SYMLINK_CURRENT=true 
+ENV PATH=${NVM_DIR}/current/bin:${PATH}
 
 # Options for common package install script
 ARG INSTALL_ZSH="true"


### PR DESCRIPTION
Ensures Node.js installed by NVM works from VS Code tasks, not just the terminal by adding a "current" symlink and adding it to the path.