### PR TITLE
Tidy up whitespace in Go dev container

### DIFF
--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -21,7 +21,7 @@ COPY library-scripts/go-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/go-debian.sh "none" "/usr/local/go" "${GOPATH}" "${USERNAME}" "false" \
     && apt-get clean -y && rm -rf /tmp/library-scripts
 
-# [Option] Install Node.js 
+# [Option] Install Node.js
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
+	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"go.useGoProxyToCheckForToolUpdates": false,
 		"go.useLanguageServer": true,
@@ -21,7 +21,7 @@
 		"go.goroot": "/usr/local/go",
 		"go.toolsGopath": "/go/bin"
 	},
-	
+
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"golang.Go"

--- a/containers/go/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/common-debian.sh
@@ -113,7 +113,7 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
     if [[ ! -z $(apt-cache --names-only search ^libssl1.1$) ]]; then
         PACKAGE_LIST="${PACKAGE_LIST}       libssl1.1"
     fi
-    
+
     # Install appropriate version of libssl1.0.x if available
     LIBSSL=$(dpkg-query -f '${db:Status-Abbrev}\t${binary:Package}\n' -W 'libssl1\.0\.?' 2>&1 || echo '')
     if [ "$(echo "$LIBSSL" | grep -o 'libssl1\.0\.[0-9]:' | uniq | sort | wc -l)" -eq 0 ]; then
@@ -128,7 +128,7 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
 
     echo "Packages to verify are installed: ${PACKAGE_LIST}"
     apt-get -y install --no-install-recommends ${PACKAGE_LIST} 2> >( grep -v 'debconf: delaying package configuration, since apt-utils is not installed' >&2 )
-        
+
     PACKAGES_ALREADY_INSTALLED="true"
 fi
 
@@ -142,7 +142,7 @@ fi
 # Ensure at least the en_US.UTF-8 UTF-8 locale is available.
 # Common need for both applications and things like the agnoster ZSH theme.
 if [ "${LOCALE_ALREADY_SET}" != "true" ] && ! grep -o -E '^\s*en_US.UTF-8\s+UTF-8' /etc/locale.gen > /dev/null; then
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen 
+    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
     locale-gen
     LOCALE_ALREADY_SET="true"
 fi
@@ -150,11 +150,11 @@ fi
 # Create or update a non-root user to match UID/GID.
 if id -u ${USERNAME} > /dev/null 2>&1; then
     # User exists, update if needed
-    if [ "${USER_GID}" != "automatic" ] && [ "$USER_GID" != "$(id -G $USERNAME)" ]; then 
-        groupmod --gid $USER_GID $USERNAME 
+    if [ "${USER_GID}" != "automatic" ] && [ "$USER_GID" != "$(id -G $USERNAME)" ]; then
+        groupmod --gid $USER_GID $USERNAME
         usermod --gid $USER_GID $USERNAME
     fi
-    if [ "${USER_UID}" != "automatic" ] && [ "$USER_UID" != "$(id -u $USERNAME)" ]; then 
+    if [ "${USER_UID}" != "automatic" ] && [ "$USER_UID" != "$(id -u $USERNAME)" ]; then
         usermod --uid $USER_UID $USERNAME
     fi
 else
@@ -164,7 +164,7 @@ else
     else
         groupadd --gid $USER_GID $USERNAME
     fi
-    if [ "${USER_UID}" = "automatic" ]; then 
+    if [ "${USER_UID}" = "automatic" ]; then
         useradd -s /bin/bash --gid $USERNAME -m $USERNAME
     else
         useradd -s /bin/bash --uid $USER_UID --gid $USERNAME -m $USERNAME
@@ -179,7 +179,7 @@ if [ "${USERNAME}" != "root" ] && [ "${EXISTING_NON_ROOT_USER}" != "${USERNAME}"
 fi
 
 # ** Shell customization section **
-if [ "${USERNAME}" = "root" ]; then 
+if [ "${USERNAME}" = "root" ]; then
     USER_RC_PATH="/root"
 else
     USER_RC_PATH="/home/${USERNAME}"
@@ -230,7 +230,7 @@ prompt() {
     fi
     local cwd="\$(pwd | sed "s|^\${HOME}|~|")"
     PS1="\${green}\${USERNAME} \${arrow_color}➜\${reset_color} \${bold_blue}\${cwd}\${reset_color} \$(scm_prompt_info)\${white}$ \${reset_color}"
-    
+
     # Prepend Python virtual env version to prompt
     if [[ -n \$VIRTUAL_ENV ]]; then
         if [ -z "\${VIRTUAL_ENV_DISABLE_PROMPT:-}" ]; then
@@ -300,7 +300,7 @@ install-oh-my()
         echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
     fi
     # Shrink git while still enabling updates
-    cd ${OH_MY_INSTALL_DIR} 
+    cd ${OH_MY_INSTALL_DIR}
     git repack -a -d -f --depth=1 --window=1
 
     if [ "${USERNAME}" != "root" ]; then

--- a/containers/go/.devcontainer/library-scripts/go-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/go-debian.sh
@@ -77,7 +77,7 @@ GO_INSTALL_SCRIPT="$(cat <<EOF
 EOF
 )"
 if [ "${TARGET_GO_VERSION}" != "none" ] && ! type go > /dev/null 2>&1; then
-    mkdir -p "${TARGET_GOROOT}" "${TARGET_GOPATH}" 
+    mkdir -p "${TARGET_GOROOT}" "${TARGET_GOPATH}"
     chown -R ${USERNAME} "${TARGET_GOROOT}" "${TARGET_GOPATH}"
     su ${USERNAME} -c "${GO_INSTALL_SCRIPT}"
 else

--- a/containers/go/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/node-debian.sh
@@ -88,7 +88,7 @@ chmod g+s ${NVM_DIR}
 # Do not update profile - we'll do this later
 export PROFILE=/dev/null
 # Install nvm
-curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash 
+curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
 source ${NVM_DIR}/nvm.sh
 if [ "${NODE_VERSION}" != "" ]; then
     nvm alias default ${NODE_VERSION}
@@ -102,7 +102,7 @@ export NVM_DIR="${NVM_DIR}"
 [ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"
 [ -s "\$NVM_DIR/bash_completion" ] && . "\$NVM_DIR/bash_completion"
 EOF
-) | tee -a /etc/bash.bashrc >> /etc/zsh/zshrc 
-fi 
+) | tee -a /etc/bash.bashrc >> /etc/zsh/zshrc
+fi
 
 echo "Done!"

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -4,7 +4,7 @@
 
 *Develop Go based applications. Includes appropriate runtime args, Go, common tools, extensions, and dependencies.*
 
-| Metadata | Value |  
+| Metadata | Value |
 |----------|-------|
 | *Contributors* | The VS Code Team |
 | *Definition type* | Dockerfile |

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -48,11 +48,11 @@
 			"man-db",
 			"zsh",
 			"yarn",
-			"tar", 
+			"tar",
 			"g++",
 			"gcc",
 			"libc6-dev",
-			"make", 
+			"make",
 			"pkg-config"
 		],
 		"git": {

--- a/containers/go/test-project/hello.go
+++ b/containers/go/test-project/hello.go
@@ -2,9 +2,11 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  * Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
  *-------------------------------------------------------------------------------------------------------------*/
- 
+
 package main
+
 import "fmt"
+
 func main() {
-    fmt.Println("Hello remote world!")
+	fmt.Println("Hello remote world!")
 }


### PR DESCRIPTION
This PR:

* Removes trailing whitespace from config files to reduce future diff sizes (many editors automatically remove trailing whitespace).
* Formats Go code with `gofmt`.

There are no functional changes.