### PR TITLE
Add devcontainer for Bash

### DIFF
--- a/containers/bash/.devcontainer/Dockerfile
+++ b/containers/bash/.devcontainer/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:latest
+# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
+# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
+# will be updated to match your local UID/GID (when using the dockerFile property).
+# See https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN apk add --no-cache\
+    bash \
+    curl \
+    git \
+    openssh-client \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+RUN addgroup -g ${USER_GID} ${USERNAME} && \
+    adduser -s /bin/ash -u ${USER_UID} -D -G ${USERNAME} ${USERNAME} && \
+    echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME}&& \
+    chmod 0440 /etc/sudoers.d/${USERNAME}
+WORKDIR /src
+ENTRYPOINT [ "/usr/bin/bash" ]

--- a/containers/bash/.devcontainer/Dockerfile
+++ b/containers/bash/.devcontainer/Dockerfile
@@ -1,22 +1,3 @@
-FROM alpine:latest
-# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
-# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
-# will be updated to match your local UID/GID (when using the dockerFile property).
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN apk add --no-cache\
-    bash \
-    curl \
-    git \
-    openssh-client \
-    sudo \
-    && rm -rf /var/lib/apt/lists/*
-RUN addgroup -g ${USER_GID} ${USERNAME} && \
-    adduser -s /bin/ash -u ${USER_UID} -D -G ${USERNAME} ${USERNAME} && \
-    echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME}&& \
-    chmod 0440 /etc/sudoers.d/${USERNAME}
+FROM mcr.microsoft.com/vscode/devcontainers/base:alpine
 WORKDIR /src
 ENTRYPOINT [ "/usr/bin/bash" ]

--- a/containers/bash/.devcontainer/devcontainer.json
+++ b/containers/bash/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+	"name": "Bash",
+	"dockerfile": "Dockerfile",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"mads-hartmann.bash-ide-vscode",
+		"rogalmic.bash-debug"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Uncomment to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"dockerFile": "Dockerfile"
+}

--- a/containers/bash/.vscode/launch.json
+++ b/containers/bash/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "bashdb",
+			"request": "launch",
+			"name": "Bash-Debug (simplest configuration)",
+			"program": "${file}"
+		}
+	]
+}

--- a/containers/bash/README.md
+++ b/containers/bash/README.md
@@ -1,0 +1,39 @@
+# Bash
+
+## Summary
+
+*Develop scripts with Bash, includes [Bash IDE](https://marketplace.visualstudio.com/items?itemName=mads-hartmann.bash-ide-vscode), and [Bash Debug](https://github.com/rogalmic/vscode-bash-debug).*
+
+|          Metadata           |                    Value                     |
+| --------------------------- | -------------------------------------------- |
+| *Contributors*              | [Aaryn Smith](https://gitlab.com/aarynsmith) |
+| *Definition type*           | Dockerfile                                   |
+| *Works in Codespaces*       | Yes                                          |
+| *Container host OS support* | Linux, macOS, Windows                        |
+| *Languages, platforms*      | Bash                                         |
+
+## Using this definition with an existing folder
+
+Just follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the Bash definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).

--- a/containers/bash/README.md
+++ b/containers/bash/README.md
@@ -8,7 +8,7 @@
 | --------------------------- | -------------------------------------------- |
 | *Contributors*              | [Aaryn Smith](https://gitlab.com/aarynsmith) |
 | *Definition type*           | Dockerfile                                   |
-| *Works in Codespaces*       | Yes                                          |
+| *Works in Codespaces*       | No                                          |
 | *Container host OS support* | Linux, macOS, Windows                        |
 | *Languages, platforms*      | Bash                                         |
 


### PR DESCRIPTION
Adds a configuration for Bash development for #254. Included Bash IDE and Bash Debug extensions.