### PR TITLE
Add commented option of embedding python project requirements into image

### DIFF
--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -62,6 +62,11 @@ RUN apt-get update \
     && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
     && rm /tmp/common-setup.sh \
     #
+    # Uncomment the following lines and the corresponding COPY line above if you wish to include your 
+    # requirements in the image itself. Only do this if your requirements rarely change. 
+    # && pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    # && rm -rf /tmp/pip-tmp \
+    #
     # Setup default python tools in a venv via pipx to avoid conflicts
     && mkdir -p ${PIPX_BIN_DIR} \
     && export PYTHONUSERBASE=/tmp/pip-tmp \


### PR DESCRIPTION
![requirements](https://user-images.githubusercontent.com/4334520/87099109-cab57e00-c1fd-11ea-94bd-95eb2d38c970.png)

The expected commented lines in the RUN command for installing requirements were missing, so I've added them.  