### PR TITLE
Add SSH, Oh My Bash! to codespaces-linux

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -8386,3 +8386,32 @@ THE SOFTWARE.
 
 
 ---------------------------------------------------------
+
+---------------------------------------------------------
+
+Oh My Bash! - MIT
+https://github.com/ohmybash/oh-my-bash/
+
+
+Copyright 2017-2020 Toan Nguyen and contributors (https://github.com/ohmybash/oh-my-bash/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
+THE SOFTWARE.
+
+
+---------------------------------------------------------

--- a/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ USER_GID=${4:-1000}
 UPGRADE_PACKAGES=${5:-"true"}
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo 'Script must be run a root. Use sudo or set "USER root" before running the script.'
+    echo 'Script must be run as root. Use sudo or set "USER root" before running the script.'
     exit 1
 fi
 

--- a/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ USER_GID=${4:-1000}
 UPGRADE_PACKAGES=${5:-"true"}
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo 'Script must be run a root. Use sudo or set "USER root" before running the script.'
+    echo 'Script must be run as root. Use sudo or set "USER root" before running the script.'
     exit 1
 fi
 

--- a/containers/alpine/.devcontainer/library-scripts/common-alpine.sh
+++ b/containers/alpine/.devcontainer/library-scripts/common-alpine.sh
@@ -14,7 +14,7 @@ USER_GID=${4:-1000}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-ansible/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/azcli-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh
@@ -14,7 +14,7 @@ USERNAME=${4:-"vscode"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-ansible/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-blockchain/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/azure-blockchain/.devcontainer/library-scripts/azcli-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-blockchain/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-blockchain/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-blockchain/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/azure-blockchain/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-cli/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/azure-cli/.devcontainer/library-scripts/azcli-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-terraform/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/azcli-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-terraform/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/docker-debian.sh
@@ -14,7 +14,7 @@ USERNAME=${4:-"vscode"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-terraform/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh
@@ -17,7 +17,7 @@ if [ -z "$1" ]; then
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/bazel/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/bazel/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/base.Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/base.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -yq vim xtail software-properties-common \
     && bash /tmp/scripts/sshd-debian.sh \
     && bash /tmp/scripts/git-lfs-debian.sh \
-    && bash /tmp/scripts/github-debian.sh ${GITHUB_CLI_VERSION}\
+    && bash /tmp/scripts/github-debian.sh \
     && bash /tmp/scripts/azcli-debian.sh \
     && bash /tmp/scripts/kubectl-helm-debian.sh \
     # Clean up

--- a/containers/codespaces-linux/.devcontainer/base.Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/base.Dockerfile
@@ -27,7 +27,7 @@ ENV PATH="${NVM_DIR}/current/bin:${DOTNET_ROOT}/tools:${SDKMAN_DIR}/bin:${SDKMAN
 
 # Install needed utilities and setup non-root user. Use a separate RUN statement to add your own dependencies.
 COPY library-scripts/azcli-debian.sh library-scripts/common-debian.sh library-scripts/git-lfs-debian.sh library-scripts/github-debian.sh \
-    library-scripts/kubectl-helm-debian.sh setup-user.sh /tmp/scripts/
+    library-scripts/kubectl-helm-debian.sh library-scripts/sshd-debian.sh setup-user.sh /tmp/scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove buster list to avoid unexpected errors given base image is stretch
     && rm /etc/apt/sources.list.d/buster.list \
@@ -40,6 +40,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install tools and shells not in common script
     && apt-get install -yq vim xtail software-properties-common \
+    && bash /tmp/scripts/sshd-debian.sh \
     && bash /tmp/scripts/git-lfs-debian.sh \
     && bash /tmp/scripts/github-debian.sh ${GITHUB_CLI_VERSION}\
     && bash /tmp/scripts/azcli-debian.sh \
@@ -104,7 +105,7 @@ RUN bash /tmp/scripts/python-debian.sh "none" "/opt/python/stable" "${PIPX_HOME}
 # Install xdebug, link composer
 RUN yes | pecl install xdebug \
     && export PHP_LOCATION=$(dirname $(dirname $(which php))) \
-    && echo "zend_extension=$(find ${PHP_LOCATION}/lib/php/extensions/ -name xdebug.so)" >  ${PHP_LOCATION}/ini/conf.d/xdebug.ini \
+    && echo "zend_extension=$(find ${PHP_LOCATION}/lib/php/extensions/ -name xdebug.so)" > ${PHP_LOCATION}/ini/conf.d/xdebug.ini \
     && echo "xdebug.remote_enable=on" >> ${PHP_LOCATION}/ini/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=on" >>  ${PHP_LOCATION}/ini/conf.d/xdebug.ini \
     && rm -rf /tmp/pear \
@@ -126,7 +127,7 @@ RUN if [ "${INSTALL_DOCKER}" = "true" ]; then \
     && rm -rf /tmp/scripts && apt-get clean -y
 
 # Fire Docker script if needed along with Oryx's benv
-ENTRYPOINT [ "/usr/local/share/docker-init.sh", "benv" ]
+ENTRYPOINT [ "/usr/local/share/docker-init.sh", "/usr/local/share/ssh-init.sh" ,"benv" ]
 CMD [ "sleep", "infinity" ]
 
 # [Optional] Install debugger for development of Codespaces - Not in resulting image by default

--- a/containers/codespaces-linux/.devcontainer/base.Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/base.Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove buster list to avoid unexpected errors given base image is stretch
     && rm /etc/apt/sources.list.d/buster.list \
     # Run common script and setup user
-    && bash /tmp/scripts/common-debian.sh "true" "${USERNAME}" "${USER_UID}" "${USER_GID}" "false" \
+    && bash /tmp/scripts/common-debian.sh "true" "${USERNAME}" "${USER_UID}" "${USER_GID}" "false" "true" \
     && bash /tmp/scripts/setup-user.sh "${USERNAME}" "${PATH}" \
     # Upgrade git to avoid security issue
     && apt-get upgrade -yq git \

--- a/containers/codespaces-linux/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/azcli-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -182,44 +182,42 @@ fi
 EOF
 )"
 
-# Codespaces Oh My Bash! theme - based off https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+# Codespaces themes - based off https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
 <<EOF
 #!/usr/bin/env bash
 prompt() {
-    if [ ! -z "${GITHUB_USER}" ]; then
-        local USERNAME="gh:@${GITHUB_USER}"
+    if [ ! -z "\${GITHUB_USER}" ]; then
+        local USERNAME="gh:@\${GITHUB_USER}"
     else
-        local USERNAME="$(whoami)"
+        local USERNAME="\$(whoami)"
     fi
-    local cwd="$(pwd | sed "s|^${HOME}|~|")"
-    if [ "$?" != "0" ]; then
-        local arrow_color=${bold_red}
+    local cwd="\$(pwd | sed "s|^\${HOME}|~|")"
+    if [ "\$?" != "0" ]; then
+        local arrow_color=\${bold_red}
     else
-        local arrow_color=${reset_color}
+        local arrow_color=\${reset_color}
     fi
-    PS1="${green}${USERNAME} ${arrow_color}➜ ${blue}${cwd}${reset_color} $(scm_prompt_info)$ "
+    PS1="\${green}\${USERNAME} \${arrow_color}➜ \${blue}\${cwd}\${reset_color} \$(scm_prompt_info)$ "
 }
-SCM_THEME_PROMPT_PREFIX="${cyan}(${bold_red}"
-SCM_THEME_PROMPT_SUFFIX="${reset_color} "
-SCM_THEME_PROMPT_DIRTY=" ${yellow}✗${cyan})"
-SCM_THEME_PROMPT_CLEAN="${cyan})"
+SCM_THEME_PROMPT_PREFIX="\${cyan}(\${bold_red}"
+SCM_THEME_PROMPT_SUFFIX="\${reset_color} "
+SCM_THEME_PROMPT_DIRTY=" \${yellow}✗\${cyan})"
+SCM_THEME_PROMPT_CLEAN="\${cyan})"
 SCM_GIT_SHOW_MINIMAL_INFO="true"
 safe_append_prompt_command prompt
 EOF
 )"
-
-# Same Oh My Zsh theme
 CODESPACES_ZSH="$(cat \
 <<EOF
 prompt() {
-    if [ ! -z "${GITHUB_USER}" ]; then
-        local USERNAME="gh:@${GITHUB_USER}"
+    if [ ! -z "\${GITHUB_USER}" ]; then
+        local USERNAME="gh:@\${GITHUB_USER}"
     else
-        local USERNAME="$(whoami)"
+        local USERNAME="\$(whoami)"
     fi
-    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
-    PROMPT+='%{$fg[blue]%}%~%{$reset_color%} $(git_prompt_info)$ '
+    PROMPT="%{$fg[green]%}\${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT+='%{$fg[blue]%}%~%{$reset_color%} \$(git_prompt_info)$ '
 }
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -182,7 +182,7 @@ fi
 EOF
 )"
 
-# Codespaces themes - based off https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+# Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
 <<EOF
 #!/usr/bin/env bash
@@ -216,17 +216,19 @@ prompt() {
     else
         local USERNAME="\$(whoami)"
     fi
-    PROMPT="%{$fg[green]%}\${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
-    PROMPT+='%{$fg[blue]%}%~%{$reset_color%} \$(git_prompt_info)$ '
+    PROMPT="%{\$fg[green]%}\${USERNAME} %(?:%{\$reset_color%}➜ :%{\$fg_bold[red]%}➜ )"
+    PROMPT+='%{\$fg[blue]%}%~%{\$reset_color%} \$(git_prompt_info)$ '
 }
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}(%{$fg_bold[red]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
-ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[yellow]%}✗%{$fg[cyan]%})"
-ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[cyan]%})"
+ZSH_THEME_GIT_PROMPT_PREFIX="%{\$fg[cyan]%}(%{\$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{\$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{\$fg[yellow]%}✗%{\$fg[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{\$fg[cyan]%})"
 prompt
 EOF
 )"
 
+# Adapted Oh My Zsh! install step to work with both "Oh Mys" rather than relying on an installer script
+# See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
 install-oh-my()
 {
     local OH_MY=$1
@@ -258,6 +260,7 @@ install-oh-my()
         mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
         echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
     fi
+    # Shrink git while still enabling updates
     cd ${OH_MY_INSTALL_DIR} 
     git repack -a -d -f --depth=1 --window=1
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -30,7 +30,7 @@ INSTALL_OH_MYS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -4,13 +4,28 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag]
+# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My *! flag]
+#
+# Usage: 
+#
+# 1. Add this file to .devcontainer/library-scripts
+#
+# 2. Add the following to .devcontainer/Dockerfile:
+#
+#    COPY library-scripts/*.sh /tmp/library-scripts/
+#    RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+#        && bash /tmp/library-scripts/common-debian.sh \
+#        && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+#
+# You can optionally pass in arguments described above to common-debian.sh. Flags are a value of "true" or "false. 
+# Pass in "none" for the username to skip the creation or modification of a non-root user while setting other arguments.
 
 INSTALL_ZSH=${1:-"true"}
 USERNAME=${2:-"vscode"}
 USER_UID=${3:-1000}
 USER_GID=${4:-1000}
 UPGRADE_PACKAGES=${5:-"true"}
+INSTALL_OH_MYS=${6:-"true"}
 
 set -e
 
@@ -85,7 +100,7 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         locales \
         sudo \
         ncdu \
-        man-db" 
+        man-db"
 
     # Install libssl1.1 if available
     if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
@@ -119,7 +134,7 @@ fi
 
 # Ensure at least the en_US.UTF-8 UTF-8 locale is available.
 # Common need for both applications and things like the agnoster ZSH theme.
-if [ "${LOCALE_ALREADY_SET}" != "true" ]; then
+if [ "${LOCALE_ALREADY_SET}" != "true" ] && ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen 
     locale-gen
     LOCALE_ALREADY_SET="true"
@@ -148,6 +163,13 @@ if [ "${USERNAME}" != "root" ] && [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}"
     EXISTING_NON_ROOT_USER="${USERNAME}"
 fi
 
+# ** Shell customization section **
+if [ "${USERNAME}" = "root" ]; then 
+    USER_RC_PATH="/root"
+else
+    USER_RC_PATH="/home/${USERNAME}"
+fi
+
 # .bashrc/.zshrc snippet
 RC_SNIPPET="$(cat << EOF
 export USER=\$(whoami)
@@ -160,27 +182,110 @@ fi
 EOF
 )"
 
-# Ensure ~/.local/bin is in the PATH for root and non-root users for bash. (zsh is later)
+# Codespaces Oh My Bash! theme - based off https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+CODESPACES_BASH="$(cat \
+<<EOF
+#!/usr/bin/env bash
+prompt() {
+    if [ ! -z "${GITHUB_USER}" ]; then
+        local USERNAME="gh:@${GITHUB_USER}"
+    else
+        local USERNAME="$(whoami)"
+    fi
+    local cwd="$(pwd | sed "s|^${HOME}|~|")"
+    if [ "$?" != "0" ]; then
+        local arrow_color=${bold_red}
+    else
+        local arrow_color=${reset_color}
+    fi
+    PS1="${green}${USERNAME} ${arrow_color}➜ ${blue}${cwd}${reset_color} $(scm_prompt_info)$ "
+}
+SCM_THEME_PROMPT_PREFIX="${cyan}(${bold_red}"
+SCM_THEME_PROMPT_SUFFIX="${reset_color} "
+SCM_THEME_PROMPT_DIRTY=" ${yellow}✗${cyan})"
+SCM_THEME_PROMPT_CLEAN="${cyan})"
+SCM_GIT_SHOW_MINIMAL_INFO="true"
+safe_append_prompt_command prompt
+EOF
+)"
+
+# Same Oh My Zsh theme
+CODESPACES_ZSH="$(cat \
+<<EOF
+prompt() {
+    if [ ! -z "${GITHUB_USER}" ]; then
+        local USERNAME="gh:@${GITHUB_USER}"
+    else
+        local USERNAME="$(whoami)"
+    fi
+    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT+='%{$fg[blue]%}%~%{$reset_color%} $(git_prompt_info)$ '
+}
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}(%{$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[yellow]%}✗%{$fg[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[cyan]%})"
+prompt
+EOF
+)"
+
+install-oh-my()
+{
+    local OH_MY=$1
+    local OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-${OH_MY}"
+    local TEMPLATE="${OH_MY_INSTALL_DIR}/templates/$2"
+    local OH_MY_GIT_URL=$3
+    local USER_RC_FILE="${USER_RC_PATH}/.${OH_MY}rc"
+
+    if [ -d "${OH_MY_INSTALL_DIR}" ] || [ "${INSTALL_OH_MYS}" != "true" ]; then
+        return 0
+    fi
+
+    umask g-w,o-w
+    mkdir -p ${OH_MY_INSTALL_DIR}
+    git clone --depth=1 \
+        -c core.eol=lf \
+        -c core.autocrlf=false \
+        -c fsck.zeroPaddedFilemode=ignore \
+        -c fetch.fsck.zeroPaddedFilemode=ignore \
+        -c receive.fsck.zeroPaddedFilemode=ignore \
+        ${OH_MY_GIT_URL} ${OH_MY_INSTALL_DIR} 2>&1
+    echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
+    if [ "${OH_MY}" = "bash" ]; then
+        sed -i -e 's/OSH_THEME=.*/OSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes/codespaces
+        echo "${CODESPACES_BASH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces/codespaces.theme.sh
+    else
+        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+        echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
+    fi
+    cd ${OH_MY_INSTALL_DIR} 
+    git repack -a -d -f --depth=1 --window=1
+
+    if [ "${USERNAME}" != "root" ]; then
+        cp -rf ${USER_RC_FILE} ${OH_MY_INSTALL_DIR} /root
+        chown -R ${USERNAME}:${USERNAME} ${USER_RC_PATH}
+    fi
+}
+
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
     echo "${RC_SNIPPET}" >> /etc/bash.bashrc
     RC_SNIPPET_ALREADY_ADDED="true"
 fi
+install-oh-my bash bashrc.osh-template https://github.com/ohmybash/oh-my-bash
 
-# Optionally install and configure zsh
-if [ "${INSTALL_ZSH}" = "true" ] && [ ! -d "/root/.oh-my-zsh" ] && [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
-    apt-get-update-if-needed
-    apt-get install -y zsh
-    curl -fsSLo- https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | bash 2>&1
-    echo "${RC_SNIPPET}" >> /etc/zsh/zshrc
-    echo -e "DEFAULT_USER=\$USER\nprompt_context(){}" >> /root/.zshrc
-    cp -fR /root/.oh-my-zsh /etc/skel
-    cp -f /root/.zshrc /etc/skel
-    sed -i -e "s/\/root\/.oh-my-zsh/\/home\/\$(whoami)\/.oh-my-zsh/g" /etc/skel/.zshrc
-    if [ "${USERNAME}" != "root" ]; then
-        cp -fR /etc/skel/.oh-my-zsh /etc/skel/.zshrc /home/$USERNAME
-        chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc
+# Optionally install and configure zsh and Oh My Zsh!
+if [ "${INSTALL_ZSH}" = "true" ]; then
+    if ! type zsh > /dev/null 2>&1; then
+        apt-get-update-if-needed
+        apt-get install -y zsh
     fi
-    ZSH_ALREADY_INSTALLED="true"
+    if [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
+        echo "${RC_SNIPPET}" >> /etc/zsh/zshrc
+        ZSH_ALREADY_INSTALLED="true"
+    fi
+    install-oh-my zsh zshrc.zsh-template https://github.com/ohmyzsh/ohmyzsh
 fi
 
 # Write marker file

--- a/containers/codespaces-linux/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/docker-debian.sh
@@ -14,7 +14,7 @@ USERNAME=${4:-"vscode"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/git-from-src-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/git-from-src-debian.sh
@@ -5,7 +5,7 @@ GIT_VERSION=${1:-"2.27.0"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/git-lfs-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/git-lfs-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/github-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/github-debian.sh
@@ -11,7 +11,7 @@ CLI_VERSION=${1:-"latest"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/go-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/go-debian.sh
@@ -16,7 +16,7 @@ INSTALL_GO_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/gradle-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/gradle-debian.sh
@@ -19,7 +19,7 @@ if [ "${GRADLE_VERSION}" = "lts" ] || [ "${GRADLE_VERSION}" = "latest" ] || [ "$
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/java-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/java-debian.sh
@@ -19,7 +19,7 @@ if [ "${JAVA_VERSION}" = "lts" ]; then
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/kubectl-helm-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/kubectl-helm-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/maven-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/maven-debian.sh
@@ -19,7 +19,7 @@ if [ "${MAVEN_VERSION}" = "lts" ] || [ "${MAVEN_VERSION}" = "current" ] || [ "${
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/powershell-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/powershell-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/python-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/python-debian.sh
@@ -16,7 +16,7 @@ INSTALL_PYTHON_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/ruby-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/ruby-debian.sh
@@ -14,7 +14,7 @@ INSTALL_RUBY_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/rust-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/rust-debian.sh
@@ -15,7 +15,7 @@ UPDATE_RUST=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
@@ -16,7 +16,7 @@ NEW_PASSWORD=${4:-"skip"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./sshd-debian.sh [SSH Port (don't use 22)] [non-root user] [start sshd now flag] [new password for user]
+
+# Note: You can change your user's password with "sudo passwd $(whoami)" (or just "passwd" if running as root).
+
+SSHD_PORT=${1:-"2222"}
+USERNAME=${2:-"vscode"}
+START_SSHD=${3:-"false"}
+NEW_PASSWORD=${4:-"skip"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Treat a user name of "none" or non-existant user as root
+if [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+# Function to run apt-get if needed
+apt-get-update-if-needed()
+{
+    if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+        echo "Running apt-get update..."
+        apt-get update
+    else
+        echo "Skipping apt-get update."
+    fi
+}
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+# Install openssh-server openssh-client
+if ! dpkg -s openssh-server openssh-client > /dev/null 2>&1; then
+    apt-get-update-if-needed
+    apt-get -y install --no-install-recommends openssh-server openssh-client 
+fi
+
+# Generate password if new password set to the word "random"
+if [ "${NEW_PASSWORD}" = "random" ]; then
+    NEW_PASSWORD="$(openssl rand -hex 16)"
+    EMIT_PASSWORD="true"
+fi
+
+# If new password not set to skip, set it for the specified user
+if [ "${NEW_PASSWORD}" != "skip" ]; then
+    echo "${USERNAME}:${NEW_PASSWORD}" | chpasswd
+    if [ "${NEW_PASSWORD}" != "root" ]; then
+        usermod -aG ssh ${USERNAME}
+    fi
+fi
+
+# Setup sshd
+mkdir -p /var/run/sshd
+sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd
+sed -i 's/#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config
+sed -i -E "s/#*\s*Port\s+.+/Port ${SSHD_PORT}/g" /etc/ssh/sshd_config
+
+# Write out a script that can be referenced as an ENTRYPOINT to auto-start sshd
+tee /usr/local/share/ssh-init.sh > /dev/null \
+<< EOF 
+#!/usr/bin/env bash
+set -e 
+
+if [ "\$(id -u)" -ne 0 ]; then
+    sudo /etc/init.d/ssh restart
+else
+    /etc/init.d/ssh restart
+fi
+
+set +e
+exec "\$@"
+EOF
+chmod +x /usr/local/share/ssh-init.sh
+chown ${USERNAME}:ssh /usr/local/share/ssh-init.sh
+
+# If we should start sshd now, do so
+if [ "${START_SSHD}" = "true" ]; then
+    /usr/local/share/ssh-init.sh
+fi
+
+# Write out result
+echo -e "Done!\n\n- Port: ${SSHD_PORT}\n- User: ${USERNAME}"
+if [ "${EMIT_PASSWORD}" = "true" ]; then
+    echo "- Password: ${NEW_PASSWORD}"
+fi
+echo -e "\nForward port ${SSHD_PORT} to your local machine and run:\n\n  ssh -p ${SSHD_PORT} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null ${USERNAME}@localhost\n"

--- a/containers/codespaces-linux/.npmignore
+++ b/containers/codespaces-linux/.npmignore
@@ -15,6 +15,7 @@ definition-manifest.json
 .devcontainer/library-scripts/python-debian.sh
 .devcontainer/library-scripts/ruby-debian.sh
 .devcontainer/library-scripts/rust-debian.sh
+.devcontainer/library-scripts/sshd-debian.sh
 .devcontainer/library-scripts/README.md
 setup-user.sh
 symlinkDotNetCore.sh

--- a/containers/codespaces-linux/README.md
+++ b/containers/codespaces-linux/README.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-*Use or extend the default large, multi-language universal container for GitHub Codespaces.*
+*Use or extend the default, large, multi-language universal container for GitHub Codespaces.*
 
 | Metadata | Value |  
 |----------|-------|
@@ -20,7 +20,35 @@ While language specific development containers can be useful, in some cases you 
 
 If you use GitHub Codespaces, this is the "universal" image that is used by default if no custom Dockerfile or image is specified. If you like what you see but want to make a few additions or changes, you can use a custom Dockerfile to extend it and add whatever you need.
 
-The container includes the `zsh` (and Oh My Zsh!) and `fish` shells that you can opt into using instead of the default `bash`. It also includes [nvm](https://github.com/nvm-sh/nvm) and [nvs](https://github.com/jasongin/nvs) if you need to install a different version of Node.js than those that are in the container by default.
+The container includes the `zsh` (and Oh My Zsh!) and `fish` shells that you can opt into using instead of the default `bash`. It also includes [nvm](https://github.com/nvm-sh/nvm), [rvm](https://rvm.io/), and [SDKMAN!](https://sdkman.io/) if you need to install a different version Node, Ruby, or Java tools than the container defaults. You can also set things up to access the container [via SSH](#accessing-the-container-using-ssh-scp-or-sshfs).
+
+## Accessing the container using SSH, SCP, or SSHFS
+
+This container also includes a running SSH server that you can use to access the contents if needed. To use it:
+
+1. Create a codespace in [GitHub Codespaces](https://github.com/features/codespaces) (this is the default image) or open this container in Remote - Containers.
+
+2. If you created a codespace using a web browser in GitHub Codespaces, setup the [VS Code extension and connect to it from your local VS Code](https://docs.github.com/en/github/developing-online-with-codespaces/connecting-to-your-codespace-from-visual-studio-code).
+
+3. When connected to the codespace, use a terminal in VS Code to set a password when connecting:
+
+   ```bash
+   sudo passwd $(whoami)
+   ```
+
+4. Press <kbd>F1</kbd> and select **Forward a Port...** and enter port `2222`.
+
+5. You're all set! You can connect using SSH as follows:
+
+   ```bash
+   ssh -p 2222 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null codespace@localhost
+   ```
+
+   The `-o` arguments are not required, but will avoid errors about the "known host" signature changing when doing this from multiple codespaces.
+
+6. Enter the password you set in step 3.
+
+That's it! Use similar arguments to those in step 5 when executing `scp` or configuring SSHFS.
 
 ## Using this definition with an existing folder
 

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.16.1",
+	"definitionVersion": "0.17.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
@@ -48,7 +48,6 @@
 			"ncdu",
 			"man-db",
 			"zsh",
-			"yarn",
 			"vim", 
 			"xtail",
 			"fish", 

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -71,6 +71,7 @@
 		],
 		"git": {
 			"Oh My Zsh!": "/home/codespace/.oh-my-zsh",
+			"Oh My Bash!": "/home/codespace/.oh-my-bash",
 			"nvm": "/home/codespace/.nvm",
 			"nvs": "/home/codespace/.nvs"
 		},

--- a/containers/dart/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dart/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/debian/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/debian/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/docker-debian.sh
@@ -14,7 +14,7 @@ USERNAME=${4:-"vscode"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/docker-from-docker/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/docker-debian.sh
@@ -14,7 +14,7 @@ USERNAME=${4:-"vscode"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/dotnetcore-fsharp/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/dotnetcore-fsharp/.devcontainer/library-scripts/azcli-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/dotnetcore/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/dotnetcore/.devcontainer/library-scripts/azcli-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/dotnetcore/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dotnetcore/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/dotnetcore/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/dotnetcore/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/go/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/go/.devcontainer/library-scripts/go-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/go-debian.sh
@@ -16,7 +16,7 @@ INSTALL_GO_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/go/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/java/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/java/.devcontainer/library-scripts/gradle-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/gradle-debian.sh
@@ -19,7 +19,7 @@ if [ "${GRADLE_VERSION}" = "lts" ] || [ "${GRADLE_VERSION}" = "latest" ] || [ "$
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/java/.devcontainer/library-scripts/java-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/java-debian.sh
@@ -19,7 +19,7 @@ if [ "${JAVA_VERSION}" = "lts" ]; then
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/java/.devcontainer/library-scripts/maven-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/maven-debian.sh
@@ -19,7 +19,7 @@ if [ "${MAVEN_VERSION}" = "lts" ] || [ "${MAVEN_VERSION}" = "current" ] || [ "${
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/java/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/javascript-node/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/javascript-node/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/docker-debian.sh
@@ -14,7 +14,7 @@ USERNAME=${4:-"vscode"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/perl/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/perl/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/php/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/php/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/php/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/php/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/powershell/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/powershell/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/python-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/python-debian.sh
@@ -16,7 +16,7 @@ INSTALL_PYTHON_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/python-3/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/python-3/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/python-3/.devcontainer/library-scripts/python-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/python-debian.sh
@@ -16,7 +16,7 @@ INSTALL_PYTHON_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/r/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/r/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/ruby/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/ruby/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/ruby/.devcontainer/library-scripts/ruby-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/ruby-debian.sh
@@ -14,7 +14,7 @@ INSTALL_RUBY_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/rust/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/rust/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/rust/.devcontainer/library-scripts/rust-debian.sh
+++ b/containers/rust/.devcontainer/library-scripts/rust-debian.sh
@@ -15,7 +15,7 @@ UPDATE_RUST=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/swift/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/swift/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/swift/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/swift/.devcontainer/library-scripts/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/azcli-debian.sh
+++ b/script-library/azcli-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -14,7 +14,7 @@ USER_GID=${4:-1000}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -182,44 +182,42 @@ fi
 EOF
 )"
 
-# Codespaces Oh My Bash! theme - based off https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+# Codespaces themes - based off https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
 <<EOF
 #!/usr/bin/env bash
 prompt() {
-    if [ ! -z "${GITHUB_USER}" ]; then
-        local USERNAME="gh:@${GITHUB_USER}"
+    if [ ! -z "\${GITHUB_USER}" ]; then
+        local USERNAME="gh:@\${GITHUB_USER}"
     else
-        local USERNAME="$(whoami)"
+        local USERNAME="\$(whoami)"
     fi
-    local cwd="$(pwd | sed "s|^${HOME}|~|")"
-    if [ "$?" != "0" ]; then
-        local arrow_color=${bold_red}
+    local cwd="\$(pwd | sed "s|^\${HOME}|~|")"
+    if [ "\$?" != "0" ]; then
+        local arrow_color=\${bold_red}
     else
-        local arrow_color=${reset_color}
+        local arrow_color=\${reset_color}
     fi
-    PS1="${green}${USERNAME} ${arrow_color}➜ ${blue}${cwd}${reset_color} $(scm_prompt_info)$ "
+    PS1="\${green}\${USERNAME} \${arrow_color}➜ \${blue}\${cwd}\${reset_color} \$(scm_prompt_info)$ "
 }
-SCM_THEME_PROMPT_PREFIX="${cyan}(${bold_red}"
-SCM_THEME_PROMPT_SUFFIX="${reset_color} "
-SCM_THEME_PROMPT_DIRTY=" ${yellow}✗${cyan})"
-SCM_THEME_PROMPT_CLEAN="${cyan})"
+SCM_THEME_PROMPT_PREFIX="\${cyan}(\${bold_red}"
+SCM_THEME_PROMPT_SUFFIX="\${reset_color} "
+SCM_THEME_PROMPT_DIRTY=" \${yellow}✗\${cyan})"
+SCM_THEME_PROMPT_CLEAN="\${cyan})"
 SCM_GIT_SHOW_MINIMAL_INFO="true"
 safe_append_prompt_command prompt
 EOF
 )"
-
-# Same Oh My Zsh theme
 CODESPACES_ZSH="$(cat \
 <<EOF
 prompt() {
-    if [ ! -z "${GITHUB_USER}" ]; then
-        local USERNAME="gh:@${GITHUB_USER}"
+    if [ ! -z "\${GITHUB_USER}" ]; then
+        local USERNAME="gh:@\${GITHUB_USER}"
     else
-        local USERNAME="$(whoami)"
+        local USERNAME="\$(whoami)"
     fi
-    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
-    PROMPT+='%{$fg[blue]%}%~%{$reset_color%} $(git_prompt_info)$ '
+    PROMPT="%{$fg[green]%}\${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT+='%{$fg[blue]%}%~%{$reset_color%} \$(git_prompt_info)$ '
 }
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -182,7 +182,7 @@ fi
 EOF
 )"
 
-# Codespaces themes - based off https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+# Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
 <<EOF
 #!/usr/bin/env bash
@@ -216,17 +216,19 @@ prompt() {
     else
         local USERNAME="\$(whoami)"
     fi
-    PROMPT="%{$fg[green]%}\${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
-    PROMPT+='%{$fg[blue]%}%~%{$reset_color%} \$(git_prompt_info)$ '
+    PROMPT="%{\$fg[green]%}\${USERNAME} %(?:%{\$reset_color%}➜ :%{\$fg_bold[red]%}➜ )"
+    PROMPT+='%{\$fg[blue]%}%~%{\$reset_color%} \$(git_prompt_info)$ '
 }
-ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}(%{$fg_bold[red]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
-ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[yellow]%}✗%{$fg[cyan]%})"
-ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[cyan]%})"
+ZSH_THEME_GIT_PROMPT_PREFIX="%{\$fg[cyan]%}(%{\$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{\$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{\$fg[yellow]%}✗%{\$fg[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{\$fg[cyan]%})"
 prompt
 EOF
 )"
 
+# Adapted Oh My Zsh! install step to work with both "Oh Mys" rather than relying on an installer script
+# See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
 install-oh-my()
 {
     local OH_MY=$1
@@ -258,6 +260,7 @@ install-oh-my()
         mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
         echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
     fi
+    # Shrink git while still enabling updates
     cd ${OH_MY_INSTALL_DIR} 
     git repack -a -d -f --depth=1 --window=1
 

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -30,7 +30,7 @@ INSTALL_OH_MYS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -4,13 +4,28 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag]
+# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My *! flag]
+#
+# Usage: 
+#
+# 1. Add this file to .devcontainer/library-scripts
+#
+# 2. Add the following to .devcontainer/Dockerfile:
+#
+#    COPY library-scripts/*.sh /tmp/library-scripts/
+#    RUN apt-get update && DEBIAN_FRONTEND=noninteractive \
+#        && bash /tmp/library-scripts/common-debian.sh \
+#        && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+#
+# You can optionally pass in arguments described above to common-debian.sh. Flags are a value of "true" or "false. 
+# Pass in "none" for the username to skip the creation or modification of a non-root user while setting other arguments.
 
 INSTALL_ZSH=${1:-"true"}
 USERNAME=${2:-"vscode"}
 USER_UID=${3:-1000}
 USER_GID=${4:-1000}
 UPGRADE_PACKAGES=${5:-"true"}
+INSTALL_OH_MYS=${6:-"true"}
 
 set -e
 
@@ -85,7 +100,7 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         locales \
         sudo \
         ncdu \
-        man-db" 
+        man-db"
 
     # Install libssl1.1 if available
     if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
@@ -119,7 +134,7 @@ fi
 
 # Ensure at least the en_US.UTF-8 UTF-8 locale is available.
 # Common need for both applications and things like the agnoster ZSH theme.
-if [ "${LOCALE_ALREADY_SET}" != "true" ]; then
+if [ "${LOCALE_ALREADY_SET}" != "true" ] && ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen 
     locale-gen
     LOCALE_ALREADY_SET="true"
@@ -148,6 +163,13 @@ if [ "${USERNAME}" != "root" ] && [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}"
     EXISTING_NON_ROOT_USER="${USERNAME}"
 fi
 
+# ** Shell customization section **
+if [ "${USERNAME}" = "root" ]; then 
+    USER_RC_PATH="/root"
+else
+    USER_RC_PATH="/home/${USERNAME}"
+fi
+
 # .bashrc/.zshrc snippet
 RC_SNIPPET="$(cat << EOF
 export USER=\$(whoami)
@@ -160,27 +182,110 @@ fi
 EOF
 )"
 
-# Ensure ~/.local/bin is in the PATH for root and non-root users for bash. (zsh is later)
+# Codespaces Oh My Bash! theme - based off https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+CODESPACES_BASH="$(cat \
+<<EOF
+#!/usr/bin/env bash
+prompt() {
+    if [ ! -z "${GITHUB_USER}" ]; then
+        local USERNAME="gh:@${GITHUB_USER}"
+    else
+        local USERNAME="$(whoami)"
+    fi
+    local cwd="$(pwd | sed "s|^${HOME}|~|")"
+    if [ "$?" != "0" ]; then
+        local arrow_color=${bold_red}
+    else
+        local arrow_color=${reset_color}
+    fi
+    PS1="${green}${USERNAME} ${arrow_color}➜ ${blue}${cwd}${reset_color} $(scm_prompt_info)$ "
+}
+SCM_THEME_PROMPT_PREFIX="${cyan}(${bold_red}"
+SCM_THEME_PROMPT_SUFFIX="${reset_color} "
+SCM_THEME_PROMPT_DIRTY=" ${yellow}✗${cyan})"
+SCM_THEME_PROMPT_CLEAN="${cyan})"
+SCM_GIT_SHOW_MINIMAL_INFO="true"
+safe_append_prompt_command prompt
+EOF
+)"
+
+# Same Oh My Zsh theme
+CODESPACES_ZSH="$(cat \
+<<EOF
+prompt() {
+    if [ ! -z "${GITHUB_USER}" ]; then
+        local USERNAME="gh:@${GITHUB_USER}"
+    else
+        local USERNAME="$(whoami)"
+    fi
+    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT+='%{$fg[blue]%}%~%{$reset_color%} $(git_prompt_info)$ '
+}
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg[cyan]%}(%{$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg[yellow]%}✗%{$fg[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[cyan]%})"
+prompt
+EOF
+)"
+
+install-oh-my()
+{
+    local OH_MY=$1
+    local OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-${OH_MY}"
+    local TEMPLATE="${OH_MY_INSTALL_DIR}/templates/$2"
+    local OH_MY_GIT_URL=$3
+    local USER_RC_FILE="${USER_RC_PATH}/.${OH_MY}rc"
+
+    if [ -d "${OH_MY_INSTALL_DIR}" ] || [ "${INSTALL_OH_MYS}" != "true" ]; then
+        return 0
+    fi
+
+    umask g-w,o-w
+    mkdir -p ${OH_MY_INSTALL_DIR}
+    git clone --depth=1 \
+        -c core.eol=lf \
+        -c core.autocrlf=false \
+        -c fsck.zeroPaddedFilemode=ignore \
+        -c fetch.fsck.zeroPaddedFilemode=ignore \
+        -c receive.fsck.zeroPaddedFilemode=ignore \
+        ${OH_MY_GIT_URL} ${OH_MY_INSTALL_DIR} 2>&1
+    echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
+    if [ "${OH_MY}" = "bash" ]; then
+        sed -i -e 's/OSH_THEME=.*/OSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes/codespaces
+        echo "${CODESPACES_BASH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces/codespaces.theme.sh
+    else
+        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+        echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
+    fi
+    cd ${OH_MY_INSTALL_DIR} 
+    git repack -a -d -f --depth=1 --window=1
+
+    if [ "${USERNAME}" != "root" ]; then
+        cp -rf ${USER_RC_FILE} ${OH_MY_INSTALL_DIR} /root
+        chown -R ${USERNAME}:${USERNAME} ${USER_RC_PATH}
+    fi
+}
+
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
     echo "${RC_SNIPPET}" >> /etc/bash.bashrc
     RC_SNIPPET_ALREADY_ADDED="true"
 fi
+install-oh-my bash bashrc.osh-template https://github.com/ohmybash/oh-my-bash
 
-# Optionally install and configure zsh
-if [ "${INSTALL_ZSH}" = "true" ] && [ ! -d "/root/.oh-my-zsh" ] && [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
-    apt-get-update-if-needed
-    apt-get install -y zsh
-    curl -fsSLo- https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh | bash 2>&1
-    echo "${RC_SNIPPET}" >> /etc/zsh/zshrc
-    echo -e "DEFAULT_USER=\$USER\nprompt_context(){}" >> /root/.zshrc
-    cp -fR /root/.oh-my-zsh /etc/skel
-    cp -f /root/.zshrc /etc/skel
-    sed -i -e "s/\/root\/.oh-my-zsh/\/home\/\$(whoami)\/.oh-my-zsh/g" /etc/skel/.zshrc
-    if [ "${USERNAME}" != "root" ]; then
-        cp -fR /etc/skel/.oh-my-zsh /etc/skel/.zshrc /home/$USERNAME
-        chown -R $USER_UID:$USER_GID /home/$USERNAME/.oh-my-zsh /home/$USERNAME/.zshrc
+# Optionally install and configure zsh and Oh My Zsh!
+if [ "${INSTALL_ZSH}" = "true" ]; then
+    if ! type zsh > /dev/null 2>&1; then
+        apt-get-update-if-needed
+        apt-get install -y zsh
     fi
-    ZSH_ALREADY_INSTALLED="true"
+    if [ "${ZSH_ALREADY_INSTALLED}" != "true" ]; then
+        echo "${RC_SNIPPET}" >> /etc/zsh/zshrc
+        ZSH_ALREADY_INSTALLED="true"
+    fi
+    install-oh-my zsh zshrc.zsh-template https://github.com/ohmyzsh/ohmyzsh
 fi
 
 # Write marker file

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -15,7 +15,7 @@ UPGRADE_PACKAGES=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/desktop-lite-debian.sh
+++ b/script-library/desktop-lite-debian.sh
@@ -95,7 +95,7 @@ PACKAGE_LIST="
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/docker-debian.sh
+++ b/script-library/docker-debian.sh
@@ -14,7 +14,7 @@ USERNAME=${4:-"vscode"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/docker-redhat.sh
+++ b/script-library/docker-redhat.sh
@@ -9,7 +9,7 @@ NONROOT_USER=${4:-"vscode"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/git-from-src-debian.sh
+++ b/script-library/git-from-src-debian.sh
@@ -5,7 +5,7 @@ GIT_VERSION=${1:-"2.27.0"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/git-lfs-debian.sh
+++ b/script-library/git-lfs-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/github-debian.sh
+++ b/script-library/github-debian.sh
@@ -11,7 +11,7 @@ CLI_VERSION=${1:-"latest"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -16,7 +16,7 @@ INSTALL_GO_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/gradle-debian.sh
+++ b/script-library/gradle-debian.sh
@@ -19,7 +19,7 @@ if [ "${GRADLE_VERSION}" = "lts" ] || [ "${GRADLE_VERSION}" = "latest" ] || [ "$
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/java-debian.sh
+++ b/script-library/java-debian.sh
@@ -19,7 +19,7 @@ if [ "${JAVA_VERSION}" = "lts" ]; then
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/maven-debian.sh
+++ b/script-library/maven-debian.sh
@@ -19,7 +19,7 @@ if [ "${MAVEN_VERSION}" = "lts" ] || [ "${MAVEN_VERSION}" = "current" ] || [ "${
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/node-debian.sh
+++ b/script-library/node-debian.sh
@@ -14,7 +14,7 @@ UPDATE_RC=${4:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/powershell-debian.sh
+++ b/script-library/powershell-debian.sh
@@ -9,7 +9,7 @@
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/python-debian.sh
+++ b/script-library/python-debian.sh
@@ -16,7 +16,7 @@ INSTALL_PYTHON_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/ruby-debian.sh
+++ b/script-library/ruby-debian.sh
@@ -14,7 +14,7 @@ INSTALL_RUBY_TOOLS=${6:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/rust-debian.sh
+++ b/script-library/rust-debian.sh
@@ -15,7 +15,7 @@ UPDATE_RUST=${5:-"true"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/sshd-debian.sh
+++ b/script-library/sshd-debian.sh
@@ -16,7 +16,7 @@ NEW_PASSWORD=${4:-"skip"}
 set -e
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 

--- a/script-library/terraform-debian.sh
+++ b/script-library/terraform-debian.sh
@@ -17,7 +17,7 @@ if [ -z "$1" ]; then
 fi
 
 if [ "$(id -u)" -ne 0 ]; then
-    echo -e 'Script must be run a root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
     exit 1
 fi
 


### PR DESCRIPTION
For #560, #561

This PR adds an SSH server to the codespaces-linux image. Instructions for use are in the [README](https://github.com/microsoft/vscode-dev-containers/tree/clantz/codespaces-ssh/containers/codespaces-linux#accessing-the-container-using-ssh-scp-or-sshfs).

It also adds Oh My Bash! for shell customization and a default theme. The theme will includes prompt with `gh:@<userid>` if `GITHUB_USER` is set and otherwise uses `whoami` to show the current active user. 

The themes are embedded in [common-debian.sh](https://github.com/microsoft/vscode-dev-containers/blob/clantz/codespaces-ssh/script-library/common-debian.sh) so we can easily update them as we finalize without requiring multiple script files to be copied around.

//cc: @jkeech 