### PR TITLE
Clarify terminology for Debian Lite

### DIFF
--- a/script-library/docs/desktop-lite.md
+++ b/script-library/docs/desktop-lite.md
@@ -45,7 +45,7 @@
 
     The `runArgs` allows the container to take advantage of an [init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to handle application and process signals in a desktop environment.
 
-4. Once you've started the container / codespace, you'll be able to use a web based desktop viewer on port **6080** from anywhere or connect a [VNC viewer](https://www.realvnc.com/en/connect/download/viewer/) to port **5901** when accessing the codespace from VS Code.
+4. Once you've started the container / codespace, you'll be able to use a browser on port **6080** from anywhere or connect a [VNC viewer](https://www.realvnc.com/en/connect/download/viewer/) to port **5901** when accessing the codespace from VS Code.
 
 5. Default **password**: `vscode`
 


### PR DESCRIPTION
I was honestly not sure what a "web based desktop viewer" exactly meant given that instructions are also talking about VNC in the same context, but it did turn out to be just a normal web browser.