### PR TITLE
fix: VS code java extension requires java 11

### DIFF
--- a/containers/azure-functions-java-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-8/.devcontainer/Dockerfile
@@ -1,6 +1,15 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/java:3.0-java8-core-tools at this URL
 # https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/java/java8/java8-core-tools.Dockerfile
-FROM mcr.microsoft.com/azure-functions/java:3.0-java8-core-tools
+FROM mcr.microsoft.com/azure-functions/java:3.0-java11-core-tools
+
+RUN apt-get -qq update && \
+    apt-get install -y software-properties-common && \
+    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 && \
+    apt-add-repository "deb http://repos.azulsystems.com/debian stable main" && \
+    apt-get -qq update && \
+    apt-get -qq -y dist-upgrade && \
+    apt-get -qq -y --no-install-recommends install zulu-8=8.46.0.19 && \
+    rm -rf /var/lib/apt/lists/*
 
 # Uncomment following lines If you want to enable Development Container Script
 # For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library

--- a/containers/azure-functions-java-8/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-8/.devcontainer/devcontainer.json
@@ -6,7 +6,14 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"java.home": "/usr/lib/jvm/zulu-8-azure-amd64"
+		"java.home": "/usr/lib/jvm/zulu-11-azure-amd64",
+		"java.configuration.runtimes": [
+			{
+			  "default": true,
+			  "name": "JavaSE-1.8",
+			  "path": "/usr/lib/jvm/zulu-8-amd64",
+			}
+		],
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.


### PR DESCRIPTION
Fix: https://github.com/microsoft/vscode-dev-containers/issues/459

VSCode Java extension requires Java 11 for the extension. 

I update the image to install not only Java 11 but also Java 8
I tested it with deploying Functions App with java8. 

Hi @Chuxel, @anthonychu , and @amamounelsayed  could you have a look? 

## TODO 
This is a quick fix. For supporting java 8, A lot of people using Java 8.  
I'll also provide java 11 soon.