### PR TITLE
Onboard java to build

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -109,6 +109,30 @@ As for any pre-built image usage, it is the image user's responsibility to ensur
 that any use of this image complies with any relevant licenses for all software 
 contained within.
 
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+openjdk - https://hub.docker.com/_/openjdk
+
+License
+View license information<http://openjdk.java.net/legal/gplv2+ce.html> for the 
+software contained in this image.
+
+As with all Docker images, these likely also contain other software which may 
+be under other licenses (such as Bash, etc from the base distribution, along
+with any direct or indirect dependencies of the primary software being contained).
+
+Some additional license information which was able to be auto-detected might be 
+found in the repo-info repository's openjdk/ directory
+<https://github.com/docker-library/repo-info/tree/master/repos/openjdk>.
+
+As for any pre-built image usage, it is the image user's responsibility to ensure 
+that any use of this image complies with any relevant licenses for all software 
+contained within.
+
+
 ---------------------------------------------------------
 
 ---------------------------------------------------------

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -1,46 +1,32 @@
-# Update the VARIANT arg in devcontainer.json to pick a Java version >= 11
 ARG VARIANT=11
-FROM openjdk:${VARIANT}-jdk-buster
+FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
-# Options for setup script
-ARG INSTALL_ZSH="true"
-ARG UPGRADE_PACKAGES="false"
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY library-scripts/*.sh /tmp/library-scripts/
-RUN /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
-    && if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/common-debian.sh
+# [Optional] Install a version of Node.js using nvm for front end dev
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Install Maven
 ARG INSTALL_MAVEN="false"
 ARG MAVEN_VERSION=3.6.3
 ARG MAVEN_DOWNLOAD_SHA="no-check"
 ENV MAVEN_HOME=/usr/local/share/maven
+COPY library-scripts/maven-debian.sh /tmp/library-scripts/
 RUN if [ "${INSTALL_MAVEN}" = "true" ]; then /bin/bash /tmp/library-scripts/maven-debian.sh ${MAVEN_VERSION} ${MAVEN_HOME} ${USERNAME} ${MAVEN_DOWNLOAD_SHA}; fi \
-    && rm -f /tmp/library-scripts/maven-debian.sh
+    && rm -f /tmp/library-scripts
 
 # [Optional] Install Gradle
 ARG INSTALL_GRADLE="false"
 ARG GRADLE_VERSION=5.4.1
 ARG GRADLE_DOWNLOAD_SHA="no-check"
 ENV GRADLE_HOME=/usr/local/share/gradle
+COPY library-scripts/maven-gradle.sh /tmp/library-scripts/
 RUN if [ "${INSTALL_GRADLE}" = "true" ]; then /bin/bash /tmp/library-scripts/gradle-debian.sh ${GRADLE_VERSION} ${GRADLE_HOME} ${USERNAME} ${GRADLE_DOWNLOAD_SHA}; fi \
-    && rm -f /tmp/library-scripts/gradle-debian.sh
-
-# [Optional] Install Node.js for use with web applications - update the INSTALL_NODE arg in devcontainer.json to enable.
-ARG INSTALL_NODE="false"
-ARG NODE_VERSION="lts/*"
-ENV NVM_DIR=/usr/local/share/nvm
-ENV NVM_SYMLINK_CURRENT=true \
-    PATH=${NVM_DIR}/current/bin:${PATH}
-COPY library-scripts/node-debian.sh /tmp/library-scripts/
-RUN if [ "$INSTALL_NODE" = "true" ]; then /bin/bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/node-debian.sh
+    && rm -f /tmp/library-scripts
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -20,7 +20,7 @@ ARG INSTALL_GRADLE="false"
 ARG GRADLE_VERSION=5.4.1
 ARG GRADLE_DOWNLOAD_SHA="no-check"
 ENV GRADLE_HOME=/usr/local/share/gradle
-COPY library-scripts/maven-gradle.sh /tmp/library-scripts/
+COPY library-scripts/gradle-debian.sh /tmp/library-scripts/
 RUN if [ "${INSTALL_GRADLE}" = "true" ]; then /bin/bash /tmp/library-scripts/gradle-debian.sh ${GRADLE_VERSION} ${GRADLE_HOME} ${USERNAME} ${GRADLE_DOWNLOAD_SHA}; fi \
     && rm -f /tmp/library-scripts
 

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -12,8 +12,8 @@ ARG MAVEN_VERSION=3.6.3
 ARG MAVEN_DOWNLOAD_SHA="no-check"
 ENV MAVEN_HOME=/usr/local/share/maven
 COPY library-scripts/maven-debian.sh /tmp/library-scripts/
-RUN if [ "${INSTALL_MAVEN}" = "true" ]; then /bin/bash /tmp/library-scripts/maven-debian.sh ${MAVEN_VERSION} ${MAVEN_HOME} ${USERNAME} ${MAVEN_DOWNLOAD_SHA}; fi \
-    && rm -f /tmp/library-scripts
+RUN if [ "${INSTALL_MAVEN}" = "true" ]; then bash /tmp/library-scripts/maven-debian.sh ${MAVEN_VERSION} ${MAVEN_HOME} ${USERNAME} ${MAVEN_DOWNLOAD_SHA}; fi \
+    && rm -f /tmp/library-scripts/maven-debian.sh
 
 # [Optional] Install Gradle
 ARG INSTALL_GRADLE="false"
@@ -21,8 +21,8 @@ ARG GRADLE_VERSION=5.4.1
 ARG GRADLE_DOWNLOAD_SHA="no-check"
 ENV GRADLE_HOME=/usr/local/share/gradle
 COPY library-scripts/gradle-debian.sh /tmp/library-scripts/
-RUN if [ "${INSTALL_GRADLE}" = "true" ]; then /bin/bash /tmp/library-scripts/gradle-debian.sh ${GRADLE_VERSION} ${GRADLE_HOME} ${USERNAME} ${GRADLE_DOWNLOAD_SHA}; fi \
-    && rm -f /tmp/library-scripts
+RUN if [ "${INSTALL_GRADLE}" = "true" ]; then bash /tmp/library-scripts/gradle-debian.sh ${GRADLE_VERSION} ${GRADLE_HOME} ${USERNAME} ${GRADLE_DOWNLOAD_SHA}; fi \
+    && rm -f /tmp/library-scripts/gradle-debian.sh
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -1,0 +1,46 @@
+# Update the VARIANT arg in devcontainer.json to pick a Java version: 11, 14
+ARG VARIANT=11
+FROM openjdk:${VARIANT}-jdk-buster
+
+# Options for setup script
+ARG INSTALL_ZSH="true"
+ARG UPGRADE_PACKAGES="false"
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
+COPY library-scripts/*.sh /tmp/library-scripts/
+RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /vscode-java-home/runtime.tar.gz /tmp/library-scripts
+
+# [Optional] Install Maven
+ARG INSTALL_MAVEN="false"
+ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_DOWNLOAD_SHA="no-check"
+ENV MAVEN_HOME=/usr/local/share/maven
+RUN if [ "${INSTALL_MAVEN}" = "true" ]; then /bin/bash /tmp/library-scripts/maven-debian.sh ${MAVEN_VERSION} ${MAVEN_HOME} ${USERNAME} ${MAVEN_DOWNLOAD_SHA}; fi \
+    && rm -f /tmp/library-scripts/maven-debian.sh
+
+# [Optional] Install Gradle
+ARG INSTALL_GRADLE="false"
+ARG GRADLE_VERSION=5.4.1
+ARG GRADLE_DOWNLOAD_SHA="no-check"
+ENV GRADLE_HOME=/usr/local/share/gradle
+RUN if [ "${INSTALL_GRADLE}" = "true" ]; then /bin/bash /tmp/library-scripts/gradle-debian.sh ${GRADLE_VERSION} ${GRADLE_HOME} ${USERNAME} ${GRADLE_DOWNLOAD_SHA}; fi \
+    && rm -f /tmp/library-scripts/gradle-debian.sh
+
+# [Optional] Install Node.js for use with web applications - update the INSTALL_NODE arg in devcontainer.json to enable.
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="none"
+ENV NVM_DIR=/usr/local/share/nvm
+ENV NVM_SYMLINK_CURRENT=true \
+    PATH=${NVM_DIR}/current/bin:${PATH}
+COPY library-scripts/node-debian.sh /tmp/library-scripts/
+RUN if [ "$INSTALL_NODE" = "true" ]; then /bin/bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/node-debian.sh
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -2,25 +2,24 @@
 ARG VARIANT=11
 FROM openjdk:${VARIANT}-jdk-buster
 
-# Options for setup script
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG INSTALL_ZSH="true"
 ARG UPGRADE_PACKAGES="false"
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY library-scripts/*.sh /tmp/library-scripts/
+COPY library-scripts/common-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
     && if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /vscode-java-home/runtime.tar.gz /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 # [Optional] Install Maven
 ARG INSTALL_MAVEN="false"
 ARG MAVEN_VERSION=3.6.3
 ARG MAVEN_DOWNLOAD_SHA="no-check"
 ENV MAVEN_HOME=/usr/local/share/maven
-RUN if [ "${INSTALL_MAVEN}" = "true" ]; then /bin/bash /tmp/library-scripts/maven-debian.sh ${MAVEN_VERSION} ${MAVEN_HOME} ${USERNAME} ${MAVEN_DOWNLOAD_SHA}; fi \
+COPY library-scripts/maven-debian.sh /tmp/library-scripts/
+RUN if [ "${INSTALL_MAVEN}" = "true" ]; then bash /tmp/library-scripts/maven-debian.sh ${MAVEN_VERSION} ${MAVEN_HOME} ${USERNAME} ${MAVEN_DOWNLOAD_SHA}; fi \
     && rm -f /tmp/library-scripts/maven-debian.sh
 
 # [Optional] Install Gradle
@@ -28,7 +27,8 @@ ARG INSTALL_GRADLE="false"
 ARG GRADLE_VERSION=5.4.1
 ARG GRADLE_DOWNLOAD_SHA="no-check"
 ENV GRADLE_HOME=/usr/local/share/gradle
-RUN if [ "${INSTALL_GRADLE}" = "true" ]; then /bin/bash /tmp/library-scripts/gradle-debian.sh ${GRADLE_VERSION} ${GRADLE_HOME} ${USERNAME} ${GRADLE_DOWNLOAD_SHA}; fi \
+COPY library-scripts/gradle-debian.sh /tmp/library-scripts/
+RUN if [ "${INSTALL_GRADLE}" = "true" ]; then bash /tmp/library-scripts/gradle-debian.sh ${GRADLE_VERSION} ${GRADLE_HOME} ${USERNAME} ${GRADLE_DOWNLOAD_SHA}; fi \
     && rm -f /tmp/library-scripts/gradle-debian.sh
 
 # [Optional] Install Node.js for use with web applications - update the INSTALL_NODE arg in devcontainer.json to enable.
@@ -38,7 +38,7 @@ ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
 COPY library-scripts/node-debian.sh /tmp/library-scripts/
-RUN if [ "$INSTALL_NODE" = "true" ]; then /bin/bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/node-debian.sh
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -1,17 +1,15 @@
 {
 	"name": "Java",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "base.Dockerfile",
 		"args": {
-			// Update the VARIANT arg to pick a Java version >= 11
+			// Update the VARIANT arg to pick a Java version: 11, 14
 			"VARIANT": "11",
-			// Options to install Maven or Gradle
-			"INSTALL_MAVEN": "true",
+			// Options
+			"INSTALL_MAVEN": "false",
 			"MAVEN_VERSION": "3.6.3",
-			"MAVEN_DOWNLOAD_SHA": "c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0",
-			"INSTALL_GRADLE": "true",
+			"INSTALL_GRADLE": "false",
 			"GRADLE_VERSION": "5.4.1",
-			"GRADLE_DOWNLOAD_SHA": "7bdbad1e4f54f13c8a78abc00c26d44dd8709d4aedb704d913fb1bb78ac025dc",
 			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"
 		}

--- a/containers/java/.devcontainer/library-scripts/gradle-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/gradle-debian.sh
@@ -29,32 +29,24 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 # Treat a user name of "none" or non-existant user as root
-if [ "${USERNAME}" = "none" ] && ! id -u ${USERNAME} > /dev/null 2>&1; then
+if [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
     USERNAME=root
 fi
 
-# Install curl, apt-get dependencies if missing
-if ! type curl > /dev/null 2>&1; then
+# Install curl, unzip if missing
+if ! dpkg -s curl ca-certificates unzip > /dev/null 2>&1; then
     export DEBIAN_FRONTEND=noninteractive
     if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
         apt-get update
     fi
-    apt-get -y install --no-install-recommends ca-certificates curl gnupg2
+    apt-get -y install --no-install-recommends curl ca-certificates unzip
 fi
 
-# Function to su if user exists and is not root
-suIf() {
-    if [ "${USERNAME}" != "root" ]; then
-        su ${USERNAME} -c "$@"
-    else
-        "$@"
-    fi
-}
 
 # Install Gradle
 echo "Downloading Gradle..."
-suIf "$(cat \
-<< EOF
+su ${USERNAME} -c "$(cat << EOF
+    set -e
     mkdir -p /tmp/downloads
     curl -sSL --output /tmp/downloads/archive-gradle.zip https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
     ([ "${GRADLE_DOWNLOAD_SHA}" = "no-check" ] || echo "${GRADLE_DOWNLOAD_SHA} */tmp/downloads/archive-gradle.zip" | sha256sum --check - )

--- a/containers/java/.devcontainer/library-scripts/maven-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/maven-debian.sh
@@ -66,7 +66,7 @@ echo "Downloading Maven..."
 suIf "$(cat \
 << EOF
     curl -fsSL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-    ([ "${MAVEN_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${MAVEN_DOWNLOAD_SHA} */tmp/maven.tar.gz" | sha512sum -c - )
+    ([ "${MAVEN_DOWNLOAD_SHA}" = "no-check" ] || echo "${MAVEN_DOWNLOAD_SHA} */tmp/maven.tar.gz" | sha512sum -c - )
     tar -xzf /tmp/maven.tar.gz -C ${MAVEN_HOME} --strip-components=1
     rm -f /tmp/maven.tar.gz
 EOF

--- a/containers/java/.npmignore
+++ b/containers/java/.npmignore
@@ -2,5 +2,7 @@ README.md
 test-project
 definition-manifest.json
 .devcontainer/library-scripts/README.md
+.devcontainer/library-scripts/common-debian.sh
+.devcontainer/library-scripts/node-debian.sh
 .vscode
 .npmignore

--- a/containers/java/README.md
+++ b/containers/java/README.md
@@ -25,6 +25,7 @@ While this definition should work unmodified, you can select the version of Java
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
+- `mcr.microsoft.com/vscode/devcontainers/java` (latest)
 - `mcr.microsoft.com/vscode/devcontainers/java:11`
 - `mcr.microsoft.com/vscode/devcontainers/java:14`
 

--- a/containers/java/README.md
+++ b/containers/java/README.md
@@ -8,6 +8,9 @@
 |----------|-------|
 | *Contributors* | The VS Code Java Team |
 | *Definition type* | Dockerfile |
+| *Published images* | mcr.microsoft.com/vscode/devcontainers/java |
+| *Available image variants* | 11, 14 |
+| *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Languages, platforms* | Java |
@@ -19,6 +22,19 @@ While this definition should work unmodified, you can select the version of Java
 ```json
 "args": { "VARIANT": "14" }
 ```
+
+You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
+
+- `mcr.microsoft.com/vscode/devcontainers/java:11`
+- `mcr.microsoft.com/vscode/devcontainers/java:14`
+
+Version specific tags tied to [releases in this repository](https://github.com/microsoft/vscode-dev-containers/releases) are also available.
+
+- `mcr.microsoft.com/vscode/devcontainers/java:0-11`
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.135-11`
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.135.0-11`
+
+Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 ### Debug Configuration
 
@@ -42,7 +58,7 @@ You can opt to install a version of Maven or Gradle by adding `"INSTALL_MAVEN: "
 
 Remove the appropriate arg or set its value to `"false"` to skip installing the specified tool.
 
-You can also specify the verison of Gradle or Maven if needed.
+You can also specify the version of Gradle or Maven if needed.
 
 ```json
 "args": { 

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["8", "11", "14"],
+	"variants": ["11", "14"],
 	"build": {
 		"latest": "true",
 		"rootDistro": "debian",
@@ -9,7 +9,7 @@
 	},
 	"dependencies": {
 		"image": "openjdk:${VARIANT}-jdk-buster",
-		"imageLink": "https://hub.docker.com/_/ruby",
+		"imageLink": "https://hub.docker.com/_/java",
 		"debian": [
 			"apt-utils", 
 			"dialog", 

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,0 +1,64 @@
+{
+	"variants": ["8", "11", "14"],
+	"build": {
+		"latest": "true",
+		"rootDistro": "debian",
+		"tags": [
+			"java:${VERSION}-${VARIANT}"
+		]
+	},
+	"dependencies": {
+		"image": "openjdk:${VARIANT}-jdk-buster",
+		"imageLink": "https://hub.docker.com/_/ruby",
+		"debian": [
+			"apt-utils", 
+			"dialog", 
+			"ca-certificates",
+			"git",
+			"iproute2",
+			"procps",
+			"curl",
+			"openssh-client",
+			"less",
+			"nano",
+			"gnupg",
+			"jq",
+			"wget",
+			"unzip",
+			"lsb-release",
+			"apt-transport-https",
+			"libc6",
+			"libgcc1",
+			"libgssapi-krb5-2",
+			"libicu[0-9][0-9]",
+			"libssl1.1",
+			"libstdc++6",
+			"zlib1g",
+			"sudo",
+			"zsh",
+			"build-essential",
+			"yarn"
+		],
+		"manual": [
+			{
+				"Component": {
+					"Type": "git",
+					"git": {
+						"Name": "Oh My Zsh!",
+						"repositoryUrl": "https://github.com/robbyrussell/oh-my-zsh",
+						"commitHash": "c130aadb6a66aa680a322c08d87ad773316f713d"
+					}
+				}
+			}, {
+				"Component": {
+					"Type": "git",
+					"git": {
+						"Name": "Nvm",
+						"repositoryUrl": "https://github.com/nvm-sh/nvm",
+						"commitHash": "f355b327d6a2a4e8020e943974086d53f00f9a02"
+					}
+				}
+			}
+		]
+	}
+}

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["11", "14"],
+	"variants": [ "14", "11"],
 	"build": {
 		"latest": "true",
 		"rootDistro": "debian",

--- a/script-library/maven-debian.sh
+++ b/script-library/maven-debian.sh
@@ -39,7 +39,7 @@ if ! type curl > /dev/null 2>&1; then
     if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
         apt-get update
     fi
-    apt-get -y install --no-install-recommends ca-certificates curl gnupg2
+    apt-get -y install --no-install-recommends ca-certificates curl
 fi
 
 # Function to su if user exists and is not root
@@ -66,7 +66,7 @@ echo "Downloading Maven..."
 suIf "$(cat \
 << EOF
     curl -fsSL -o /tmp/maven.tar.gz https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-    ([ "${MAVEN_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${MAVEN_DOWNLOAD_SHA} */tmp/maven.tar.gz" | sha512sum -c - )
+    ([ "${MAVEN_DOWNLOAD_SHA}" = "no-check" ] || echo "${MAVEN_DOWNLOAD_SHA} */tmp/maven.tar.gz" | sha512sum -c - )
     tar -xzf /tmp/maven.tar.gz -C ${MAVEN_HOME} --strip-components=1
     rm -f /tmp/maven.tar.gz
 EOF


### PR DESCRIPTION
This PR on-boards the java container into the image build process and is part of work for #154.

Currently it will output the following image variants for Java versions:

```
mcr.microsoft.com/vscode/devcontainers/java:11
mcr.microsoft.com/vscode/devcontainers/java:14
```

...based on the [contents of `base.Dockerfile`](https://github.com/microsoft/vscode-dev-containers/blob/clantz/onboard-java/containers/java/.devcontainer/base.Dockerfile). 

Note that we generally we drop no longer supported versions of Java from the build process once the version is out of support. However, existing tags, just with an older image. 

**Note that this does not include Java 8** because the Java extension seems to require it be set to Java home, and there appears to be no good way with symlinks to get this to work consistently because `"java.configuration.runtimes"` appears to force you to enter a specific `"name"` value. It would need its own dedicated build.  (As an aside, I'm really surprised there isn't a `"java.extension.home"` property or something like that added.)

In the next VS Code release, the default Dockerfile in the container will use [this instead](https://github.com/microsoft/vscode-dev-containers/blob/clantz/onboard-java/containers/java/.devcontainer/Dockerfile), but without the "dev-" prefix. The image includes `nvm`, but doesn't install Node in the image since it isn't always needed for Java development, but can be useful in web development involving Java.  

It also has scripts to install Maven and Gradle referenced from both dockerfiles, but they are not in the image given `mvnw` / `gradlew` are often used.

//cc: @testforstephen @akaroml - Let me know what you think.