### PR TITLE
Install php extensions

### DIFF
--- a/containers/php-mariadb/.devcontainer/Dockerfile
+++ b/containers/php-mariadb/.devcontainer/Dockerfile
@@ -6,7 +6,10 @@ FROM mcr.microsoft.com/vscode/devcontainers/php:dev-${VARIANT}
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y mariadb-client \ 
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
+    
+# Install PHP extensions
+RUN docker-php-ext-install pdo_mysql
+    
 # Update args in docker-compose.yaml to set the UID/GID of the "vscode" user.
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID


### PR DESCRIPTION
This would be more convenience because the user would definitely have to install this extension to connect to the database. And this also introduce an official way to install php extensions in the official php docker.