### PR TITLE
Fix paths in .npmignore for Julia

### DIFF
--- a/containers/julia/.npmignore
+++ b/containers/julia/.npmignore
@@ -1,6 +1,4 @@
-../README.md
-../test-project
-../.vscode/launch.json
-../.vscode/launch.test.json
-../.vscode/settings.json
-../.vscode/tasks.json
+README.md
+test-project
+.vscode
+.npmignore


### PR DESCRIPTION
I believe the current paths in there are the reason while files are copied into user repositories that shouldn't really be copied.