### PR TITLE
containers/go: correct tools installation in modules mode

### DIFF
--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -17,31 +17,27 @@ RUN apt-get update \
     # Build Go tools w/module support
     && mkdir -p /tmp/gotools \
     && cd /tmp/gotools \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -v golang.org/x/tools/gopls@latest 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -v \
-        honnef.co/go/tools/...@latest \
-        golang.org/x/tools/cmd/gorename@latest \
-        golang.org/x/tools/cmd/goimports@latest \
-        golang.org/x/tools/cmd/guru@latest \
-        golang.org/x/lint/golint@latest \
-        github.com/mdempsky/gocode@latest \
-        github.com/cweill/gotests/...@latest \
-        github.com/haya14busa/goplay/cmd/goplay@latest \
-        github.com/sqs/goreturns@latest \
-        github.com/josharian/impl@latest \
-        github.com/davidrjenni/reftools/cmd/fillstruct@latest \
-        github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest  \
-        github.com/ramya-rao-a/go-outline@latest  \
-        github.com/acroca/go-symbols@latest  \
-        github.com/godoctor/godoctor@latest  \
-        github.com/rogpeppe/godef@latest  \
-        github.com/zmb3/gogetdoc@latest \
-        github.com/fatih/gomodifytags@latest  \
-        github.com/mgechev/revive@latest  \
-        github.com/go-delve/delve/cmd/dlv@latest 2>&1 \
-    #
-    # Build Go tools w/o module support
-    && GOPATH=/tmp/gotools go get -v github.com/alecthomas/gometalinter 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/tools/gopls 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x honnef.co/go/tools/... 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/tools/cmd/gorename 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/tools/cmd/goimports 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/tools/cmd/guru 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/lint/golint 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/mdempsky/gocode 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/cweill/gotests/... 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/haya14busa/goplay/cmd/goplay 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/sqs/goreturns 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/josharian/impl 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/davidrjenni/reftools/cmd/fillstruct 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/uudashr/gopkgs/v2/cmd/gopkgs 2>&1  \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/ramya-rao-a/go-outline 2>&1  \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/acroca/go-symbols 2>&1  \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/godoctor/godoctor 2>&1  \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/rogpeppe/godef 2>&1  \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/zmb3/gogetdoc 2>&1 \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/fatih/gomodifytags 2>&1  \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/mgechev/revive 2>&1  \
+    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/go-delve/delve/cmd/dlv 2>&1 \
     #
     # Build gocode-gomod
     && GOPATH=/tmp/gotools go get -x -d github.com/stamblerre/gocode 2>&1 \
@@ -67,6 +63,4 @@ RUN apt-get update \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* /tmp/gotools
 
-# Update this to "on" or "off" as appropriate
 ENV GO111MODULE=auto
-


### PR DESCRIPTION
When installing tools, install them individuallly rather than
with one single `go get` command. Otherwise, the go command
runs MVS for all the listed tools and builds each tool with
unexpected dependencies.

See https://github.com/golang/vscode-go/issues/363#issuecomment-660335139

Also, remove gometalinter - vscode-go no longer uses it.

GO111MODULE=auto is perfectly fine. If `go.mod` exists
in the repo, the go command will automatically switch to the
modules mode. Unsetting is also fine but I will leave it as it is.