### PR TITLE
Simplify Python 3 base.Dockerfile 

### DIFF
--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -11,4 +11,3 @@ FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 # RUN apt-get update \
 #     && export DEBIAN_FRONTEND=noninteractive \
 #    && apt-get -y install --no-install-recommends <your-package-list-here>
-

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -2,37 +2,11 @@
 ARG VARIANT=3
 FROM python:${VARIANT}
 
-# [Optional] If you would prefer to have multiple Python versions in your container,
-# replace the FROM statement above with the following:
-#
-# FROM ubuntu:bionic
-# ARG PYTHON_PACKAGES="python3.5 python3.6 python3.7 python3.8 python3 python3-pip python3-venv"
-# RUN apt-get update && apt-get install --no-install-recommends -yq software-properties-common \
-#     && add-apt-repository ppa:deadsnakes/ppa && apt-get update \
-#     && apt-get install -yq --no-install-recommends ${PYTHON_PACKAGES} \
-#     && pip3 install --no-cache-dir --upgrade pip setuptools wheel
-
 # This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in
 # devcontainer.json to use it. More info: https://aka.ms/vscode-remote/containers/non-root-user.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-
-# Default set of utilities to install in a side virtual env
-ARG DEFAULT_UTILS="\
-    pylint \
-    flake8 \
-    autopep8 \
-    black \
-    yapf \
-    mypy \
-    pydocstyle \
-    pycodestyle \
-    bandit \
-    virtualenv"
-ENV PIPX_HOME=/usr/local/py-utils
-ENV PIPX_BIN_DIR=${PIPX_HOME}/bin
-ENV PATH=${PATH}:${PIPX_BIN_DIR}
 
 # Options for common setup script
 ARG INSTALL_ZSH="true"
@@ -48,24 +22,35 @@ RUN apt-get update \
     && ([ "${COMMON_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/common-setup.sh" | sha256sum -c -)) \
     && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
     && rm /tmp/common-setup.sh \
-    #
-    # Setup default python tools in a venv via pipx to avoid conflicts
-    && mkdir -p ${PIPX_BIN_DIR} \
+    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
+    && apt-get purge -y imagemagick imagemagick-6-common \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Setup default python tools in a venv via pipx to avoid conflicts
+ARG DEFAULT_UTILS="\
+    pylint \
+    flake8 \
+    autopep8 \
+    black \
+    yapf \
+    mypy \
+    pydocstyle \
+    pycodestyle \
+    bandit \
+    virtualenv"
+ENV PIPX_HOME=/usr/local/py-utils
+ENV PIPX_BIN_DIR=${PIPX_HOME}/bin
+ENV PATH=${PATH}:${PIPX_BIN_DIR}
+RUN mkdir -p ${PIPX_BIN_DIR} \
     && export PYTHONUSERBASE=/tmp/pip-tmp \
     && pip3 install --disable-pip-version-check --no-warn-script-location --no-cache-dir --user pipx \
     && /tmp/pip-tmp/bin/pipx install --pip-args=--no-cache-dir pipx \
     && echo "${DEFAULT_UTILS}" | xargs -n 1 /tmp/pip-tmp/bin/pipx install --system-site-packages --pip-args=--no-cache-dir --pip-args=--force-reinstall \
     && chown -R ${USER_UID}:${USER_GID} ${PIPX_HOME} \
-    && rm -rf /tmp/pip-tmp \
-    #
-    # Tactically remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
-    # Can leave in Dockerfile once upstream base image moves to > 7.0.7-28.
-    && apt-get purge -y imagemagick imagemagick-6-common \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /tmp/pip-tmp
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -110,6 +110,19 @@ RUN mkdir -p ${PIP_TARGET} \
     | tee -a /root/.bashrc /root/.zshrc /home/vscode/.bashrc >> /home/vscode/.zshrc \
 ```
 
+#### [Optional] Installing multiple versions of Python in the same image
+
+If you would prefer to have multiple Python versions in your container, use `base.Dockerfile` and update `FROM` statement:
+
+```Dockerfile
+FROM ubuntu:bionic
+ARG PYTHON_PACKAGES="python3.5 python3.6 python3.7 python3.8 python3 python3-pip python3-venv"
+RUN apt-get update && apt-get install --no-install-recommends -yq software-properties-common \
+     && add-apt-repository ppa:deadsnakes/ppa && apt-get update \
+     && apt-get install -yq --no-install-recommends ${PYTHON_PACKAGES} \
+     && pip3 install --no-cache-dir --upgrade pip setuptools wheel
+```
+
 ### Adding the definition to your project
 
 Just follow these steps:


### PR DESCRIPTION
Related to #409

With Codespaces, more people are looking at the `base.Dockerfile` in this repository since it does not yet have the "Add" experience the Remote - Containers extension has. As a result, I'm going through and doing some simplification and layer refinement. 

For Python, this:
1. Breaks out the pipx install section so that you can add tools to it without re-running the common setup script
2. Removes the giant comment about adding multiple images and adds this to the README instead.
3. Misc other cleanup