### PR TITLE
Modified node-postgres docker-compose for GH codespaces

### DIFF
--- a/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
@@ -36,8 +36,10 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
 
-    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward MongoDB locally.
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward Postgres locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
 volumes:


### PR DESCRIPTION
The node-postgres docker-compose works as expected if using the Remote Development - Containers extension in VS Code. However, when using this docker-compose in GitHub codespaces the networking is not created correctly and the node container cannot access the postgres container. This change allows the `5432` port to be shared with the host so it works as intended in GitHub codespaces. It will not impact users working locally.