### PR TITLE
Updates to Jekyll container

### DIFF
--- a/containers/jekyll/.devcontainer/Dockerfile
+++ b/containers/jekyll/.devcontainer/Dockerfile
@@ -3,13 +3,13 @@ FROM mcr.microsoft.com/vscode/devcontainers/ruby:2
 # ENV Variables required by Jekyll
 ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
-    TZ=America/Chicago \
+    TZ=Etc/UTC \
     LC_ALL=en_US.UTF-8 \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US
 
-    # Install jekyll
-RUN gem install bundler jekyll
+# Install bundler
+RUN gem install bundler
 
 # [Option] Install Node.js
 ARG NODE_VERSION="lts/*"

--- a/containers/jekyll/.devcontainer/devcontainer.json
+++ b/containers/jekyll/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
+			// Enable Node.js: pick the latest LTS version
 			"NODE_VERSION": "lts/*"
 		}	
 	},
@@ -16,10 +17,15 @@
 	"extensions": [],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [4000],
+	"forwardPorts": [
+		// Jekyll server
+		4000,
+		// Live reload server
+		35729
+	],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "bundle install",
+	"postCreateCommand": "sh .devcontainer/post-create.sh",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/containers/jekyll/.devcontainer/post-create.sh
+++ b/containers/jekyll/.devcontainer/post-create.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# If there's a Gemfile, then run `bundle install`
+# It's assumed that the Gemfile will install Jekyll too
+if [ -f Gemfile ]; then
+    bundle install
+else
+    # If there's no Gemfile, install Jekyll
+    sudo gem install jekyll
+fi

--- a/containers/jekyll/README.md
+++ b/containers/jekyll/README.md
@@ -13,6 +13,11 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Ruby, Jekyll |
 
+In addition to Ruby and Bundler, this development container installs Jekyll and the required tools at startup:
+
+- If your Jekyll project contains a `Gemfile` in the root folder, the development container will install all gems at startup by running `bundle install`. This is the [recommended](https://jekyllrb.com/docs/step-by-step/10-deployment/#gemfile) approach as it allows you to specify the exact Jekyll version your project requires and list all additional Jekyll plugins.
+- If there's no `Gemfile`, the development container will install Jekyll automatically, picking the latest version. You might need to manually install the other dependencies your project relies on, including all relevant Jekyll plugins.
+
 ## Using this definition with an existing folder
 
 Follow these steps:


### PR DESCRIPTION
This PR contains a few updates to the Jekyll container

1. If there's a Gemfile, do not install Jekyll by default. Doing that would automatically install the latest version, which may or may not be what the user wants. Instead, run `bundle install` in the post-create step. If there's no Gemfile, then installs jekyll in the post-create step. This should be a compromise for #447 
2. Adding live reload server port to the list of ports (for `jekyll serve -l`)
3. Updated default time zone to a more universal Etc/UTC