### PR TITLE
Update containers/dotnet readme

### DIFF
--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -157,13 +157,12 @@ This definition includes some test code that will help you verify it is working 
 1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
 2. Clone this repository.
 3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
-4. Select the `containers/dotnetcore` folder.
+4. Select the `containers/dotnet` folder.
 5. After the folder has opened in the container, if prompted to restore packages in a notification, click "Restore".
 6. After packages are restored, press <kbd>F5</kbd> to start the project.
-7. Once the project is running, press <kbd>F1</kbd> and select **Remote-Containers: Forward Port from Container...**
-8. Select port 8090 and click the "Open Browser" button in the notification that appears.
-9. You should see "Hello remote world from ASP.NET!" after the page loads.
-10. From here, you can add breakpoints or edit the contents of the `test-project` folder to do further testing.
+7. Once the project is running, open your browser to http://0.0.0.0:8090. Or, in the Debug Console view, select the "http://0.0.0.0:8090" link.
+8. You should see "Hello remote world from ASP.NET!" after the page loads.
+9. From here, you can add breakpoints or edit the contents of the `test-project` folder to do further testing.
 
 ## License
 


### PR DESCRIPTION
Updated the **containers/dotnetcore** folder to containers/dotnet.

Also, in VS Code 1.51.1, I did not see the **Remote-Containers: Forward Port from Container** option so I updated the steps there as well. See below:
![image](https://user-images.githubusercontent.com/289304/101488683-e9937a00-392d-11eb-944e-2030d3de38a4.png)
