### PR TITLE
Add nvm to Python image

### DIFF
--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -1,5 +1,10 @@
 ARG VARIANT=3
-FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/python:dev-${VARIANT}
+
+# [Optional] Install a version of Node.js using nvm for front end dev
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/
@@ -7,6 +12,8 @@ FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 #    && rm -rf /tmp/pip-tmp
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update \
-#     && export DEBIAN_FRONTEND=noninteractive \
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -2,21 +2,18 @@
 ARG VARIANT=3
 FROM python:${VARIANT}
 
-# Options for common setup script
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG INSTALL_ZSH="true"
 ARG UPGRADE_PACKAGES="true"
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
+COPY .devcontainer/library-scripts/common-debian.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install common packages, non-root user
-    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
-    # Clean up
+    && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 # Setup default python tools in a venv via pipx to avoid conflicts
@@ -42,13 +39,24 @@ RUN mkdir -p ${PIPX_BIN_DIR} \
     && chown -R ${USER_UID}:${USER_GID} ${PIPX_HOME} \
     && rm -rf /tmp/pip-tmp
 
+# [Optional] Install Node.js for use with web applications - update the INSTALL_NODE arg in devcontainer.json to enable.
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="none"
+ENV NVM_DIR=/usr/local/share/nvm
+ENV NVM_SYMLINK_CURRENT=true \
+    PATH=${NVM_DIR}/current/bin:${PATH}
+COPY .devcontainer/library-scripts/node-debian.sh /tmp/library-scripts/
+RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/
 # RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
 #    && rm -rf /tmp/pip-tmp
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update \
-#     && export DEBIAN_FRONTEND=noninteractive \
-#    && apt-get -y install --no-install-recommends <your-package-list-here>
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
 
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -3,8 +3,13 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
-		// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8 
-		"args": { "VARIANT": "3" }
+		"args": { 
+			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8 
+			"VARIANT": "3",
+			// Options
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*"
+		}
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/containers/python-3/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/node-debian.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user]
+
+export NVM_DIR=${1:-"/usr/local/share/nvm"}
+export NODE_VERSION=${2:-"lts/*"}
+USERNAME=${3:-"vscode"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Treat a user name of "none" or non-existant user as root
+if [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+if [ "${NODE_VERSION}" = "none" ]; then
+    export NODE_VERSION=
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, apt-transport-https, tar, or gpg if missing
+if ! dpkg -s apt-transport-https curl ca-certificates tar > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates tar gnupg2
+fi
+
+# Install yarn
+if type yarn > /dev/null 2>&1; then
+    echo "Yarn already installed."
+else
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+    apt-get update
+    apt-get -y install --no-install-recommends yarn
+fi
+
+# Install the specified node version if NVM directory already exists, then exit
+if [ -d "${NVM_DIR}" ]; then
+    echo "NVM already installed."
+    if [ "${NODE_VERSION}" != "" ]; then
+       su ${USERNAME} -c "nvm install ${NODE_VERSION}"
+    fi
+    exit 0
+fi
+
+mkdir -p ${NVM_DIR}
+
+NVM_INIT=$(cat <<EOF
+export NVM_DIR="${NVM_DIR}"
+[ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"
+[ -s "\$NVM_DIR/bash_completion" ] && . "\$NVM_DIR/bash_completion"
+if [ "\$(stat -c '%U' \$NVM_DIR)" != "${USERNAME}" ]; then
+    sudo chown -R ${USERNAME}:root \$NVM_DIR
+fi
+EOF
+)
+
+echo "${NVM_INIT}" | tee -a /root/.bashrc /root/.zshrc >> /etc/skel/.bashrc 
+# Set up non-root user if applicable
+if [ "${USERNAME}" != "root" ]; then   
+    # Add NVM init and add code to update NVM ownership if UID/GID changes
+    echo "${NVM_INIT}" | tee -a /home/${USERNAME}/.bashrc >> /home/${USERNAME}/.zshrc
+    chown ${USERNAME} ${NVM_DIR} /home/${USERNAME}/.bashrc /home/${USERNAME}/.zshrc
+fi
+
+# Run NVM installer as non-root if needed
+su ${USERNAME} -c "$(cat << EOF
+    set -e
+    curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash 
+    if [ "${NODE_VERSION}" != "" ]; then
+        source $NVM_DIR/nvm.sh
+        nvm alias default ${NODE_VERSION}
+    fi
+EOF
+)" 2>&1
+
+echo "Done!"

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -42,6 +42,18 @@ Alternatively, you can use the contents of `base.Dockerfile` to fully customize 
 
 Beyond Python and `git`, this image / `Dockerfile` includes a number of Python tools, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
+### Installing Node.js
+
+Given how frequently Python-based web applications use Node.js for front end code, this container also includes Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
+
+```json
+"args": {
+    "VARIANT": "3",
+    "INSTALL_NODE": "true",
+    "NODE_VERSION": "10"
+}
+```
+
 #### Installing or updating Python utilities
 
 This container installs all Python development utilities using [pipx](https://pipxproject.github.io/pipx/) to avoid impacting the global Python environment. You can use this same utility add additional utilities in an isolated environment. For example:


### PR DESCRIPTION
"How do I add node" is a common question for images here that are used frequently with web-based development.  This PR adds nvm to the Python base image and an optional arg to install Node.js using it as a part of #470.
