### PR TITLE
[Codespaces] Manually set the name oryx uses for python venv

### DIFF
--- a/containers/codespaces-linux/.devcontainer/devcontainer.json
+++ b/containers/codespaces-linux/.devcontainer/devcontainer.json
@@ -43,5 +43,5 @@
 	// "forwardPorts": [],
 
 	// "oryx build" will automatically install your dependencies and attempt to build your project
-	"postCreateCommand": "oryx build || echo 'Could not auto-build. Skipping.'"
+	"postCreateCommand": "oryx build -p virtualenv_name=.venv || echo 'Could not auto-build. Skipping.'"
 }


### PR DESCRIPTION
As illustrated [in the Oryx repo](https://github.com/microsoft/Oryx/blob/1a35fbce482b20b71290f3a837a3469803ce4b44/src/BuildScriptGenerator/Python/PythonPlatform.cs#L547) you can set the python venv manually.  Fixes [public feedback](https://github.community/t/codespace-doesnt-handle-python-venv-properly/137691) and an internal issue referring to venv naming being unintuitive in codespaces.