### PR TITLE
Update Ruby-based definitions to use new pre-built dev containers Ruby definition

### DIFF
--- a/containers/jekyll/.devcontainer/Dockerfile
+++ b/containers/jekyll/.devcontainer/Dockerfile
@@ -11,6 +11,10 @@ ENV LANG=en_US.UTF-8 \
     # Install jekyll
 RUN gem install bundler jekyll
 
+# Install a version of Node.js using nvm
+ARG NODE_VERSION="lts/*"
+RUN sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}" 2>&1
+
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \
 #     && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/jekyll/.devcontainer/Dockerfile
+++ b/containers/jekyll/.devcontainer/Dockerfile
@@ -11,14 +11,16 @@ ENV LANG=en_US.UTF-8 \
     # Install jekyll
 RUN gem install bundler jekyll
 
-# Install a version of Node.js using nvm
+# Install a version of Node.js using nvm for dynamic front end content
 ARG NODE_VERSION="lts/*"
-RUN sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}" 2>&1
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update \
-#     && export DEBIAN_FRONTEND=noninteractive \
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
 # [Optional] Uncomment this line to install additional gems.
 # RUN gem install <your-gem-names-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/containers/jekyll/.devcontainer/Dockerfile
+++ b/containers/jekyll/.devcontainer/Dockerfile
@@ -1,65 +1,20 @@
-FROM debian:10
-
-# This Dockerfile adds a non-root 'vscode' user with sudo access. However, for Linux,
-# this user's GID/UID must match your local user UID/GID to avoid permission issues
-# with bind mounts. Update USER_UID / USER_GID if yours is not 1000. See
-# https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:2
 
 # ENV Variables required by Jekyll
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US:en
-ENV TZ=America/Chicago
-ENV LC_ALL=en_US.UTF-8
-ENV LANG=en_US.UTF-8
-ENV LANGUAGE=en_US
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    TZ=America/Chicago \
+    LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US
 
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-RUN apt-get update \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    #
-    # Install vim, git, process tools, lsb-release
-    && apt-get install -y \
-        git \
-        openssh-client \
-        less \
-    #
-    # Install ruby
-    && apt-get install -y \
-        make \
-        ruby-full \
-		build-essential \
-        zlib1g-dev \
-        locales \
-    #
-    # Add en_US.UTF-8 locale
-    && echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen \
-    #
-    # Generate locale files
-    && locale-gen \
-    #
     # Install jekyll
-    && gem install \
-        bundler \
-        jekyll \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+RUN gem install bundler jekyll
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \
 #     && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install additional gems.
+# RUN gem install <your-gem-names-here>

--- a/containers/jekyll/.devcontainer/devcontainer.json
+++ b/containers/jekyll/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
 	"name": "Jekyll",
-	"dockerFile": "Dockerfile",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"NODE_VERSION": "lts/*"
+		}	
+	},
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -1,36 +1,13 @@
-# Update the VARIANT arg in devcontainer.json to pick a Ruby version: 2, 2.7, 2.6, 2.5
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/master/containers/ruby/.devcontainer/base.Dockerfile
 ARG VARIANT=2
-FROM ruby:${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
-# Options for setup script
-ARG INSTALL_ZSH="true"
-ARG UPGRADE_PACKAGES="false"
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+# Install Rails
+RUN gem install rails webdrivers 
 
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY library-scripts/common-debian.sh /tmp/library-scripts/
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
-    && apt-get install -y build-essential libsqlite3-dev zlib1g-dev libxml2  \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/library-scripts
-
-# Install Ruby tools, rails
-RUN gem install rake ruby-debug-ide debase rails webdrivers 
-
-# [Optional] Install Node.js for use with web applications - update the INSTALL_NODE arg in devcontainer.json to enable.
-ARG INSTALL_NODE="false"
+# Install a version of Node.js using nvm
 ARG NODE_VERSION="lts/*"
-ENV NVM_DIR=/usr/local/share/nvm \
-    NVM_SYMLINK_CURRENT=true \
-    PATH=${NVM_DIR}/current/bin:${PATH}
-COPY library-scripts/node-debian.sh /tmp/library-scripts/
-RUN if [ "$INSTALL_NODE" = "true" ]; then \
-        /bin/bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
-        && apt-get clean -y && rm -rf /var/lib/apt/lists/*; \
-    fi \
-    && rm -rf /tmp/library-scripts
+RUN sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}" 2>&1
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \
@@ -39,3 +16,4 @@ RUN if [ "$INSTALL_NODE" = "true" ]; then \
 
 # [Optional] Uncomment this line to install additional gems.
 # RUN gem install <your-gem-names-here>
+

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -1,4 +1,3 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/master/containers/ruby/.devcontainer/base.Dockerfile
 ARG VARIANT=2
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -4,15 +4,16 @@ FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 # Install Rails
 RUN gem install rails webdrivers 
 
-# Install a version of Node.js using nvm
+# Install a version of Node.js using nvm for dynamic front end content
 ARG NODE_VERSION="lts/*"
-RUN sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}" 2>&1
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update \
-#     && export DEBIAN_FRONTEND=noninteractive \
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
 # [Optional] Uncomment this line to install additional gems.
 # RUN gem install <your-gem-names-here>
 
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/containers/ruby-rails/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails/.devcontainer/devcontainer.json
@@ -5,8 +5,6 @@
 		"args": { 
 			// Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5
 			"VARIANT": "2",
-			// Options
-			"INSTALL_NODE": "true",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -1,4 +1,3 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/master/containers/ruby/.devcontainer/base.Dockerfile
 ARG VARIANT=2
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -4,14 +4,16 @@ FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 # Install Sinatra
 RUN gem install sinatra sinatra-reloader thin data_mapper dm-sqlite-adapter 
 
-# Install a version of Node.js using nvm
+# Install a version of Node.js using nvm for dynamic front end content
 ARG NODE_VERSION="lts/*"
-RUN sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}" 2>&1
+RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update \
-#     && export DEBIAN_FRONTEND=noninteractive \
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
 # [Optional] Uncomment this line to install additional gems.
 # RUN gem install <your-gem-names-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -1,36 +1,13 @@
-# Update the VARIANT arg in devcontainer.json to pick a Ruby version: 2, 2.7, 2.6, 2.5
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/blob/master/containers/ruby/.devcontainer/base.Dockerfile
 ARG VARIANT=2
-FROM ruby:${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
-# Options for setup script
-ARG INSTALL_ZSH="true"
-ARG UPGRADE_PACKAGES="false"
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
+# Install Sinatra
+RUN gem install sinatra sinatra-reloader thin data_mapper dm-sqlite-adapter 
 
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY library-scripts/common-debian.sh /tmp/library-scripts/
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
-    && apt-get install -y build-essential libsqlite3-dev  \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/library-scripts
-
-# Install Ruby tools, Sinatra
-RUN gem install rake ruby-debug-ide debase sinatra sinatra-reloader thin data_mapper dm-sqlite-adapter 
-
-# [Optional] Install Node.js for use with web applications - update the INSTALL_NODE arg in devcontainer.json to enable.
-ARG INSTALL_NODE="false"
+# Install a version of Node.js using nvm
 ARG NODE_VERSION="lts/*"
-ENV NVM_DIR=/usr/local/share/nvm \
-    NVM_SYMLINK_CURRENT=true \
-    PATH=${NVM_DIR}/current/bin:${PATH}
-COPY library-scripts/node-debian.sh /tmp/library-scripts/
-RUN if [ "$INSTALL_NODE" = "true" ]; then \
-        /bin/bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
-        && apt-get clean -y && rm -rf /var/lib/apt/lists/*; \
-    fi \
-    && rm -rf /tmp/library-scripts
+RUN sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}" 2>&1
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \

--- a/containers/ruby-sinatra/.devcontainer/devcontainer.json
+++ b/containers/ruby-sinatra/.devcontainer/devcontainer.json
@@ -5,8 +5,6 @@
 		"args": { 
 			// Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5
 			"VARIANT": "2",
-			// Options
-			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -4,9 +4,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 # [Optional] Install a version of Node.js using nvm
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then \
-        sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}"; \
-    fi
+RUN if [ "${INSTALL_NODE}" = "true" ]; then sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}" 2>&1; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -1,16 +1,17 @@
 ARG VARIANT=2
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
-# [Optional] Install a version of Node.js using nvm
+# [Optional] Install a version of Node.js using nvm for front end dev
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then sudo -u vscode bash -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION}" 2>&1; fi
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update \
-#     && export DEBIAN_FRONTEND=noninteractive \
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
 # [Optional] Uncomment this line to install additional gems.
 # RUN gem install <your-gem-names-here>
 
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1


### PR DESCRIPTION
This PR switches the RoR, Ruby Sinatra, and Jekyll definitions to use the pre-built MCR Ruby image that contains most of what the Dockerfiles in these definitions added. This is related to #154 

//cc: @cmendible as FYI