### PR TITLE
Add trailing comma after extensions array

### DIFF
--- a/container-templates/docker-compose/.devcontainer/devcontainer.json
+++ b/container-templates/docker-compose/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [],
 
 	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
 	// "shutdownAction": "none",

--- a/container-templates/dockerfile/.devcontainer/devcontainer.json
+++ b/container-templates/dockerfile/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/container-templates/image/.devcontainer/devcontainer.json
+++ b/container-templates/image/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/alpine/.devcontainer/devcontainer.json
+++ b/containers/alpine/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	// Note that some extensions may not work in Alpine Linux. See https://aka.ms/vscode-remote/linux.
-	"extensions": []
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/azure-ansible/.devcontainer/devcontainer.json
+++ b/containers/azure-ansible/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 		"redhat.vscode-yaml",
 		"ms-vscode.azurecli",
 		"ms-azuretools.vscode-docker"
-	]
+	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 

--- a/containers/azure-blockchain/.devcontainer/devcontainer.json
+++ b/containers/azure-blockchain/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	"extensions": [
 		"ms-vscode.azurecli",
 		"azblockchain.azure-blockchain"
-	]	
+	],	
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/azure-cli/.devcontainer/devcontainer.json
+++ b/containers/azure-cli/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-vscode.azurecli"
-	]
+	],
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"ms-dotnettools.csharp"
-	]
+	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",

--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"ms-dotnettools.csharp"
-	]
+	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",

--- a/containers/azure-functions-java-11/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-11/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"vscjava.vscode-java-pack"
-	]
+	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "java -version",

--- a/containers/azure-functions-java-8/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-8/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"vscjava.vscode-java-pack"
-	]
+	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "java -version",

--- a/containers/azure-functions-pwsh/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-pwsh/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	"extensions": [
 		"ms-azuretools.vscode-azurefunctions",
 		"ms-vscode.powershell"
-	]
+	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",

--- a/containers/azure-machine-learning-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-machine-learning-python-3/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 	"extensions": [ 
 		"ms-toolsai.vscode-ai",
 		"ms-azuretools.vscode-docker"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/azure-terraform/.devcontainer/devcontainer.json
+++ b/containers/azure-terraform/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 		"ms-azuretools.vscode-azureterraform",
 		"ms-vscode.azurecli",
 		"ms-azuretools.vscode-docker"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/bazel/.devcontainer/devcontainer.json
+++ b/containers/bazel/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"devondcarew.bazel-code"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/codespaces-linux/.devcontainer/devcontainer.json
+++ b/containers/codespaces-linux/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
 		"GitHub.vscode-pull-request-github",
 		"MS-vsliveshare.vsliveshare",
 		"VisualStudioExptTeam.vscodeintellicode"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/cpp/.devcontainer/devcontainer.json
+++ b/containers/cpp/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-vscode.cpptools"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/dapr-dotnetcore-3.1/.devcontainer/devcontainer.json
+++ b/containers/dapr-dotnetcore-3.1/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 		"ms-azuretools.vscode-dapr",
 		"ms-azuretools.vscode-docker",
 		"ms-dotnettools.csharp"
-	]
+	],
 
 	// Uncomment the next line if you want start specific services in your Docker Compose config.
 	// "runServices": [],

--- a/containers/dapr-typescript-node-12/.devcontainer/devcontainer.json
+++ b/containers/dapr-typescript-node-12/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
 		"ms-azuretools.vscode-dapr",
 		"ms-azuretools.vscode-docker",
 		"ms-vscode.vscode-typescript-tslint-plugin"
-	]
+	],
 
 	// Uncomment the next line if you want start specific services in your Docker Compose config.
 	// "runServices": [],

--- a/containers/dart/.devcontainer/devcontainer.json
+++ b/containers/dart/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dart-code.dart-code"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/debian/.devcontainer/devcontainer.json
+++ b/containers/debian/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/docker-existing-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-existing-docker-compose/.devcontainer/devcontainer.json
@@ -23,7 +23,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/docker-existing-dockerfile/.devcontainer/devcontainer.json
+++ b/containers/docker-existing-dockerfile/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/docker-from-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-from-docker-compose/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-azuretools.vscode-docker"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/docker-from-docker/.devcontainer/devcontainer.json
+++ b/containers/docker-from-docker/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-azuretools.vscode-docker"
-	]
+	],
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/dotnetcore-fsharp/.devcontainer/devcontainer.json
+++ b/containers/dotnetcore-fsharp/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 	"extensions": [
 		"Ionide.Ionide-fsharp",
 		"ms-dotnettools.csharp"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/dotnetcore/.devcontainer/devcontainer.json
+++ b/containers/dotnetcore/.devcontainer/devcontainer.json
@@ -20,7 +20,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-dotnettools.csharp"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [5000, 5001],

--- a/containers/elm/.devcontainer/devcontainer.json
+++ b/containers/elm/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"Elmtooling.elm-ls-vscode"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// 8000 is the default port used for the `elm reactor` command

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"golang.Go"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/java-8/.devcontainer/devcontainer.json
+++ b/containers/java-8/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"vscjava.vscode-java-pack"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"vscjava.vscode-java-pack"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/javascript-node-mongo/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-mongo/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 	"extensions": [
 		"dbaeumer.vscode-eslint",
 		"mongodb.mongodb-vscode" 
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [3000, 27017],

--- a/containers/javascript-node-postgres/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-postgres/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 		"dbaeumer.vscode-eslint",
 		"mtxr.sqltools",
 		"mtxr.sqltools-driver-pg"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [3000, 5432],

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/kubernetes-helm/.devcontainer/devcontainer.json
+++ b/containers/kubernetes-helm/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	"extensions": [
 		"ms-azuretools.vscode-docker",
 		"ms-kubernetes-tools.vscode-kubernetes-tools"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/markdown/.devcontainer/devcontainer.json
+++ b/containers/markdown/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
 		"DavidAnson.vscode-markdownlint",
 		"shd101wyy.markdown-preview-enhanced",
 		"bierner.github-markdown-preview"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/perl/.devcontainer/devcontainer.json
+++ b/containers/perl/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 	"extensions": [
 		"mortenhenriksen.perl-debug",
 		"d9705996.perl-toolbox"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/powershell/.devcontainer/devcontainer.json
+++ b/containers/powershell/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-vscode.powershell"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/puppet/.devcontainer/devcontainer.json
+++ b/containers/puppet/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	"extensions": [
 		"puppet.puppet-vscode",
 		"rebornix.Ruby"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/python-3-anaconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-anaconda/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
+++ b/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 	"extensions": [
 		"ms-python.python",
 		"ms-python.devicesimulatorexpress"
-	]
+	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 

--- a/containers/python-3-miniconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-miniconda/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/python-3-postgres/.devcontainer/devcontainer.json
+++ b/containers/python-3-postgres/.devcontainer/devcontainer.json
@@ -38,7 +38,7 @@
 		"ms-python.python",
 		"mtxr.sqltools",
 		"mtxr.sqltools-driver-pg"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [5000, 5432],

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ikuyadeu.r"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/reasonml/.devcontainer/devcontainer.json
+++ b/containers/reasonml/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"jaredly.reason-vscode"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/ruby-rails/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"rebornix.Ruby"
-	]
+	],
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/ruby-sinatra/.devcontainer/devcontainer.json
+++ b/containers/ruby-sinatra/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"rebornix.Ruby"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [4567],

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -19,7 +19,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"rebornix.Ruby"
-	]
+	],
 	
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/rust/.devcontainer/devcontainer.json
+++ b/containers/rust/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
 		"mutantdino.resourcemonitor"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/swift/.devcontainer/devcontainer.json
+++ b/containers/swift/.devcontainer/devcontainer.json
@@ -29,7 +29,7 @@
 	"extensions": [
 		"vknabel.vscode-swift-development-environment",
 		"vadimcn.vscode-lldb"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
 	"extensions": [
 		"dbaeumer.vscode-eslint",
 		"ms-vscode.vscode-typescript-tslint-plugin"
-	]
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/ubuntu/.devcontainer/devcontainer.json
+++ b/containers/ubuntu/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": []
+	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],


### PR DESCRIPTION
This would be convenience since we don't have to add a comma after the `extensions` array whenever we need to use an option below this `entensions` option. 

We already did that with the following devcontainer:

- containers/azure-functions-node/.devcontainer/devcontainer.json
- containers/azure-functions-python-3/.devcontainer/devcontainer.json
- containers/bash/.devcontainer/devcontainer.json
- containers/deno/.devcontainer/devcontainer.json
- containers/hugo/.devcontainer/devcontainer.json
- containers/jekyll/.devcontainer/devcontainer.json
- containers/php/.devcontainer/devcontainer.json
- containers/php-mariadb/.devcontainer/devcontainer.json
- containers/vue/.devcontainer/devcontainer.json