### PR TITLE
Onboard Anaconda and Miniconda to image build

### DIFF
--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -15,6 +15,8 @@ on:
       - 'containers/javascript-node/**'
       - 'containers/php/**'
       - 'containers/python-3/**'
+      - 'containers/python-3-anaconda/**'
+      - 'containers/python-3-miniconda/**'
       - 'containers/ruby/**'
       - 'containers/rust/**'
       - 'containers/typescript-node/**'

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -244,6 +244,80 @@ contained within.
 
 ---------------------------------------------------------
 
+continuumio/anaconda3 - BSD-3-Clause
+https://hub.docker.com/r/continuumio/anaconda3
+https://github.com/ContinuumIO/docker-images/tree/master/anaconda3
+
+
+Except where noted below, docker-anaconda is released under the following terms:
+
+(c) 2012 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+continuumio/miniconda3 - BSD-3-Clause
+https://hub.docker.com/r/continuumio/miniconda3
+https://github.com/ContinuumIO/docker-images/tree/master/miniconda3
+
+
+Except where noted below, docker-miniconda is released under the following terms:
+
+(c) 2012 Continuum Analytics, Inc. / http://continuum.io
+All Rights Reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of Continuum Analytics, Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL CONTINUUM ANALYTICS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
 robbyrussell/oh-my-zsh - MIT
 https://ohmyz.sh/
 

--- a/containers/python-3-anaconda/.devcontainer/Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/Dockerfile
@@ -1,26 +1,10 @@
-FROM continuumio/anaconda3
-
-# Options for common setup script
-ARG INSTALL_ZSH="true"
-ARG UPGRADE_PACKAGES="false"
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+FROM mcr.microsoft.com/vscode/devcontainers/anaconda:dev-3
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
 COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
 RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
     && rm -rf /tmp/conda-tmp
-
-# Install pylint
-RUN /opt/conda/bin/pip install pylint
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/python-3-anaconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/base.Dockerfile
@@ -1,0 +1,38 @@
+FROM continuumio/anaconda3
+
+# [Option] Install zsh
+ARG INSTALL_ZSH="true"
+# [Option] Upgrade OS packages to their latest versions
+ARG UPGRADE_PACKAGES="true"
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
+    && apt-get purge -y imagemagick imagemagick-6-common \
+    # Install common packages, non-root user
+    && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="none"
+ENV NVM_DIR=/usr/local/share/nvm
+ENV NVM_SYMLINK_CURRENT=true \
+    PATH=${NVM_DIR}/current/bin:${PATH}
+COPY .devcontainer/library-scripts/node-debian.sh /tmp/library-scripts/
+RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# Copy environment.yml (if found) to a temp locaition so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/containers/python-3-anaconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/base.Dockerfile
@@ -11,9 +11,6 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
-    && apt-get purge -y imagemagick imagemagick-6-common \
-    # Install common packages, non-root user
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 

--- a/containers/python-3-anaconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-anaconda/.devcontainer/devcontainer.json
@@ -1,7 +1,13 @@
 {
-	"name": "Python 3 - Anaconda",
-	"context": "..",
-	"dockerFile": "Dockerfile",
+	"name": "Anaconda (Python 3)",
+	"build": { 
+		"context": "..",
+		"dockerfile": "base.Dockerfile",
+		"args": {
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*"
+		}
+	},
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
@@ -9,6 +15,11 @@
 		"python.pythonPath": "/opt/conda/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/opt/conda/bin/autopep8",
+		"python.formatting.yapfPath": "/opt/conda/bin/yapf",
+		"python.linting.flake8Path": "/opt/conda/bin/flake8",
+		"python.linting.pycodestylePath": "/opt/conda/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/opt/conda/bin/pydocstyle",
 		"python.linting.pylintPath": "/opt/conda/bin/pylint"
 	},
 

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/node-debian.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user]
+
+export NVM_DIR=${1:-"/usr/local/share/nvm"}
+export NODE_VERSION=${2:-"lts/*"}
+USERNAME=${3:-"vscode"}
+UPDATE_RC=${4:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Treat a user name of "none" or non-existant user as root
+if [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+if [ "${NODE_VERSION}" = "none" ]; then
+    export NODE_VERSION=
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, apt-transport-https, tar, or gpg if missing
+if ! dpkg -s apt-transport-https curl ca-certificates tar > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates tar gnupg2
+fi
+
+# Install yarn
+if type yarn > /dev/null 2>&1; then
+    echo "Yarn already installed."
+else
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+    apt-get update
+    apt-get -y install --no-install-recommends yarn
+fi
+
+# Install the specified node version if NVM directory already exists, then exit
+if [ -d "${NVM_DIR}" ]; then
+    echo "NVM already installed."
+    if [ "${NODE_VERSION}" != "" ]; then
+       su ${USERNAME} -c "source $NVM_DIR/nvm.sh && nvm install ${NODE_VERSION} && nvm clear-cache"
+    fi
+    exit 0
+fi
+
+
+# Run NVM installer as non-root if needed
+mkdir -p ${NVM_DIR}
+chown ${USERNAME} ${NVM_DIR}
+su ${USERNAME} -c "$(cat << EOF
+    set -e
+
+    # Do not update profile - we'll do this manually
+    export PROFILE=/dev/null
+
+    curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash 
+    source ${NVM_DIR}/nvm.sh
+    if [ "${NODE_VERSION}" != "" ]; then
+        nvm alias default ${NODE_VERSION}
+    fi
+    nvm clear-cache 
+EOF
+)" 2>&1
+
+if [ "${UPDATE_RC}" = "true" ]; then
+    echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc with NVM scripts..."
+(cat <<EOF
+export NVM_DIR="${NVM_DIR}"
+sudoIf()
+{
+    if [ "\$(id -u)" -ne 0 ]; then
+        sudo "\$@"
+    else
+        "\$@"
+    fi
+}
+if [ "\$(stat -c '%U' \$NVM_DIR)" != "${USERNAME}" ]; then
+    if [ "\$(id -u)" -eq 0 ] || type sudo > /dev/null 2>&1; then
+        echo "Fixing permissions of \"\$NVM_DIR\"..."
+        sudoIf chown -R ${USERNAME}:root \$NVM_DIR
+    else
+        echo "Warning: NVM directory is not owned by ${USERNAME} and sudo is not installed. Unable to correct permissions."
+    fi
+fi
+[ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"
+[ -s "\$NVM_DIR/bash_completion" ] && . "\$NVM_DIR/bash_completion"
+EOF
+) | tee -a /etc/bash.bashrc >> /etc/zsh/zshrc 
+fi 
+
+echo "Done!"

--- a/containers/python-3-anaconda/README.md
+++ b/containers/python-3-anaconda/README.md
@@ -1,31 +1,36 @@
-# Python 3 - Anaconda
+# Anaconda (Python 3)
 
 ## Summary
 
-*Develop Python 3 - Anaconda applications. Installs dependencies from your environment.yml file and the Python extension.*
+*Develop Anaconda applications in Python3. Installs dependencies from your environment.yml file and the Python extension.*
 
 | Metadata | Value |  
 |----------|-------|
 | *Contributors* | The [VS Code Python extension](https://marketplace.visualstudio.com/itemdetails?itemName=ms-python.python) team |
 | *Definition type* | Dockerfile |
+| *Published image* | mcr.microsoft.com/vscode/devcontainers/anaconda:3 |
+| *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Languages, platforms* | Python, Anaconda |
 
 ## Using this definition with an existing folder
 
-While the definition itself works unmodified, there are some tips that can help you deal with some of common setup issues.
+### Configuration
 
-### Adding the contents of environment.yml to the image
+While the definition itself works unmodified, you can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` to the following. An example `Dockerfile` is included in this repository.
 
-For convenience, this definition will automatically install dependencies from the `environment.yml` file in the parent folder when the container is built. You can change this behvior by altering this line in the `.devcontainer/Dockerfile`:
+- `mcr.microsoft.com/vscode/devcontainers/anaconda` (or `anaconda:3`)
 
-```Dockerfile
-RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
-    && rm -rf /tmp/conda-tmp \
-```
+Version specific tags tied to [releases in this repository](https://github.com/microsoft/vscode-dev-containers/releases) are also available.
 
-### Debug Configuration
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0`
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.141`
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.141.0`
+
+Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+
+#### Debug Configuration
 
 Note that only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
 
@@ -33,7 +38,7 @@ Note that only the integrated terminal is supported by the Remote - Containers e
 "console": "integratedTerminal"
 ```
 
-### Using the forwardPorts property
+#### Using the forwardPorts property
 
 By default, frameworks like Flask only listens to localhost inside the container. As a result, we recommend using the `forwardPorts` property (available in v0.98.0+) to make these ports available locally.
 
@@ -44,6 +49,40 @@ By default, frameworks like Flask only listens to localhost inside the container
 The `appPort` property [publishes](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwards the port, so applications need to listen to `*` or `0.0.0.0` for the application to be accessible externally. This conflicts with the defaults of some Python frameworks, but fortunately the `forwardPorts` property does not have this limitation.
 
 If you've already opened your folder in a container, rebuild the container using the **Remote-Containers: Rebuild Container** command from the Command Palette (<kbd>F1</kbd>) so the settings take effect.
+
+### Installing Node.js
+
+Given how frequently Node.js is used for CLIs and front-end code, this container also includes the option to install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
+
+```json
+"args": {
+    "INSTALL_NODE": "true",
+    "NODE_VERSION": "10"
+}
+```
+
+#### Installing a different version of Python
+
+As covered in the [user FAQ](https://docs.anaconda.com/anaconda/user-guide/faq) for Anaconda, you can install different versions of Python than the one in this image by running the following from a terminal:
+
+```bash
+conda install python=3.6
+```
+
+Or in a Dockerfile:
+
+```Dockerfile
+RUN conda install -y python=3.6
+```
+
+### [Optional] Adding the contents of environment.yml to the image
+
+For convenience, this definition will automatically install dependencies from the `environment.yml` file in the parent folder when the container is built. You can change this behavior by altering this line in the `.devcontainer/Dockerfile`:
+
+```Dockerfile
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
+```
 
 ### Adding the definition to your folder
 

--- a/containers/python-3-anaconda/definition-manifest.json
+++ b/containers/python-3-anaconda/definition-manifest.json
@@ -1,15 +1,14 @@
 {
-	"variants": ["3", "3.8", "3.7", "3.6"],
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
-			"python:${VERSION}-${VARIANT}"
+			"anaconda:${VERSION}-3"
 		]
 	},
 	"dependencies": {
-		"image": "python:${VARIANT}",
-		"imageLink": "https://hub.docker.com/_/python",
+		"image": "anaconda3:${VARIANT}",
+		"imageLink": "https://hub.docker.com/r/continuumio/anaconda3",
 		"debian": [
 			"apt-utils",
 			"git",
@@ -52,19 +51,6 @@
 		"git": {
 			"Oh My Zsh!": "/root/.oh-my-zsh",
 			"nvm": "/usr/local/share/nvm"
-		},
-		"pipx": [
-			"pylint",
-			"flake8",
-			"autopep8",
-			"black",
-			"yapf",
-			"mypy",
-			"pydocstyle",
-			"pycodestyle",
-			"bandit",
-			"virtualenv",
-			"pipx"
-		]
+		}
 	}
 }

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -1,17 +1,9 @@
-FROM continuumio/miniconda3
+FROM mcr.microsoft.com/vscode/devcontainers/miniconda:dev-3
 
-# Options for common setup script
-ARG INSTALL_ZSH="true"
-ARG UPGRADE_PACKAGES="false"
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
@@ -19,8 +11,10 @@ COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
 RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
     && rm -rf /tmp/conda-tmp
 
-# Install pylint
-RUN /opt/conda/bin/pip install pylint
+# [Optional] Uncomment to install a different version of Python than the default
+# RUN conda install -y python=3.6 \
+#     && pip install --no-cache-dir pipx \
+#     && pipx reinstall-all
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/python-3-miniconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/base.Dockerfile
@@ -1,0 +1,49 @@
+FROM continuumio/miniconda3
+
+# [Option] Install zsh
+ARG INSTALL_ZSH="true"
+# [Option] Upgrade OS packages to their latest versions
+ARG UPGRADE_PACKAGES="true"
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+COPY .devcontainer/library-scripts/common-debian.sh /tmp/library-scripts/
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# [Optional] Uncomment to install a different version of Python than the default
+# RUN conda install -y python=3.6
+
+# Setup default python tools in a venv via pipx to avoid conflicts
+ENV PIPX_HOME=/usr/local/py-utils \
+    PIPX_BIN_DIR=/usr/local/py-utils/bin
+ENV PATH=${PATH}:${PIPX_BIN_DIR}
+COPY .devcontainer/library-scripts/python-debian.sh /tmp/library-scripts/
+RUN ln -s /opt/conda/bin/pip /opt/conda/bin/pip3 \
+    && bash /tmp/library-scripts/python-debian.sh "none" "/opt/conda" "${PIPX_HOME}" "${USERNAME}" "false" \ 
+    && apt-get clean -y && rm -rf /tmp/library-scripts
+
+# [Option] Install Node.js
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="none"
+ENV NVM_DIR=/usr/local/share/nvm
+ENV NVM_SYMLINK_CURRENT=true \
+    PATH=${NVM_DIR}/current/bin:${PATH}
+COPY .devcontainer/library-scripts/node-debian.sh /tmp/library-scripts/
+RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+# Copy environment.yml (if found) to a temp locaition so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+

--- a/containers/python-3-miniconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-miniconda/.devcontainer/devcontainer.json
@@ -1,7 +1,13 @@
 {
-	"name": "Python 3 - Miniconda",
-	"context": "..",
-	"dockerFile": "Dockerfile",
+	"name": "Miniconda (Python 3)",
+	"build": { 
+		"context": "..",
+		"dockerfile": "base.Dockerfile",
+		"args": {
+			"INSTALL_NODE": "true",
+			"NODE_VERSION": "lts/*"
+		}
+	},
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
@@ -9,7 +15,15 @@
 		"python.pythonPath": "/opt/conda/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/opt/conda/bin/pylint"
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/node-debian.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user]
+
+export NVM_DIR=${1:-"/usr/local/share/nvm"}
+export NODE_VERSION=${2:-"lts/*"}
+USERNAME=${3:-"vscode"}
+UPDATE_RC=${4:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Treat a user name of "none" or non-existant user as root
+if [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+if [ "${NODE_VERSION}" = "none" ]; then
+    export NODE_VERSION=
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install curl, apt-transport-https, tar, or gpg if missing
+if ! dpkg -s apt-transport-https curl ca-certificates tar > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        apt-get update
+    fi
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates tar gnupg2
+fi
+
+# Install yarn
+if type yarn > /dev/null 2>&1; then
+    echo "Yarn already installed."
+else
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+    apt-get update
+    apt-get -y install --no-install-recommends yarn
+fi
+
+# Install the specified node version if NVM directory already exists, then exit
+if [ -d "${NVM_DIR}" ]; then
+    echo "NVM already installed."
+    if [ "${NODE_VERSION}" != "" ]; then
+       su ${USERNAME} -c "source $NVM_DIR/nvm.sh && nvm install ${NODE_VERSION} && nvm clear-cache"
+    fi
+    exit 0
+fi
+
+
+# Run NVM installer as non-root if needed
+mkdir -p ${NVM_DIR}
+chown ${USERNAME} ${NVM_DIR}
+su ${USERNAME} -c "$(cat << EOF
+    set -e
+
+    # Do not update profile - we'll do this manually
+    export PROFILE=/dev/null
+
+    curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash 
+    source ${NVM_DIR}/nvm.sh
+    if [ "${NODE_VERSION}" != "" ]; then
+        nvm alias default ${NODE_VERSION}
+    fi
+    nvm clear-cache 
+EOF
+)" 2>&1
+
+if [ "${UPDATE_RC}" = "true" ]; then
+    echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc with NVM scripts..."
+(cat <<EOF
+export NVM_DIR="${NVM_DIR}"
+sudoIf()
+{
+    if [ "\$(id -u)" -ne 0 ]; then
+        sudo "\$@"
+    else
+        "\$@"
+    fi
+}
+if [ "\$(stat -c '%U' \$NVM_DIR)" != "${USERNAME}" ]; then
+    if [ "\$(id -u)" -eq 0 ] || type sudo > /dev/null 2>&1; then
+        echo "Fixing permissions of \"\$NVM_DIR\"..."
+        sudoIf chown -R ${USERNAME}:root \$NVM_DIR
+    else
+        echo "Warning: NVM directory is not owned by ${USERNAME} and sudo is not installed. Unable to correct permissions."
+    fi
+fi
+[ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"
+[ -s "\$NVM_DIR/bash_completion" ] && . "\$NVM_DIR/bash_completion"
+EOF
+) | tee -a /etc/bash.bashrc >> /etc/zsh/zshrc 
+fi 
+
+echo "Done!"

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/python-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/python-debian.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./python-debian.sh [Python Version] [Python intall path] [PIPX_HOME] [non-root user] [Update rc files flag] [install tools]
+
+PYTHON_VERSION=${1:-"3.8.3"}
+PYTHON_INSTALL_PATH=${2:-"/usr/local/python${PYTHON_VERSION}"}
+export PIPX_HOME=${3:-"/usr/local/py-utils"}
+USERNAME=${4:-"vscode"}
+UPDATE_RC=${5:-"true"}
+INSTALL_PYTHON_TOOLS=${6:-"true"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Treat a user name of "none" or non-existant user as root
+if [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+function updaterc() {
+    if [ "${UPDATE_RC}" = "true" ]; then
+        echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
+        echo -e "$1" | tee -a /etc/bash.bashrc >> /etc/zsh/zshrc
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install python from source if needed
+if [ "${PYTHON_VERSION}" != "none" ]; then
+
+    if [ -d "${PYTHON_INSTALL_PATH}" ]; then
+        echo "Path ${PYTHON_INSTALL_PATH} already exists. Assuming Python already installed."
+    else
+        echo "Building Python ${PYTHON_VERSION} from source..."
+        # Install prereqs if missing
+        PREREQ_PKGS="curl ca-certificates tar make build-essential libffi-dev \
+            libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
+            libncurses5-dev libncursesw5-dev xz-utils tk-dev"
+        if ! dpkg -s ${PREREQ_PKGS} > /dev/null 2>&1; then
+            if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+                apt-get update
+            fi
+            apt-get -y install --no-install-recommends ${PREREQ_PKGS}
+        fi
+
+        # Download and build from src
+        mkdir -p /tmp/python-src "${PYTHON_INSTALL_PATH}"
+        cd /tmp/python-src
+        curl -sSL -o /tmp/python-dl.tgz "https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz"
+        tar -xzf /tmp/python-dl.tgz -C "/tmp/python-src" --strip-components=1
+        ./configure --prefix="${PYTHON_INSTALL_PATH}" --enable-optimizations --with-ensurepip=install
+        make -j 8
+        make install
+        rm -rf /tmp/python-dl.tgz /tmp/python-src
+        cd /tmp
+        chown -R ${USERNAME} "${PYTHON_INSTALL_PATH}"
+        ln -s ${PYTHON_INSTALL_PATH}/bin/python3 ${PYTHON_INSTALL_PATH}/bin/python
+        ln -s ${PYTHON_INSTALL_PATH}/bin/pip3 ${PYTHON_INSTALL_PATH}/bin/pip
+        ln -s ${PYTHON_INSTALL_PATH}/bin/idle3 ${PYTHON_INSTALL_PATH}/bin/idle
+        ln -s ${PYTHON_INSTALL_PATH}/bin/pydoc3 ${PYTHON_INSTALL_PATH}/bin/pydoc
+        ln -s ${PYTHON_INSTALL_PATH}/bin/python3-config ${PYTHON_INSTALL_PATH}/bin/python-config
+        updaterc "export PATH=${PYTHON_INSTALL_PATH}/bin:\${PATH}"
+    fi
+fi
+
+# If not installing python tools, exit
+if [ "${INSTALL_PYTHON_TOOLS}" != "true" ]; then
+    echo "Done!"
+    exit 0;
+fi
+
+DEFAULT_UTILS="\
+    pylint \
+    flake8 \
+    autopep8 \
+    black \
+    yapf \
+    mypy \
+    pydocstyle \
+    pycodestyle \
+    bandit \
+    pipenv \
+    virtualenv"
+
+export PIPX_BIN_DIR=${PIPX_HOME}/bin
+export PATH=${PYTHON_INSTALL_PATH}/bin:${PIPX_BIN_DIR}:${PATH}
+mkdir -p ${PIPX_BIN_DIR}
+chown -R ${USERNAME} ${PIPX_HOME} ${PIPX_BIN_DIR}
+su ${USERNAME} -c "$(cat << EOF
+    set -e
+    echo "Installing Python tools..."
+    export PIPX_HOME=${PIPX_HOME}
+    export PIPX_BIN_DIR=${PIPX_BIN_DIR}
+    export PYTHONUSERBASE=/tmp/pip-tmp
+    export PIP_CACHE_DIR=/tmp/pip-tmp/cache
+    export PATH=${PATH}
+    pip3 install --disable-pip-version-check --no-warn-script-location --no-cache-dir --user pipx
+    /tmp/pip-tmp/bin/pipx install --pip-args=--no-cache-dir pipx
+    echo "${DEFAULT_UTILS}" | xargs -n 1 /tmp/pip-tmp/bin/pipx install --system-site-packages --pip-args=--no-cache-dir --pip-args=--force-reinstall
+    chown -R ${USERNAME} ${PIPX_HOME}
+    rm -rf /tmp/pip-tmp
+EOF
+)"
+updaterc "export PIPX_HOME=${PIPX_HOME}\nexport PIPX_BIN_DIR=${PIPX_BIN_DIR}\nexport PATH=\${PATH}:\${PIPX_BIN_DIR}"

--- a/containers/python-3-miniconda/README.md
+++ b/containers/python-3-miniconda/README.md
@@ -1,31 +1,36 @@
-# Python 3 - Miniconda
+# Miniconda (Python 3)
 
 ## Summary
 
-*Develop Python 3 - Miniconda applications. Installs dependencies from your environment.yml file and the Python extension.*
+*Develop Miniconda applications in Python 3. Installs dependencies from your environment.yml file and the Python extension.*
 
 | Metadata | Value |  
 |----------|-------|
 | *Contributors* | The [VS Code Python extension](https://marketplace.visualstudio.com/itemdetails?itemName=ms-python.python) team |
 | *Definition type* | Dockerfile |
+| *Published image* | mcr.microsoft.com/vscode/devcontainers/miniconda:3 |
+| *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
-| *Languages, platforms* | Python, Anaconda |
+| *Languages, platforms* | Python, Anaconda, Miniconda |
 
 ## Using this definition with an existing folder
 
-While the definition itself works unmodified, there are some tips that can help you deal with some of common setup issues.
+### Configuration
 
-### Adding the contents of environment.yml to the image
+While the definition itself works unmodified, you can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` to the following. An example `Dockerfile` is included in this repository.
 
-For convenience, this definition will automatically install dependencies from the `environment.yml` file in the parent folder when the container is built.You can change this behavior by altering this line in the `.devcontainer/Dockerfile`:
+- `mcr.microsoft.com/vscode/devcontainers/minconda` (or `minconda:3`)
 
-```Dockerfile
-RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
-    && rm -rf /tmp/conda-tmp \
-```
+Version specific tags tied to [releases in this repository](https://github.com/microsoft/vscode-dev-containers/releases) are also available.
 
-### Debug Configuration
+- `mcr.microsoft.com/vscode/devcontainers/minconda:0`
+- `mcr.microsoft.com/vscode/devcontainers/minconda:0.141`
+- `mcr.microsoft.com/vscode/devcontainers/minconda:0.141.0`
+
+Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+
+#### Debug Configuration
 
 Note that only the integrated terminal is supported by the Remote - Containers extension. You may need to modify `launch.json` configurations to include the following value if an external console is used.
 
@@ -33,9 +38,9 @@ Note that only the integrated terminal is supported by the Remote - Containers e
 "console": "integratedTerminal"
 ```
 
-### Using the forwardPorts property
+#### Using the forwardPorts property
 
-By default, frameworks like Flask only listen to localhost inside the container. As a result, we recommend using the `forwardPorts` property (available in v0.98.0+) to make these ports available locally.
+By default, frameworks like Flask only listens to localhost inside the container. As a result, we recommend using the `forwardPorts` property (available in v0.98.0+) to make these ports available locally.
 
 ```json
 "forwardPorts": [5000]
@@ -44,6 +49,58 @@ By default, frameworks like Flask only listen to localhost inside the container.
 The `appPort` property [publishes](https://docs.docker.com/config/containers/container-networking/#published-ports) rather than forwards the port, so applications need to listen to `*` or `0.0.0.0` for the application to be accessible externally. This conflicts with the defaults of some Python frameworks, but fortunately the `forwardPorts` property does not have this limitation.
 
 If you've already opened your folder in a container, rebuild the container using the **Remote-Containers: Rebuild Container** command from the Command Palette (<kbd>F1</kbd>) so the settings take effect.
+
+#### Installing Node.js
+
+Given how frequently Node.js is used for CLIs and front-end code, this container also includes the option to install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
+
+```json
+"args": {
+    "INSTALL_NODE": "true",
+    "NODE_VERSION": "10"
+}
+```
+
+#### Installing or updating Python utilities
+
+This container installs all Python development utilities using [pipx](https://pipxproject.github.io/pipx/) to avoid impacting the global Python environment. You can use this same utility add additional utilities in an isolated environment. For example:
+
+```bash
+pipx install prospector
+```
+
+Note that if you change the version of Python from the default, you'll need to run a few commands to update the utilities and `pipx`. More on that next.
+
+#### Installing a different version of Python
+
+As covered in the [user FAQ](https://docs.anaconda.com/anaconda/user-guide/faq) for Anaconda, you can install different versions of Python than the one in this image by running the following from a terminal:
+
+```bash
+conda install python=3.6
+pip install --no-cache-dir pipx
+pipx uninstall pipx
+pipx reinstall-all
+```
+
+Or in a Dockerfile:
+
+```Dockerfile
+RUN conda install -y python=3.6 \
+    && pip install --no-cache-dir pipx \
+    && pipx uninstall pipx \
+    && pipx reinstall-all
+```
+
+See the [pipx documentation](https://pipxproject.github.io/pipx/docs/) for additional information.
+
+### [Optional] Adding the contents of environment.yml to the image
+
+For convenience, this definition will automatically install dependencies from the `environment.yml` file in the parent folder when the container is built. You can change this behavior by altering this line in the `.devcontainer/Dockerfile`:
+
+```Dockerfile
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
+```
 
 ### Adding the definition to your folder
 

--- a/containers/python-3-miniconda/definition-manifest.json
+++ b/containers/python-3-miniconda/definition-manifest.json
@@ -1,15 +1,14 @@
 {
-	"variants": ["3", "3.8", "3.7", "3.6"],
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
-			"python:${VERSION}-${VARIANT}"
+			"miniconda:${VERSION}-3"
 		]
 	},
 	"dependencies": {
-		"image": "python:${VARIANT}",
-		"imageLink": "https://hub.docker.com/_/python",
+		"image": "anaconda3:${VARIANT}",
+		"imageLink": "https://hub.docker.com/r/continuumio/miniconda3",
 		"debian": [
 			"apt-utils",
 			"git",

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -44,7 +44,7 @@ Beyond Python and `git`, this image / `Dockerfile` includes a number of Python t
 
 ### Installing Node.js
 
-Given how frequently Python-based web applications use Node.js for front end code, this container also includes Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
+Given how frequently Node.js is used for CLIs and front-end code, this container also includes the option to install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
 ```json
 "args": {


### PR DESCRIPTION
This updates the Anaconda and Miniconda definitions to mirror Python and adds them to the image build as a part of #154.

Two notes:
- `.devcontainer/devcontainer.json` will be updated to use `Dockerfile` once a dev image exists.
- The added contents of the `library-scripts` folder are automatically updated from `/script-library` in this repo, so they can generally be assumed to work.

This should also resolve #166.