### PR TITLE
Fix symlinking script for .NET Core installations

### DIFF
--- a/containers/codespaces-linux/.devcontainer/symlinkDotNetCore.sh
+++ b/containers/codespaces-linux/.devcontainer/symlinkDotNetCore.sh
@@ -18,12 +18,12 @@ cp -f "$splitSdksDir/3/ThirdPartyNotices.txt" "$allSdksDir"
 
 function createLinks() {
     local sdkVersion="$1"
-    local runtimeVersion="$2"
     
-    cd "$splitSdksDir/$sdkVersion"
+    installedDir="$splitSdksDir/$sdkVersion"
+    cd "$installedDir"
 
-    # Find folders with name as sdk or runtime version
-    find . -name "$sdkVersion" -o -name "$runtimeVersion" | while read subPath; do
+    # Find folders with the name being a version number like 3.1.0 or 3.1.301
+    find . -type d -regex '.*/[0-9]\.[0-9]\.[0-9]+' | while read subPath; do
         # Trim beginning 2 characters from the line which currently looks like, for example, './sdk/2.2.402'
         subPath="${subPath:2}"
         
@@ -31,17 +31,17 @@ function createLinks() {
         linkFromParentDir=$(dirname $linkFrom)
         mkdir -p "$linkFromParentDir"
 
-        linkTo="$splitSdksDir/$sdkVersion/$subPath"
+        linkTo="$installedDir/$subPath"
         ln -s $linkTo $linkFrom
     done
 }
 
-createLinks "3.1.301" "3.1.5"
+createLinks "3.1.301"
 echo
-createLinks "3.0.103" "3.0.3"
+createLinks "3.0.103"
 echo
-createLinks "2.2.402" "2.2.7"
+createLinks "2.2.402"
 echo
-createLinks "2.1.807" "2.1.19"
+createLinks "2.1.807"
 echo
-createLinks "1.1.14" "1.1.13"
+createLinks "1.1.14"

--- a/containers/codespaces-linux/.devcontainer/symlinkDotNetCore.sh
+++ b/containers/codespaces-linux/.devcontainer/symlinkDotNetCore.sh
@@ -32,7 +32,7 @@ function createLinks() {
         mkdir -p "$linkFromParentDir"
 
         linkTo="$installedDir/$subPath"
-        ln -s $linkTo $linkFrom
+        ln -sTf $linkTo $linkFrom
     done
 }
 


### PR DESCRIPTION
Newer .NET Core SDKs have multiple versions of packages under various subdirectories like `./packs`, so our previous checks for a specific sdk or runtime version were missing some directories that needed to be symlinked.

This update makes the symlinking more generic to symlink all subdirectories that look like a three-segment version number.

I've tested this update manually and it fixes the .NET Core installations under /home/codespace/.dotnet, and OmniSharp intellisense is working again.

Before:
```
codespace:/opt/dotnet/sdks/3.1.301$ find . -name "3.1.301" -o -name "3.1.5"
./host/fxr/3.1.5
./packs/Microsoft.NETCore.App.Host.linux-x64/3.1.5
./shared/Microsoft.NETCore.App/3.1.5
./shared/Microsoft.AspNetCore.App/3.1.5
./sdk/3.1.301
```

After:
```
codespace:/opt/dotnet/sdks/3.1.301$ find . -type d -regex '.*/[0-9]\.[0-9]\.[0-9]+'
./host/fxr/3.1.5
./packs/Microsoft.NETCore.App.Host.linux-x64/3.1.5
./packs/Microsoft.AspNetCore.App.Ref/3.1.3
./packs/NETStandard.Library.Ref/2.1.0
./packs/Microsoft.NETCore.App.Ref/3.1.0
./shared/Microsoft.NETCore.App/3.1.5
./shared/Microsoft.AspNetCore.App/3.1.5
./sdk/3.1.301
./templates/3.1.6
```