### PR TITLE
Fixing the api-server URL condition mistakes

### DIFF
--- a/containers/kubernetes-helm/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm/.devcontainer/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update \
             mkdir -p $HOME/.kube\n\
             sudo cp -r /usr/local/share/kube-localhost/* $HOME/.kube\n\
             sudo chown -R $(id -u) $HOME/.kube\n\
-            sed -i -e "s/localhost/host.docker.internal/g" $HOME/.kube/config\n\
+            sed -i -e "s/127.0.0.1/host.docker.internal/g" $HOME/.kube/config\n\
         \n\
             if [ -d "/usr/local/share/minikube-localhost" ]; then\n\
                 mkdir -p $HOME/.minikube\n\

--- a/containers/kubernetes-helm/README.md
+++ b/containers/kubernetes-helm/README.md
@@ -83,7 +83,7 @@ You can adapt your own existing development container Dockerfile to support this
     if [ "$SYNC_LOCALHOST_KUBECONFIG" == "true" ] && [ -d "/usr/local/share/kube-localhost" ];; then\n\
         mkdir -p $HOME/.kube\n\
         cp -r /usr/local/share/kube-localhost/* $HOME/.kube\n\
-        sed -i -e "s/localhost/host.docker.internal/g" $HOME/.kube/config\n\
+        sed -i -e "s/127.0.0.1/host.docker.internal/g" $HOME/.kube/config\n\
     \n\
         if [ -d "/usr/local/share/minikube-localhost" ]; then\n\
             mkdir -p $HOME/.minikube\n\
@@ -130,7 +130,7 @@ Follow these directions to set up non-root access using `socat`:
             mkdir -p $HOME/.kube\n\
             sudo cp -r /usr/local/share/kube-localhost/* $HOME/.kube\n\
             sudo chown -R $(id -u) $HOME/.kube\n\
-            sed -i -e "s/localhost/host.docker.internal/g" $HOME/.kube/config\n\
+            sed -i -e "s/127.0.0.1/host.docker.internal/g" $HOME/.kube/config\n\
         \n\
             if [ -d "/usr/local/share/minikube-localhost" ]; then\n\
                 mkdir -p $HOME/.minikube\n\


### PR DESCRIPTION
Signed-off-by: Aisuko <urakiny@gmail.com>

fix #442 

The PR changed the `localhost` to `127.0.0.1` which the condition includes the `Copy localhost's ~/.kube/config file into the container` script. It looks like no reason but I try to test and will show the result.

```
# Initial the cluster at local 
minikube start or kind create cluster

# Checking the config 
kubectl config view
```

The all of the config like 

```
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: DATA+OMITTED
    server: https://127.0.0.1:61531
  name: kind-kind
contexts:
- context:
    cluster: kind-kind
    user: kind-kind
  name: kind-kind
current-context: kind-kind
kind: Config
preferences: {}
users:
- name: kind-kind
  user:
    client-certificate-data: REDACTED
    client-key-data: REDACTED
```


|Result|kind@v0.8.1|minikube@v1.12.1(mac)/v1.11.1(ubuntu20.04)|
|:---:|:---:|:---:|
|Ubuntu20.04|`server: https://127.0.0.1:35309`|`server: https://172.17.0.3:8443`|
|macOS Catalina|`server: https://127.0.0.1:61531`|`server: https://127.0.0.1:32772`|

I'd like to add an ARG at first but there may no reason add a new layer just for saving the server URL. 