### PR TITLE
Changes to the Hugo container

### DIFF
--- a/containers/hugo/.devcontainer/Dockerfile
+++ b/containers/hugo/.devcontainer/Dockerfile
@@ -1,11 +1,13 @@
-FROM golang:1.13
+# Update the NODE_VERSION arg in docker-compose.yml to pick a Node version: 10, 12, 14
+ARG NODE_VERSION=14
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
 
 # VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
 ARG VARIANT=hugo
 # VERSION can be either 'latest' or a specific version number
 ARG VERSION=latest
 
-# Download and patch selected Hugo binary
+# Download Hugo
 RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \
     rm -rf /var/lib/apt/lists/* && \
     case ${VERSION} in \
@@ -15,13 +17,9 @@ RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \
     echo ${VERSION} && \
     wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-64bit.tar.gz && \
     tar xf ${VERSION}.tar.gz && \
-    mv hugo* /usr/bin/hugo && \
-    go get github.com/yaegashi/muslstack && \
-    muslstack -s 0x800000 /usr/bin/hugo
+    mv hugo /usr/bin/hugo
 
-# Copy patched hugo binary from build stage
-FROM mcr.microsoft.com/vscode/devcontainers/base
-COPY --from=0 /usr/bin/hugo /usr/bin
+# Hugo dev server port
 EXPOSE 1313
 
 # [Optional] Uncomment this section to install additional OS packages you may want.
@@ -29,3 +27,5 @@ EXPOSE 1313
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
+# [Optional] Uncomment if you want to install more global node packages
+# RUN sudo -u node npm install -g <your-package-list-here>

--- a/containers/hugo/.devcontainer/devcontainer.json
+++ b/containers/hugo/.devcontainer/devcontainer.json
@@ -11,6 +11,8 @@
 			// Example versions: latest, 0.73.0, 0,71.1
 			// Rebuild the container if it already exists to update.
 			"VERSION": "latest",
+			// Update NODE_VERSION to pick the Node.js version: 12, 14
+			"NODE_VERSION": "14",
 		}
 	},
 

--- a/containers/hugo/.vscode/tasks.json
+++ b/containers/hugo/.vscode/tasks.json
@@ -12,6 +12,7 @@
                 "isDefault": true
             },
             "isBackground": true,
+            "problemMatcher": []
         },
         {
             "label": "Build",
@@ -21,6 +22,7 @@
                 "kind": "build",
                 "isDefault": true
             },
+            "problemMatcher": []
         }
     ]
 }

--- a/containers/hugo/README.md
+++ b/containers/hugo/README.md
@@ -13,6 +13,16 @@
 | *Container OS*              | Debian                                       |
 | *Languages, platforms*      | Hugo                                         |
 
+This development container includes the Hugo static site generator as well as Node.js (to help with working on themes).
+
+There are 3 configuration options in the `devcontainer.json` file:
+
+- `VARIANT`: the default value is `hugo`. Set this to `hugo_extended` if you want to use SASS/SCSS
+- `VERSION`: version of Hugo to download, e.g. `0.71.1`. The default value is `latest`, which always picks the latest version available.
+- `NODE_VERSION`: version of Node.js to use, for example `14` (the default value)
+
+The `.vscode` folder additionally contains a sample `tasks.json` file that can be used to set up Visual Studio Code [tasks](https://code.visualstudio.com/docs/editor/tasks) for working with Hugo sites.
+
 ## Using this definition with an existing folder
 
 Just follow these steps:


### PR DESCRIPTION
1. Re-basing this to the Node.js container because that can be very useful to build themes (note: this container does not include Go just like the old container didn't - I don't believe this is necessary when working with Hugo).
2. Removed a command that was patching the binary. That is not necessary when not running on Alpine (the container runs on Debian)
3. The downloaded binary is always called `hugo` (even in extended mode), so changed `mv hugo*` to `mv hugo` to be on the safer side
4. Disabled problem matchers in tasks.json