### PR TITLE
Update Go definition to use common script, two layers, simplify a bit

### DIFF
--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -57,8 +57,8 @@ RUN mkdir -p /tmp/gotools \
     && (echo "${GO_TOOLS_WITH_MODULES}" | xargs -n 1 go get -x )2>&1 \
     # gocode-gomod
     && export GO111MODULE=auto \
-    && GOPATH=/tmp/gotools go get -x -d github.com/stamblerre/gocode 2>&1 \
-    && GOPATH=/tmp/gotools go build -o gocode-gomod github.com/stamblerre/gocode \
+    && go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && go build -o gocode-gomod github.com/stamblerre/gocode \
     # golangci-lint
     && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin 2>&1 \
     # Move Go tools into path and clean up

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1
+# Update the VARIANT arg in devcontainer.json to pick an Go version
+ARG VARIANT=1
+FROM golang:${VARIANT}
 
 # This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in
 # devcontainer.json to use it. More info: https://aka.ms/vscode-remote/containers/non-root-user.
@@ -6,61 +8,70 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+# Options for common setup script - SHA generated on release
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="false"
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SHA="dev-mode"
+
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    #
-    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git openssh-client less iproute2 procps lsb-release \
-    #
-    # Build Go tools w/module support
-    && mkdir -p /tmp/gotools \
-    && cd /tmp/gotools \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/tools/gopls 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x honnef.co/go/tools/... 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/tools/cmd/gorename 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/tools/cmd/goimports 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/tools/cmd/guru 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x golang.org/x/lint/golint 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/mdempsky/gocode 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/cweill/gotests/... 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/haya14busa/goplay/cmd/goplay 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/sqs/goreturns 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/josharian/impl 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/davidrjenni/reftools/cmd/fillstruct 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/uudashr/gopkgs/v2/cmd/gopkgs 2>&1  \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/ramya-rao-a/go-outline 2>&1  \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/acroca/go-symbols 2>&1  \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/godoctor/godoctor 2>&1  \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/rogpeppe/godef 2>&1  \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/zmb3/gogetdoc 2>&1 \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/fatih/gomodifytags 2>&1  \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/mgechev/revive 2>&1  \
-    && GOPATH=/tmp/gotools GO111MODULE=on go get -x github.com/go-delve/delve/cmd/dlv 2>&1 \
-    #
-    # Build gocode-gomod
-    && GOPATH=/tmp/gotools go get -x -d github.com/stamblerre/gocode 2>&1 \
-    && GOPATH=/tmp/gotools go build -o gocode-gomod github.com/stamblerre/gocode \
-    #
-    # Install Go tools
-    && mv /tmp/gotools/bin/* /usr/local/bin/ \
-    && mv gocode-gomod /usr/local/bin/ \
-    #
-    # Install golangci-lint
-    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin 2>&1 \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
+    && apt-get -y install --no-install-recommends curl ca-certificates 2>&1 \
+    && curl -sSL  ${COMMON_SCRIPT_SOURCE} -o /tmp/common-setup.sh \
+    && ([ "${COMMON_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} /tmp/common-setup.sh" | sha256sum -c -)) \
+    && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/* /tmp/gotools
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Go tools
+ARG GO_TOOLS_WITH_MODULES="\
+    golang.org/x/tools/gopls \
+    honnef.co/go/tools/... \
+    golang.org/x/tools/cmd/gorename \
+    golang.org/x/tools/cmd/goimports \
+    golang.org/x/tools/cmd/guru \
+    golang.org/x/lint/golint \
+    github.com/mdempsky/gocode \
+    github.com/cweill/gotests/... \
+    github.com/haya14busa/goplay/cmd/goplay \
+    github.com/sqs/goreturns \
+    github.com/josharian/impl \
+    github.com/davidrjenni/reftools/cmd/fillstruct \
+    github.com/uudashr/gopkgs/v2/cmd/gopkgs \
+    github.com/ramya-rao-a/go-outline \
+    github.com/acroca/go-symbols \
+    github.com/godoctor/godoctor \
+    github.com/rogpeppe/godef \
+    github.com/zmb3/gogetdoc \
+    github.com/fatih/gomodifytags \
+    github.com/mgechev/revive \
+    github.com/go-delve/delve/cmd/dlv"
+RUN mkdir -p /tmp/gotools \
+    && cd /tmp/gotools \
+    && export GOPATH=/tmp/gotools \
+    # Go tools w/module support
+    && export GO111MODULE=on \
+    && (echo "${GO_TOOLS_WITH_MODULES}" | xargs -n 1 go get -x )2>&1 \
+    # gocode-gomod
+    && export GO111MODULE=auto \
+    && GOPATH=/tmp/gotools go get -x -d github.com/stamblerre/gocode 2>&1 \
+    && GOPATH=/tmp/gotools go build -o gocode-gomod github.com/stamblerre/gocode \
+    # golangci-lint
+    && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin 2>&1 \
+    # Move Go tools into path and clean up
+    && mv /tmp/gotools/bin/* /usr/local/bin/ \
+    && mv gocode-gomod /usr/local/bin/ \
+    && rm -rf /tmp/gotools
 
 ENV GO111MODULE=auto
+
+# [Optional] Uncomment the next line to use go get to install anything else you need
+# RUN go get -x <your-dependency-or-tool>
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update \
+#     && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -1,6 +1,10 @@
 {
 	"name": "Go",
-	"dockerFile": "Dockerfile",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update the VARIANT arg to pick a version of Go
+		"args": { "VARIANT": "1" }
+	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 
 	// Set *default* container specific settings.json values on container create.

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -14,7 +14,13 @@
 
 ## Using this definition with an existing folder
 
-This definition does not require any special steps to use. Just follow these steps:
+While the definition itself works unmodified, you can select the version of Go the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
+
+```json
+"args": { "VARIANT": "1.13" }
+```
+
+### Adding the definition to your project
 
 1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
 

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -17,7 +17,7 @@
 While the definition itself works unmodified, you can select the version of Go the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "1.13" }
+"args": { "VARIANT": "1.14" }
 ```
 
 ### Adding the definition to your project


### PR DESCRIPTION
This PR is part of #409 and related to #375. It does a few things to the Go definition:

1. Switches it to using the common script used in other definitions that installs common utilities and creates the vscode non-root user.
2. Separates out the installation of the Go tools into a separate layer so that any modifications will not require a re-run of the common script while still ensuring each layer cleans up before moving to the next step.
3. Uses xargs to simplify the code that installs all the different Go tools.
4. Adds comments at the end of the Dockerfile about adding your own `RUN` statements for additional installed contents.
5. Adds a build arg that allows you to specify the Go version from devcontainer.json

For #375, we would just need to trim the list in the `GO_TOOLS_WITH_MODULES` arg once we're ready and it's easier for people to opt to do that themselves now.

//cc: @hyangah @lawrencegripper for input