### PR TITLE
[Codespaces] Installing libsecret-1-dev by default

### DIFF
--- a/containers/codespaces-linux/.devcontainer/base.Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/base.Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove 'imagemagick imagemagick-6-common' due to http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install tools and shells not in common script
-    && apt-get install -yq vim xtail software-properties-common \
+    && apt-get install -yq vim xtail software-properties-common libsecret-1-dev \
     && bash /tmp/scripts/sshd-debian.sh \
     && bash /tmp/scripts/git-lfs-debian.sh \
     && bash /tmp/scripts/github-debian.sh \


### PR DESCRIPTION
This PR simply installs the `libsecret-1-dev` package in the universal image, which ensures that common app scenarios work without any further modification (e.g. Node apps that depend on `keytar`). Without this, developers that are using macOS might be surprised to see that their environment no longer works, because they aren't used to the extra requirements for Linux.