### PR TITLE
Azure Functions Java 11 DevContainer

### DIFF
--- a/containers/azure-functions-java-11/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-11/.devcontainer/Dockerfile
@@ -1,0 +1,20 @@
+# Find the Dockerfile for mcr.microsoft.com/azure-functions/java:3.0-java8-core-tools at this URL
+# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/java/java8/java8-core-tools.Dockerfile
+FROM mcr.microsoft.com/azure-functions/java:3.0-java11-core-tools
+
+# Uncomment following lines If you want to enable Development Container Script
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
+
+# Avoid warnings by switching to noninteractive
+# ENV DEBIAN_FRONTEND=noninteractive
+
+# # Comment out these lines if you want to use zsh.
+
+# ARG INSTALL_ZSH=true
+# ARG USERNAME=vscode
+# ARG USER_UID=1000
+# ARG USER_GID=$USER_UID
+
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+#     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
+#     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-java-11/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-11/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Azure Functions & Java 11",
+	"dockerFile": "Dockerfile",
+	"forwardPorts": [ 7071 ],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"java.home": "/usr/lib/jvm/zulu-11-azure-amd64"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-azuretools.vscode-azurefunctions",
+		"vscjava.vscode-java-pack"
+	]
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "java -version",
+
+	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
+	// "remoteUser": "vscode"
+}

--- a/containers/azure-functions-java-11/.devcontainer/maven-settings.xml
+++ b/containers/azure-functions-java-11/.devcontainer/maven-settings.xml
@@ -1,0 +1,6 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository>/usr/share/maven/ref/repository</localRepository>
+</settings>

--- a/containers/azure-functions-java-11/.npmignore
+++ b/containers/azure-functions-java-11/.npmignore
@@ -1,0 +1,5 @@
+README.md
+test-project
+definition-manifest.json
+.vscode
+.npmignore

--- a/containers/azure-functions-java-11/README.md
+++ b/containers/azure-functions-java-11/README.md
@@ -1,0 +1,61 @@
+# Azure Functions & Java 11
+
+## Summary
+
+*Develop Azure Functions in Java. Includes JDK 11, Maven, XML tools, the Azure Functions SDK, and related extensions and dependencies.*
+
+| Metadata | Value |  
+|----------|-------|
+| *Contributors* | The VS Code Java Team |
+| *Definition type* | Dockerfile |
+| *Works in Codespaces* | Yes |
+| *Container host OS support* | Linux, macOS, Windows |
+| *Languages, platforms* | Azure Functions, Java |
+
+## Using this definition with an existing folder
+
+This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/), learn more about using [Azure Functions with VS Code](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code) and [Java Azure Functions with VS Code](https://code.visualstudio.com/docs/java/java-azurefunctions) here. Once you have an Azure account, follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the Azure Functions & Java 11 definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of `containers/azure-functions-java-11/.devcontainer` to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## Testing the definition
+
+This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Clone this repository.
+3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
+4. Select the `containers/azure-functions-java-11` folder.
+5. After the folder has opened in the container, press <kbd>F1</kbd> and select **Azure Functions: Create Function...**.
+6. Enter these options:
+   1. Yes (when prompted to create a new project)
+   2. Java
+   3. HTTP Trigger
+   4. HTTPTrigger-Java
+   5. Anonymous
+   6. Open in current window
+7. Press <kbd>F5</kbd> to start debugging project.
+8. After the debugger is started, open a local browser and enter the URL: `http://localhost:7071/api/HttpTrigger-Java?name=remote`.
+    - If the port 7071 is not already open, press <kbd>F1</kbd>, select **Remote-Containers: Forward Port from Container...**, and then port 7071.
+9. You should see "Hello, remote" echoed by the Azure Function.
+10. From here, you can add breakpoints or edit the contents of the `test-project` folder to do further testing.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).


### PR DESCRIPTION
## A part of Fix 
https://github.com/microsoft/vscode-dev-containers/issues/459

This is the Java Functions Container for Java 11. 
I tested, it works. 

## NOTE
We need to wait until the end of this month.  VSCode Azure Functions extension will estimated that they will support it at the end of this month. 

https://github.com/microsoft/vscode-azurefunctions/issues/2033

Until then, we can use Azure Functions Core Tools to create/deploy the functions. 
For more details, refer to [Quickstart: Create a function in Azure that responds to HTTP requests](
https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-azure-function-azure-cli?tabs=bash%2Cbrowser&pivots=programming-language-java)