### PR TITLE
Use code as shim instead of as an alias

### DIFF
--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -183,12 +183,29 @@ RC_SNIPPET="$(cat << EOF
 export USER=\$(whoami)
 
 export PATH=\$PATH:\$HOME/.local/bin
-
-if type code-insiders > /dev/null 2>&1 && ! type code > /dev/null 2>&1; then 
-    alias code=code-insiders
-fi
 EOF
 )"
+
+# code shim, it fallbacks to code-insiders if code is not available
+cat << 'EOF' > /usr/local/bin/code
+#!/bin/sh
+
+get_in_path_except_current() {
+  which -a "$1" | grep -v "$0" | head -1
+}
+
+code="$(get_in_path_except_current code)"
+
+if [ -n "$code" ]; then
+  exec "$code" "$@"
+elif [ "$(command -v code-insiders)" ]; then
+  exec code-insiders "$@"
+else
+  echo "code or code-insiders is not installed" >&2
+  exit 127
+fi
+EOF
+chmod +x /usr/local/bin/code
 
 # Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \


### PR DESCRIPTION
This is a better approach, since using alias does not make it work when `code` is called by CLIs, such as `git` or `gh`.

PS: this does not take precedence over the normal `code` binary, so it's harmless when it's not useful. See:

```sh-session
$ which -a code
/home/vscode/.vscode-server/bin/58bb7b2331731bf72587010e943852e13e6fd3cf/bin/code
/usr/local/bin/code
```

References https://github.com/MicrosoftDocs/vscodespaces/issues/809.