### PR TITLE
Update Vue definition to match consolidated javascript-node definition, fix non-root scenario

### DIFF
--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -7,13 +7,13 @@
 ARG VARIANT=3
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
-# [Optional] If your requirements rarely change, uncomment this section to add them to the image.
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 #
 # COPY requirements.txt /tmp/pip-tmp/
 # RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
 #    && rm -rf /tmp/pip-tmp
 
-# [Optional] Uncomment this section to install additional packages.
+# [Optional] Uncomment this section to install additional OS packages.
 #
 # RUN apt-get update \
 #     && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -7,7 +7,7 @@
 ARG VARIANT=3
 FROM python:${VARIANT}
 
-# If you would prefer to have multiple Python versions in your container,
+# [Optional] If you would prefer to have multiple Python versions in your container,
 # replace the FROM statement above with the following:
 #
 # FROM ubuntu:bionic
@@ -24,10 +24,6 @@ FROM python:${VARIANT}
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-
-# Uncomment the following COPY line and the corresponding lines in the `RUN` command if you wish to
-# include your requirements in the image itself. Only do this if your requirements rarely change.
-# COPY requirements.txt /tmp/pip-tmp/
 
 # Default set of utilities to install in a side virtual env
 ARG DEFAULT_UTILS="\
@@ -62,11 +58,6 @@ RUN apt-get update \
     && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
     && rm /tmp/common-setup.sh \
     #
-    # Uncomment the following lines and the corresponding COPY line above if you wish to include your 
-    # requirements in the image itself. Only do this if your requirements rarely change. 
-    # && pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
-    # && rm -rf /tmp/pip-tmp \
-    #
     # Setup default python tools in a venv via pipx to avoid conflicts
     && mkdir -p ${PIPX_BIN_DIR} \
     && export PYTHONUSERBASE=/tmp/pip-tmp \
@@ -85,5 +76,15 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
 
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+#
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
 
+# [Optional] Uncomment this section to install additional OS packages.
+#
+# RUN apt-get update \
+#     && export DEBIAN_FRONTEND=noninteractive \
+#    && apt-get -y install --no-install-recommends <your-package-list-here>
 

--- a/containers/vue/.devcontainer/Dockerfile
+++ b/containers/vue/.devcontainer/Dockerfile
@@ -1,6 +1,7 @@
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:14
+ARG VARIANT=14
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
-RUN npm install -g http-server @vue/cli @vue/cli-service-global
+RUN sudo -u node npm install -g http-server @vue/cli @vue/cli-service-global
 WORKDIR /app
 
 EXPOSE 8080

--- a/containers/vue/.devcontainer/devcontainer.json
+++ b/containers/vue/.devcontainer/devcontainer.json
@@ -1,27 +1,32 @@
 {
 	"name": "Vue",
-	"dockerfile": "Dockerfile",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		// Update 'VARIANT' to pick a Node version. Rebuild the container 
+		// if it already exists to update. Available variants: 10, 12, 14
+		"args": { "VARIANT": "14" }
+	},
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/zsh"
 	},
+	
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint",
 		"octref.vetur"
 	],
+	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	"forwardPorts": [
 		8080
 	],
+	
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
-	// Uncomment to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
-	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node",
-	"dockerFile": "Dockerfile",
-	"context": ".."
+	// "remoteUser": "node"
 }


### PR DESCRIPTION
I just merged in #399 which consolidates the node 10, 12, 14 definitions into one with a build arg. This updates Vue to use the same pattern.

I also noticed that the vue CLI was installed globally as root, which can cause problems with caching, so I prefixed that with `sudo -u node`.

LMK if it looks good @AarynSmith 