### PR TITLE
chore: changing "restart" to "start" of sshd server

### DIFF
--- a/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
@@ -86,9 +86,9 @@ tee /usr/local/share/ssh-init.sh > /dev/null \
 set -e 
 
 if [ "\$(id -u)" -ne 0 ]; then
-    sudo /etc/init.d/ssh restart
+    sudo /etc/init.d/ssh start
 else
-    /etc/init.d/ssh restart
+    /etc/init.d/ssh start
 fi
 
 set +e

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.19.0",
+	"definitionVersion": "0.19.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/script-library/sshd-debian.sh
+++ b/script-library/sshd-debian.sh
@@ -86,9 +86,9 @@ tee /usr/local/share/ssh-init.sh > /dev/null \
 set -e 
 
 if [ "\$(id -u)" -ne 0 ]; then
-    sudo /etc/init.d/ssh restart
+    sudo /etc/init.d/ssh start
 else
-    /etc/init.d/ssh restart
+    /etc/init.d/ssh start
 fi
 
 set +e


### PR DESCRIPTION
pid file of the sshd server gets saved in the container. When it is restarted on a different VM, the pid is different and that process gets killed.
This results in random process kills and failure of about 10% of the resumes.
Fix is to change "restart" to "start" so that no process gets killed as container doesn't have any processes at that time.