### PR TITLE
Update azure-ansible to use common scripts

### DIFF
--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -1,72 +1,55 @@
-# Pick any base image, but if you select node, skip installing node. 😊
-FROM debian:9
+# You can pick any Debian/Ubuntu-based image. 😊
+FROM mcr.microsoft.com/vscode/devcontainers/base:buster
 
-# This Dockerfile adds a non-root user with sudo access. Update the “remoteUser” property in
-# devcontainer.json to use it. More info: https://aka.ms/vscode-remote/containers/non-root-user.
+COPY library-scripts/*.sh /tmp/library-scripts/
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="false"
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    #
-    # Verify git, required tools installed
-    && apt-get install -y \
-        git \
-        openssh-client \
-        less \
-        iproute2 \
-        curl \
-        procps \
-        unzip \
-        apt-transport-https \
-        ca-certificates \
-        gnupg-agent \
-        software-properties-common \
-        lsb-release 2>&1 \
-    #
-    # [Optional] Install Node.js for Azure Cloud Shell support 
-    # Change the "lts/*" in the two lines below to pick a different version
-    && curl -so- https://raw.githubusercontent.com/creationix/nvm/v0.34.0/install.sh | bash 2>&1 \
-    && /bin/bash -c "source $HOME/.nvm/nvm.sh \
-        && nvm install lts/* \
-        && nvm alias default lts/*" 2>&1 \
-    #
-    # [Optional] For local testing instead of cloud shell
-    # Install Docker CE CLI. 
-    && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
-    && add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" \
-    && apt-get update \
-    && apt-get install -y docker-ce-cli \
-    #
-    # [Optional] For local testing instead of cloud shell
-    # Install the Azure CLI
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
-    && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
-    && apt-get update \
-    && apt-get install -y azure-cli \
-    #
-    # Install Ansible
-    && apt-get install -y libssl-dev libffi-dev python-dev python-pip \
-    && pip install ansible[azure] \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+    && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && apt-get install -y libssl-dev libffi-dev python3-dev python3-pip \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Optional installs. Use a separate RUN statement to add your own dependencies.
+ARG INSTALL_AZURE_CLI="true"
+ARG INSTALL_DOCKER="true"
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+ENV NVM_DIR=/usr/local/share/nvm \
+    NVM_SYMLINK_CURRENT=true \
+    PATH=${NVM_DIR}/current/bin:${PATH}
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    # Install Azure CLI
+    && if [ "${INSTALL_AZURE_CLI}" = "true" ]; then \
+        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
+        && curl -sL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - 2>/dev/null \
+        && apt-get update \
+        && apt-get install -y azure-cli; \
+    fi \
+    # Install Node.js
+    && if [ "${INSTALL_AZURE_CLI}" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+    # Install Docker CLI
+    && if [ "${INSTALL_DOCKER}" = "true" ]; then \
+        bash /tmp/library-scripts/docker-debian.sh "true" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}"; \
+    else \
+        echo '#!/bin/bash\n"$@"' > /usr/local/share/docker-init.sh \
+        && chmod +x /usr/local/share/docker-init.sh; \
+    fi \
+    && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# Install Ansible
+RUN pip3 install ansible[azure]
+
+ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
+CMD [ "sleep", "infinity" ]
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \
 #     && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
-

--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -20,8 +20,8 @@ ARG INSTALL_AZURE_CLI="true"
 ARG INSTALL_DOCKER="true"
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
-ENV NVM_DIR=/usr/local/share/nvm \
-    NVM_SYMLINK_CURRENT=true \
+ENV NVM_DIR=/usr/local/share/nvm
+ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/azure-ansible/.devcontainer/devcontainer.json
+++ b/containers/azure-ansible/.devcontainer/devcontainer.json
@@ -1,15 +1,24 @@
 {
 	"name": "Azure Ansible",
-	"dockerFile": "Dockerfile",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"INSTALL_AZURE_CLI": "true",
+			"INSTALL_DOCKER": "true",
+			"INSTALL_NODE": "true"
+		}
+	},
 	"mounts": [
 		// [Optional] Anisble Collections: Uncomment if you want to mount your local .ansible/collections folder.
 		// "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ansible/collections,target=/root/.ansible/collections,type=bind,consistency=cached",
-		"source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+		"source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind"
 	],
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"
 	},
+
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"vscoss.vscode-ansible",
@@ -19,10 +28,10 @@
 	]
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
+
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "ansible --version",
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
 	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
 	// "remoteUser": "vscode"
 }

--- a/containers/azure-ansible/.devcontainer/library-scripts/README.md
+++ b/containers/azure-ansible/.devcontainer/library-scripts/README.md
@@ -1,0 +1,5 @@
+# Warning: Folder contents may be replaced
+
+The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+
+To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./common-debian.sh <install zsh flag> <username> <user UID> <user GID> <upgrade packages flag>
+
+set -e
+
+INSTALL_ZSH=${1:-"true"}
+USERNAME=${2:-"$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)"}
+USER_UID=${3:-1000}
+USER_GID=${4:-1000}
+UPGRADE_PACKAGES=${5:-"true"}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo 'Script must be run a root. Use sudo or set "USER root" before running the script.'
+    exit 1
+fi
+
+# Treat a user name of "none" as root
+if [ "${USERNAME}" = "none" ] || [ "${USERNAME}" = "root" ]; then
+    USERNAME=root
+    USER_UID=0
+    USER_GID=0
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install apt-utils to avoid debconf warning
+apt-get -y install --no-install-recommends apt-utils 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 )
+
+# Get to latest versions of all packages
+if [ "${UPGRADE_PACKAGES}" = "true" ]; then
+    apt-get -y upgrade --no-install-recommends
+fi
+
+# Install common developer tools and dependencies
+apt-get -y install --no-install-recommends \
+    git \
+    openssh-client \
+    less \
+    iproute2 \
+    procps \
+    curl \
+    wget \
+    unzip \
+    nano \
+    jq \
+    lsb-release \
+    ca-certificates \
+    apt-transport-https \
+    dialog \
+    gnupg2 \
+    libc6 \
+    libgcc1 \
+    libgssapi-krb5-2 \
+    libicu[0-9][0-9] \
+    liblttng-ust0 \
+    libstdc++6 \
+    zlib1g \
+    locales
+
+# Ensure at least the en_US.UTF-8 UTF-8 locale is available.
+# Common need for both applications and things like the agnoster ZSH theme.
+echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen 
+locale-gen
+
+# Install libssl1.1 if available
+if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
+    apt-get -y install  --no-install-recommends libssl1.1
+fi
+ 
+# Install appropriate version of libssl1.0.x if available
+LIBSSL=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 || echo '')
+if [ "$(echo "$LIBSSL" | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort | wc -l)" -eq 0 ]; then
+    if [[ ! -z $(apt-cache --names-only search ^libssl1.0.2$) ]]; then
+        # Debian 9
+        apt-get -y install  --no-install-recommends libssl1.0.2
+    elif [[ ! -z $(apt-cache --names-only search ^libssl1.0.0$) ]]; then
+        # Ubuntu 18.04, 16.04, earlier
+        apt-get -y install  --no-install-recommends libssl1.0.0
+    fi
+fi
+
+# Create or update a non-root user to match UID/GID - see https://aka.ms/vscode-remote/containers/non-root-user.
+if id -u $USERNAME > /dev/null 2>&1; then
+    # User exists, update if needed
+    if [ "$USER_GID" != "$(id -G $USERNAME)" ]; then 
+        groupmod --gid $USER_GID $USERNAME 
+        usermod --gid $USER_GID $USERNAME
+    fi
+    if [ "$USER_UID" != "$(id -u $USERNAME)" ]; then 
+        usermod --uid $USER_UID $USERNAME
+    fi
+else
+    # Create user
+    groupadd --gid $USER_GID $USERNAME
+    useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME
+fi
+
+# Add add sudo support for non-root user
+apt-get install -y sudo
+echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
+chmod 0440 /etc/sudoers.d/$USERNAME
+
+# Ensure ~/.local/bin is in the PATH for root and non-root users for bash. (zsh is later)
+echo "export PATH=\$PATH:\$HOME/.local/bin" | tee -a /root/.bashrc >> /home/$USERNAME/.bashrc 
+chown $USER_UID:$USER_GID /home/$USERNAME/.bashrc
+
+# Optionally install and configure zsh
+if [ "$INSTALL_ZSH" = "true" ] && [ ! -d "/root/.oh-my-zsh" ]; then 
+    apt-get install -y zsh
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)"
+    echo "export PATH=\$PATH:\$HOME/.local/bin" >> /root/.zshrc
+    cp -R /root/.oh-my-zsh /home/$USERNAME
+    cp /root/.zshrc /home/$USERNAME
+    sed -i -e "s/\/root\/.oh-my-zsh/\/home\/$USERNAME\/.oh-my-zsh/g" /home/$USERNAME/.zshrc
+    chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc
+fi
+

--- a/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./docker-debian.sh <enable non-root docker socket access flag> <source socket> <target socket> <non-root user>
+
+set -e
+
+ENABLE_NONROOT_DOCKER=${1:-"true"}
+SOURCE_SOCKET=${2:-"/var/run/docker-host.sock"}
+TARGET_SOCKET=${3:-"/var/run/docker.sock"}
+NONROOT_USER=${4:-"vscode"}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo 'Script must be run a root. Use sudo or set "USER root" before running the script.'
+    exit 1
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install Docker CLI
+apt-get -y install  --no-install-recommends apt-transport-https ca-certificates curl gnupg2 lsb-release
+curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+echo "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
+apt-get update
+apt-get -y install --no-install-recommends docker-ce-cli
+
+# Install Docker Compose
+LATEST_COMPOSE_VERSION=$(curl -sSL "https://api.github.com/repos/docker/compose/releases/latest" | grep -o -P '(?<="tag_name": ").+(?=")')
+curl -sSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+chmod +x /usr/local/bin/docker-compose \
+
+# By default, make the source and target sockets the same
+if [ "${SOURCE_SOCKET}" != "${TARGET_SOCKET}" ]; then
+    touch "${SOURCE_SOCKET}"
+    ln -s "${SOURCE_SOCKET}" "${TARGET_SOCKET}"
+    chown -h "${NONROOT_USER}" "${TARGET_SOCKET}"
+fi
+
+# If enabling non-root access, setup socat
+if [ "${ENABLE_NONROOT_DOCKER}" = "true" ]; then
+    apt-get -y install socat
+    tee /usr/local/share/docker-init.sh << EOF 
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+set -e
+
+SOCAT_PATH_BASE=/tmp/vscr-dind-socat
+SOCAT_LOG=\${SOCAT_PATH_BASE}.log
+SOCAT_PID=\${SOCAT_PATH_BASE}.pid
+
+# Wrapper function to only use sudo if not already root
+sudoIf()
+{
+    if [ "\$(id -u)" -ne 0 ]; then
+        sudo "\$@"
+    else
+        "\$@"
+    fi
+}
+
+# Log messages
+log()
+{
+    echo -e "[\$(date)] \$@" | sudoIf tee -a \${SOCAT_LOG} > /dev/null
+}
+
+echo -e "\n** \$(date) **" | sudoIf tee -a \${SOCAT_LOG} > /dev/null
+log "Ensuring ${NONROOT_USER} has access to ${SOURCE_SOCKET} via ${TARGET_SOCKET}"
+
+# If enabled, try to add a docker group with the right GID. If the group is root, 
+# fall back on using socat to forward the docker socket to another unix socket so 
+# that we can set permissions on it without affecting the host.
+if [ "${ENABLE_NONROOT_DOCKER}" = "true" ] && [ "${SOURCE_SOCKET}" != "${TARGET_SOCKET}" ] && [ "${NONROOT_USER}" != "root" ] && [ "${NONROOT_USER}" != "0" ]; then
+    SOCKET_GID=\$(stat -c '%g' ${SOURCE_SOCKET})
+    if [ "\${SOCKET_GID}" != "0" ]; then
+        log "Adding user to group with GID \${SOCKET_GID}."
+        if [ "\$(cat /etc/group | grep :\${SOCKET_GID}:)" = "" ]; then
+            sudoIf groupadd --gid \${SOCKET_GID} docker-host
+        fi
+        # Add user to group if not already in it
+        if [ "\$(id ${NONROOT_USER} | grep -E 'groups=.+\${SOCKET_GID}\(')" = "" ]; then
+            sudoIf usermod -aG \${SOCKET_GID} ${NONROOT_USER}
+        fi
+    else
+        # Enable proxy if not already running
+        if [ ! -f "\${SOCAT_PID}" ] || ! ps -p \$(cat \${SOCAT_PID}) > /dev/null; then
+            log "Enabling socket proxy."
+            log "Proxying ${SOURCE_SOCKET} to ${TARGET_SOCKET} for vscode"
+            sudoIf rm -rf ${TARGET_SOCKET}
+            (sudoIf socat UNIX-LISTEN:${TARGET_SOCKET},fork,mode=660,user=${NONROOT_USER} UNIX-CONNECT:${SOURCE_SOCKET} 2>&1 | sudoIf tee -a \${SOCAT_LOG} > /dev/null & echo "\$!" | sudoIf tee \${SOCAT_PID} > /dev/null)
+        else
+            log "Socket proxy already running."
+        fi
+    fi
+    log "Success"
+fi
+
+# Execute whatever commands were passed in (if any). This allows us 
+# to set this script to ENTRYPOINT while still executing the default CMD.
+set +e
+"\$@"
+EOF
+else 
+    echo '/usr/bin/env bash -c "\$@"' > /usr/local/share/docker-init.sh
+fi
+chmod +x /usr/local/share/docker-init.sh

--- a/containers/azure-ansible/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/node-debian.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./node-debian.sh <directory to install nvm> <node version to install (use "none" to skip)> <non-root user>
+
+set -e
+
+export NVM_DIR=${1:-"/usr/local/share/nvm"}
+export NODE_VERSION=${2:-"lts/*"}
+NONROOT_USER=${3:-"vscode"}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo 'Script must be run a root. Use sudo or set "USER root" before running the script.'
+    exit 1
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+if [ "${NODE_VERSION}" = "none" ]; then
+    export NODE_VERSION=
+fi
+
+# Install NVM
+mkdir -p ${NVM_DIR}
+curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash 2>&1
+if [ "${NODE_VERSION}" != "" ]; then
+    /bin/bash -c "source $NVM_DIR/nvm.sh && nvm alias default ${NODE_VERSION}" 2>&1
+fi
+
+echo -e "export NVM_DIR=\"${NVM_DIR}\"\n\
+[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\"\n\
+[ -s \"\$NVM_DIR/bash_completion\" ] && \\. \"\$NVM_DIR/bash_completion\"" \
+| tee -a /home/${NONROOT_USER}/.bashrc /home/${NONROOT_USER}/.zshrc >> /root/.zshrc
+
+echo -e "if [ \"\$(stat -c '%U' \$NVM_DIR)\" != \"${NONROOT_USER}\" ]; then\n\
+    sudo chown -R ${NONROOT_USER}:root \$NVM_DIR\n\
+fi" | tee -a /root/.bashrc /root/.zshrc /home/${NONROOT_USER}/.bashrc >> /home/${NONROOT_USER}/.zshrc
+
+chown ${NONROOT_USER}:${NONROOT_USER} /home/${NONROOT_USER}/.bashrc /home/${NONROOT_USER}/.zshrc
+chown -R ${NONROOT_USER}:root ${NVM_DIR}
+
+# Install yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - 2>/dev/null
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+apt-get update
+apt-get -y install --no-install-recommends yarn

--- a/containers/azure-ansible/.npmignore
+++ b/containers/azure-ansible/.npmignore
@@ -1,5 +1,6 @@
 README.md
 test-project
 definition-manifest.json
+.devcontainer/library-scripts/README.md
 .vscode
 .npmignore

--- a/containers/azure-ansible/README.md
+++ b/containers/azure-ansible/README.md
@@ -14,9 +14,22 @@
 
 ## Using this definition with an existing folder
 
-While technically optional, this definition includes the Ansible extension. You may need an Azure account for your operations. You can create a [free trial account here](https://azure.microsoft.com/en-us/free/) and find out more about using [Ansible with Azure here](https://docs.microsoft.com/en-us/azure/ansible/ansible-overview).  If you plan to use the Azure Cloud Shell for all of your Ansible operations, you can comment out the installation of the Docker CLI in `.devcontainer/Dockerfile`. Conversely, if you do not plan to use Cloud Shell, you can comment out the installation of Node.js. The definition has been setup so you can do either as it makes sense.
+While technically optional, this definition includes the Ansible extension. You may need an Azure account for your operations. You can create a [free trial account here](https://azure.microsoft.com/en-us/free/) and find out more about using [Ansible with Azure here](https://docs.microsoft.com/en-us/azure/ansible/ansible-overview).
 
-Next, follow these steps:
+There are a few options you can pick from  by updating the following line in `.devcontainer/devcontainer.json`:
+
+```Dockerfile
+"arg": {
+   "INSTALL_AZURE_CLI": "true",
+   "INSTALL_DOCKER": "true",
+   "INSTALL_NODE": "true"
+}
+`
+If you plan to use the Azure Cloud Shell for all of your Ansible operations, you can set `"INSTALL_DOCKER": "false"`. Conversely, if you do not plan to use Cloud Shell, you can set `"INSTALL_DOCKER": "false"`. By default, both are installed so you can decide later.
+
+Beyond `git`, this `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
+
+### Adding the definition to your project
 
 1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
 

--- a/containers/azure-terraform/.devcontainer/devcontainer.json
+++ b/containers/azure-terraform/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 			"TFLINT_VERSION": "0.18.0",
 			"INSTALL_AZURE_CLI": "true",
 			"INSTALL_DOCKER": "true",
-			"INSTALL_NODE": "true"		 
+			"INSTALL_NODE": "true"
 		}
 	},
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],

--- a/containers/azure-terraform/.npmignore
+++ b/containers/azure-terraform/.npmignore
@@ -1,5 +1,6 @@
 README.md
 test-project
 definition-manifest.json
+.devcontainer/library-scripts/README.md
 .vscode
 .npmignore


### PR DESCRIPTION
This is similar to #461 but this time for `azure-ansible`. The update adds `ARG`s to allow people to select what to install/not install from `devcontainer.json` and switches the definition to use common scripts to simplify future maintenance.

@cmendible - Let me know if this looks good to merge to you.