### PR TITLE
Update oryx image and symlink to newest version.

### DIFF
--- a/containers/codespaces-linux/.devcontainer/Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-FROM mcr.microsoft.com/oryx/build:vso-20200601.2 as kitchensink
+FROM mcr.microsoft.com/oryx/build:vso-20200706.2 as kitchensink
 
 ARG BASH_PROMPT="PS1='\[\e]0;\u: \w\a\]\[\033[01;32m\]\u\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '"
 ARG FISH_PROMPT="function fish_prompt\n    set_color green\n    echo -n (whoami)\n    set_color normal\n    echo -n \":\"\n    set_color blue\n    echo -n (pwd)\n    set_color normal\n    echo -n \"> \"\nend\n"

--- a/containers/codespaces-linux/.devcontainer/symlinkDotNetCore.sh
+++ b/containers/codespaces-linux/.devcontainer/symlinkDotNetCore.sh
@@ -36,12 +36,12 @@ function createLinks() {
     done
 }
 
-createLinks "3.1.202" "3.1.4"
+createLinks "3.1.301" "3.1.5"
 echo
 createLinks "3.0.103" "3.0.3"
 echo
 createLinks "2.2.402" "2.2.7"
 echo
-createLinks "2.1.806" "2.1.17"
+createLinks "2.1.807" "2.1.19"
 echo
 createLinks "1.1.14" "1.1.13"

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.10.0",
+	"definitionVersion": "0.11.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Update to latest oryx, that includes .Net Core 3.1.302 as per https://github.com/microsoft/vscode-dev-containers/issues/398

Also updates the corresponding symlink file.