### PR TITLE
Add cmake

### DIFF
--- a/containers/rust/.devcontainer/Dockerfile
+++ b/containers/rust/.devcontainer/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
     #
     # Verify git, needed tools installed
-    && apt-get -y install git openssh-client less iproute2 procps lsb-release \
+    && apt-get -y install git openssh-client cmake less iproute2 procps lsb-release \
     #
     # Install lldb, vadimcn.vscode-lldb VSCode extension dependencies
     && apt-get install -y lldb python3-minimal libpython3.7 \


### PR DESCRIPTION
Cmake is a required dependency for building rust, see https://github.com/rust-lang/rust/blob/dbf3ae7c3beb5b493375bf76152e490b8cc81d1c/README.md#building-on-a-unix-like-system