### PR TITLE
Use bash -c instead of piping in the script-library docs

### DIFF
--- a/script-library/README.md
+++ b/script-library/README.md
@@ -65,7 +65,7 @@ Note that the CI process for this repository will automatically keep scripts in 
 If you prefer, you can download the script using `curl` or `wget` and execute it instead. This can convenient to do with your own `Dockerfile`, but is generally avoided for definitions in this repository. To avoid unexpected issues, you should reference a release specific version of the script, rather than using master. For example:
 
 ```Dockerfile
-RUN curl -sSL -o- "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.131.0/script-library/common-debian.sh" | bash -
+RUN bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.131.0/script-library/common-debian.sh")" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 ```
 
@@ -74,11 +74,18 @@ Or if you're not sure if `curl` is installed:
 ```Dockerfile
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive  \
     && apt-get -y install --no-install-recommends curl ca-certificates \
-    && curl -sSL -o- "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.131.0/script-library/common-debian.sh" | bash - \
+    && bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.131.0/script-library/common-debian.sh")" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 ```
 
 As before, the last line is technically optional, but minimizes the size of the layer by removing temporary contents.  
+
+You can also use `wget`:
+
+```Dockerfile
+RUN bash -c "$(wget -qO- "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.131.0/script-library/common-debian.sh")" \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+```
 
 ### Arguments
 
@@ -99,7 +106,7 @@ RUN /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "vscode" "1
 
 #### Using arguments when downloading with curl
 
-The trick here is to use the syntax `| bash -s --` after the `curl` command and then listing the arguments.
+The trick here is to use the double-dashes (`--`) after the `bash -c` command and then listing the arguments.
 
 ```Dockerfile
 # Options for script
@@ -108,7 +115,7 @@ ARG INSTALL_ZSH="true"
 # Download script and run it with the option above
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive  \
     && apt-get -y install --no-install-recommends curl ca-certificates \
-    && curl -sSL -o- "hhttps://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.131.0/script-library/common-debian.sh" | bash -s -- "${INSTALL_ZSH}" "vscode" "1000" "1000" "true" \
+    && bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/v0.131.0/script-library/common-debian.sh")" -- "${INSTALL_ZSH}" "vscode" "1000" "1000" "true" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 ```
 


### PR DESCRIPTION
This way is simpler (at least for passing parameters) + safer. That's why Homebrew suggests this way (https://brew.sh/).