### PR TITLE
Prevent docker scripts to spawn yet another process

### DIFF
--- a/script-library/docker-debian.sh
+++ b/script-library/docker-debian.sh
@@ -145,8 +145,7 @@ fi
 
 # Execute whatever commands were passed in (if any). This allows us 
 # to set this script to ENTRYPOINT while still executing the default CMD.
-set +e
-"\$@"
+exec "\$@"
 EOF
 chmod +x /usr/local/share/docker-init.sh
 chown ${USERNAME}:root /usr/local/share/docker-init.sh

--- a/script-library/docker-redhat.sh
+++ b/script-library/docker-redhat.sh
@@ -125,8 +125,7 @@ fi
 
 # Execute whatever commands were passed in (if any). This allows us 
 # to set this script to ENTRYPOINT while still executing the default CMD.
-set +e
-"\$@"
+exec "\$@"
 EOF
 else 
     echo '/usr/bin/env bash -c "\$@"' > /usr/local/share/docker-init.sh


### PR DESCRIPTION
The exec replaces the current process with the new process, so we don't have yet another process running in the process tree.