### PR TITLE
Remove buster source list from VSCS image

### DIFF
--- a/containers/codespaces-linux/.devcontainer/Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/Dockerfile
@@ -155,6 +155,9 @@ RUN apt-get update -yq\
     #
     # Clean up
     && apt-get autoremove -y \
-    && apt-get clean -y
+    && apt-get clean -y \
+    #
+    # Remove buster source list
+    && rm /etc/apt/sources.list.d/buster.list
 
 USER codespace


### PR DESCRIPTION
We had a [user report](https://github.com/MicrosoftDocs/vscodespaces/issues/644) that they were unable to install `ca-certificates` due to conflicting `apt` sources in the Oryx image. I filed an issue with Oryx but I'm not sure how long it'll take for them to fix it so this is the fix in the meantime.