### PR TITLE
Add Devcontainer for Vue.js

### DIFF
--- a/containers/vue/.devcontainer/Dockerfile
+++ b/containers/vue/.devcontainer/Dockerfile
@@ -1,16 +1,4 @@
-FROM node:lts-alpine
-
-# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
-# this user's GID/UID must match your local user UID/GID to avoid permission issues
-# with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
-# https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=node
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN apk add --no-cache sudo git openssh-client \
-	&& echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-	&& chmod 0440 /etc/sudoers.d/$USERNAME
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:14
 
 RUN npm install -g http-server @vue/cli @vue/cli-service-global
 WORKDIR /app

--- a/containers/vue/.devcontainer/Dockerfile
+++ b/containers/vue/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:lts-alpine
+
+# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
+# this user's GID/UID must match your local user UID/GID to avoid permission issues
+# with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
+# https://aka.ms/vscode-remote/containers/non-root-user for details.
+ARG USERNAME=node
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN apk add --no-cache sudo git openssh-client \
+	&& echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
+	&& chmod 0440 /etc/sudoers.d/$USERNAME
+
+RUN npm install -g http-server @vue/cli @vue/cli-service-global
+WORKDIR /app
+COPY . .
+
+EXPOSE 8080
+CMD [ "/usr/local/bin/npm run serve" ]

--- a/containers/vue/.devcontainer/Dockerfile
+++ b/containers/vue/.devcontainer/Dockerfile
@@ -2,7 +2,5 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:14
 
 RUN npm install -g http-server @vue/cli @vue/cli-service-global
 WORKDIR /app
-COPY . .
 
 EXPOSE 8080
-CMD [ "/usr/local/bin/npm run serve" ]

--- a/containers/vue/.devcontainer/devcontainer.json
+++ b/containers/vue/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+{
+	"name": "Vue",
+	"dockerfile": "Dockerfile",
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/sh"
+	},
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"octref.vetur"
+	],
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		8080
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+	// Uncomment to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	"dockerFile": "Dockerfile",
+	"context": ".."
+}

--- a/containers/vue/.devcontainer/devcontainer.json
+++ b/containers/vue/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"dockerfile": "Dockerfile",
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/sh"
+		"terminal.integrated.shell.linux": "/bin/zsh"
 	},
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [

--- a/containers/vue/.npmignore
+++ b/containers/vue/.npmignore
@@ -1,0 +1,5 @@
+README.md
+test-project
+definition-manifest.json
+.vscode
+.npmignore

--- a/containers/vue/.vscode/tasks.json
+++ b/containers/vue/.vscode/tasks.json
@@ -13,5 +13,15 @@
 			},
 			"isBackground": true,
 		},
+		{
+			"label": "Build Project",
+			"type": "shell",
+			"command": "npm run build",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"isBackground": true,
+		},
 	]
 }

--- a/containers/vue/.vscode/tasks.json
+++ b/containers/vue/.vscode/tasks.json
@@ -11,7 +11,7 @@
 				"kind": "test",
 				"isDefault": true
 			},
-			"isBackground": true,
+			"isBackground": true
 		},
 		{
 			"label": "Build Project",
@@ -21,7 +21,14 @@
 				"kind": "build",
 				"isDefault": true
 			},
-			"isBackground": true,
+			"isBackground": true
 		},
+		{
+			"label": "Create New Project",
+			"type": "shell",
+			"command": "vue create .",
+			"isBackground": false,
+			"problemMatcher": []
+		}
 	]
 }

--- a/containers/vue/.vscode/tasks.json
+++ b/containers/vue/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558 
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Serve Project",
+			"type": "shell",
+			"command": "npm run serve",
+			"group": {
+				"kind": "test",
+				"isDefault": true
+			},
+			"isBackground": true,
+		},
+	]
+}

--- a/containers/vue/README.md
+++ b/containers/vue/README.md
@@ -1,0 +1,39 @@
+# Vue
+
+## Summary
+
+*Develop applications with Vue.js, includes everything you need to get up and running.*
+
+|          Metadata           |                    Value                     |
+| --------------------------- | -------------------------------------------- |
+| *Contributors*              | [Aaryn Smith](https://gitlab.com/aarynsmith) |
+| *Definition type*           | Dockerfile                                   |
+| *Works in Codespaces*       | No                                           |
+| *Container host OS support* | Linux, macOS, Windows                        |
+| *Languages, platforms*      | Javascript                                   |
+
+## Using this definition with an existing folder
+
+Just follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the Hugo definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).


### PR DESCRIPTION
This adds a config for Vue.js using a node image. 

@Chuxel I debated running the same image from the others and rolling in node, but not sure thats any more efficent, or do you think I should copy the javascript-node-14 config and add in the Vue install?