### PR TITLE
Fix inappropriate MongoDB reference in favor of PSQL

### DIFF
--- a/containers/python-3-postgres/.devcontainer/docker-compose.yml
+++ b/containers/python-3-postgres/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   app:
-    build: 
+    build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
@@ -17,17 +17,17 @@ services:
 
     volumes:
       - ..:/workspace:cached
-      
+
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
-    
+
     # Runs app on the same network as the database container, allows "forwardPorts" in devcontainer.json function.
     network_mode: service:db
 
     # Uncomment the next line to use a non-root user for all processes.
     # user: vscode
 
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
@@ -40,7 +40,7 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_PASSWORD: postgres
 
-    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward MongoDB locally.
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
 volumes:


### PR DESCRIPTION
The goal of this PR is to make a superfluous change in the python 3 postgres container docker-compose.yml.

Currently, the docker-compose.yml file notes:

`# Add "forwardPorts": ["5432"] to **devcontainer.json** to forward MongoDB locally` 

The proposed change simply adjusts `MongoDB` to `PostgreSQL` and strips trailing whitespace throughout `docker-compose.yml`.