### PR TITLE
Fix schellcheck warning in Debian desktop script

### DIFF
--- a/script-library/desktop-lite-debian.sh
+++ b/script-library/desktop-lite-debian.sh
@@ -63,7 +63,7 @@ fi
 # Determine the appropriate non-root user
 if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
     USERNAME=""
-    POSSIBLE_USERS=("vscode", "node", "codespace", "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
     for CURRENT_USER in ${POSSIBLE_USERS[@]}; do
         if id -u ${CURRENT_USER} > /dev/null 2>&1; then
             USERNAME=${CURRENT_USER}


### PR DESCRIPTION
See https://github.com/koalaman/shellcheck/wiki/SC2054 for background. Seems like a reasonable complaint.