### PR TITLE
Update devcontainer.json

### DIFF
--- a/containers/rust/.devcontainer/devcontainer.json
+++ b/containers/rust/.devcontainer/devcontainer.json
@@ -6,14 +6,20 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"lldb.executable": "/usr/bin/lldb"
+		"lldb.executable": "/usr/bin/lldb",
+		// VS Code don't watch files under ./target
+		"files.watcherExclude": {
+			"**/target/**": true
+		}
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"rust-lang.rust",
 		"bungcip.better-toml",
-		"vadimcn.vscode-lldb"
+		"vadimcn.vscode-lldb",
+		// (Optional) Displays the current CPU stats, memory/disk consumption, clock freq. etc. of the container host in the VS Code status bar.
+		"mutantdino.resourcemonitor"
 	]
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
Don't watch the rust ./target directory created/used by cargo. Stops cargo locked/missing file warnings.
Added a useful remote extension that allows one to the monitor resource utilization of the container host.