### PR TITLE
Move Julia post create commands into the image

### DIFF
--- a/containers/julia/.devcontainer/devcontainer.json
+++ b/containers/julia/.devcontainer/devcontainer.json
@@ -3,6 +3,6 @@
 	"name": "Julia (Community)",
 	"image": "ghcr.io/julia-vscode/julia-devcontainer",
 	"extensions": ["julialang.language-julia"],
-	"postCreateCommand": "julia --project=. -e 'using Pkg; if (isfile(joinpath(pwd(),\"Manifest.toml\")) || isfile(joinpath(pwd(),\"JuliaManifest.toml\"))) && (isfile(joinpath(pwd(),\"Project.toml\")) || isfile(joinpath(pwd(),\"JuliaProject.toml\"))); Pkg.instantiate(); end'",
+	"postCreateCommand": "/julia-devcontainer-scripts/postcreate.jl",
 	"remoteUser": "vscode"
 }


### PR DESCRIPTION
This significantly simplifies the template for Julia by moving all the code that we had here in the template into a Julia script file that is part of the julia-devcontainer docker image. This also makes it very easy for us to update that post create script without having to update anything here in this repo.

You can see the content of `postcreate.jl` [here](https://github.com/julia-vscode/julia-devcontainer/blob/master/postcreate.jl). It is already a bit richer than what we have here currently, and I expect that it will get better as we move forward.

The docker file now copies that file into the `julia-devcontainer`, see [here](https://github.com/julia-vscode/julia-devcontainer/blob/1b95bb98456f8bd6bd491ec4cb931dcbdf501ac7/Dockerfile#L33).

I think this is all getting very, very close to super convenient :) In my ideal world a user wouldn't even have to specify this `postCreateCommand` at all. Maybe something like that: at the stage where codespaces right now runs the `postCreateCommand`, it would first check for the existence of some standard post create script in the docker image, say `/codespaces/postcreate.sh`. If that file exists in the docker image, codespaces would run it. If the user had additionally specified something in the `postCreateCommand` setting in `.devcontainer`, it would run that next. But, for another day :)

PS: Random other question. Is there a way to host our docker image somehow differently, so that a user could just write `"image": "julia-devcontainer"`? Just something shorter that is not a full URL?