### PR TITLE
Fix typo in php-mariadb's README.md

### DIFF
--- a/containers/php-mariadb/README.md
+++ b/containers/php-mariadb/README.md
@@ -51,7 +51,7 @@ You also can connect to MariaDB from an external tool when using VS Code by upda
 
 ### Adding another service
 
-You can add other services to your `docker-compose.yml` file [as described in Docker's documentaiton](https://docs.docker.com/compose/compose-file/#service-configuration-reference). However, if you want anything running in this service to be available in the container on localhost, or want to forward the service locally, be sure to add this line to the service config:
+You can add other services to your `docker-compose.yml` file [as described in Docker's documentation](https://docs.docker.com/compose/compose-file/#service-configuration-reference). However, if you want anything running in this service to be available in the container on localhost, or want to forward the service locally, be sure to add this line to the service config:
 
 ```yaml
 # Runs the service on the same network as the database container, allows "forwardPorts" in devcontainer.json function.

--- a/containers/php-mariadb/README.md
+++ b/containers/php-mariadb/README.md
@@ -74,22 +74,6 @@ If you want to wire in something directly from your source code into the `www` f
 sudo rm -rf /var/www/html && sudo ln -s . /var/www/html
 ```
 
-### Starting / stopping Apache
-
-This dev container includes Apache in addition to the PHP CLI. While you can use PHP's built in CLI (e.g. `php -S 0.0.0.0:8080`), you can start Apache by running:
-
-```bash
-apache2ctl start
-```
-
-Apache will be available on port `8080`.
-
-If you want to wire in something directly from your source code into the `www` folder, you can add a symlink as follows to `postCreateCommand`:
-
-```bash
-sudo rm -rf /var/www/html && sudo ln -s . /var/www/html
-```
-
 ### Adding the definition to your project
 
 1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.


### PR DESCRIPTION
Fix a typo, and remove a paragraph present twice