### PR TITLE
Move bash definition to Debian/Ubuntu

### DIFF
--- a/containers/bash/.devcontainer/Dockerfile
+++ b/containers/bash/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:alpine
+FROM mcr.microsoft.com/vscode/devcontainers/base:buster
 WORKDIR /src
 
 # [Optional] Uncomment this section to install additional OS packages you may want.

--- a/containers/bash/.devcontainer/Dockerfile
+++ b/containers/bash/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+# [Choice] Debian / Ubuntu version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT=debian-10
+FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 WORKDIR /src
 
 # [Optional] Uncomment this section to install additional OS packages you may want.

--- a/containers/bash/.devcontainer/devcontainer.json
+++ b/containers/bash/.devcontainer/devcontainer.json
@@ -1,7 +1,9 @@
 {
 	"name": "Bash (Community)",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
+		"args": { "VARIANT": "debian-10" }
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/containers/bash/README.md
+++ b/containers/bash/README.md
@@ -8,7 +8,7 @@
 | --------------------------- | -------------------------------------------- |
 | *Contributors*              | [Aaryn Smith](https://gitlab.com/aarynsmith) |
 | *Definition type*           | Dockerfile                                   |
-| *Works in Codespaces*       | No                                          |
+| *Works in Codespaces*       | Yes                                          |
 | *Container host OS support* | Linux, macOS, Windows                        |
 | *Languages, platforms*      | Bash                                         |
 


### PR DESCRIPTION
Updates the bash definition to use a choice of Debian / Ubuntu to ensure it works in GitHub Codespaces - technically could set variant to "alpine" as well.

//cc: @AarynSmith given you contributed the definition