### PR TITLE
Add Homebrew install script to the script library

### DIFF
--- a/script-library/README.md
+++ b/script-library/README.md
@@ -23,6 +23,7 @@ Some scripts have special installation instructions (like `desktop-lite-debian.s
 | [GitHub CLI Install Script](docs/github.md) | `github-debian.sh` |
 | [Go (golang) Install Script](docs/go.md) | `go-debian.sh` |
 | [Gradle Install Script](docs/gradle.md) | `gradle-debian.sh` |
+| [Homebrew Install Script](docs/homebrew.md) | `homebrew-debian.sh` |
 | [Java Install Script](docs/java.md) | `java-debian.sh` |
 | [Kubectl and Helm Install Script](docs/kubectl-helm.md) | `kubectl-helm-debian.sh` |
 | [Maven Install Script](docs/maven.md) | `maven-debian.sh` |

--- a/script-library/docs/homebrew.md
+++ b/script-library/docs/homebrew.md
@@ -1,0 +1,37 @@
+# Homebrew Install Script
+
+*Adds Homebrew to a container.*
+
+**Script status**: Stable
+
+**OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
+
+## Syntax
+
+```text
+./homebrew-debian.sh [Non-root user] [Add to rc files flag] [Use shallow clone flag] [BREW_PREFIX]
+```
+
+|Argument|Default|Description|
+|--------|-------|-----------|
+|Non-root user|`automatic`| Specifies a user in the container other than root that will use Homebrew. A value of `automatic` will cause the script to check for a user called `vscode`, then `node`, `codespace`, and finally a user with a UID of `1000` before falling back to `root`. |
+| Add to rc files flag | `true` | A `true`/`false` flag that indicates whether the `PATH` should be updated via `/etc/bash.bashrc` and `/etc/zsh/zshrc`. |
+| Use shallow clone flag | `false` | A `true`/`false` flag that indicates whether the script should install Homebrew using shallow clone. Shallow clone allows significantly reduce installation size at the expense of not being able to run `brew update` meaning the package index will be frozen at the moment of image creation. |
+| BREW_PREFIX | `/home/linuxbrew/.linuxbrew` | Location to install Homebrew. Please note that changing this setting will prevent you from using some of the precompiled binaries and therefore isn't recommended. |
+
+## Usage
+
+Usage:
+
+1. Add [`homebrew-debian.sh`](../homebrew-debian.sh) to `.devcontainer/library-scripts`
+
+2. Add the following to your `.devcontainer/Dockerfile`:
+
+    ```Dockerfile
+    ENV BREW_PREFIX=/home/linuxbrew/.linuxbrew
+    ENV PATH=${BREW_PREFIX}/sbin:${BREW_PREFIX}/bin:${PATH}
+    COPY library-scripts/homebrew-debian.sh /tmp/library-scripts/
+    RUN apt-get update && bash /tmp/library-scripts/homebrew-debian.sh
+    ```
+
+That's it!

--- a/script-library/homebrew-debian.sh
+++ b/script-library/homebrew-debian.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+#
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/homebrew.md
+#
+# Syntax: ./homebrew-debian.sh [non-root user] [add Homebrew binaries to PATH] [whether to use shallow clone] [where to install Homebrew]
+
+USERNAME=${1:-"automatic"}
+UPDATE_RC=${2:-"true"}
+USE_SHALLOW_CLONE=${3:-"false"}
+BREW_PREFIX=${4:-"/home/linuxbrew/.linuxbrew"}
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+# Determine the appropriate non-root user
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
+    USERNAME=""
+    POSSIBLE_USERS=("vscode" "node" "codespace" "$(awk -v val=1000 -F ":" '$3==val{print $1}' /etc/passwd)")
+    for CURRENT_USER in ${POSSIBLE_USERS[@]}; do
+        if id -u ${CURRENT_USER} > /dev/null 2>&1; then
+            USERNAME=${CURRENT_USER}
+            break
+        fi
+    done
+    if [ "${USERNAME}" = "" ]; then
+        USERNAME=root
+    fi
+elif [ "${USERNAME}" = "none" ] || ! id -u ${USERNAME} > /dev/null 2>&1; then
+    USERNAME=root
+fi
+
+function updaterc() {
+    if [ "${UPDATE_RC}" = "true" ]; then
+        echo "Updating /etc/bash.bashrc and /etc/zsh/zshrc..."
+        echo -e "$1" | tee -a /etc/bash.bashrc >> /etc/zsh/zshrc
+    fi
+}
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Install dependencies if missing
+if ! dpkg -s \
+    bzip2 \
+    ca-certificates \
+    curl \
+    file \
+    fonts-dejavu-core \
+    g++ \
+    git \
+    less \
+    libz-dev \
+    locales \
+    make \
+    netbase \
+    openssh-client \
+    patch \
+    sudo \
+    tzdata \
+    uuid-runtime \
+    > /dev/null 2>&1; then
+        if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
+            apt-get update
+        fi
+        apt-get -y install --no-install-recommends \
+            bzip2 \
+            ca-certificates \
+            curl \
+            file \
+            fonts-dejavu-core \
+            g++ \
+            git \
+            less \
+            libz-dev \
+            locales \
+            make \
+            netbase \
+            openssh-client \
+            patch \
+            sudo \
+            tzdata \
+            uuid-runtime
+fi
+
+# Install Homebrew
+mkdir -p "${BREW_PREFIX}"
+if [ "${USE_SHALLOW_CLONE}" = "false" ]; then
+    echo "Installing Homebrew..."
+    git clone https://github.com/Homebrew/brew "${BREW_PREFIX}/Homebrew"
+    mkdir -p "${BREW_PREFIX}/Homebrew/Library/Taps/homebrew"
+    git clone https://github.com/Homebrew/linuxbrew-core "${BREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core"
+else
+    echo "Installing Homebrew with shallow clone..."
+    git clone --depth 1 https://github.com/Homebrew/brew "${BREW_PREFIX}/Homebrew"
+    mkdir -p "${BREW_PREFIX}/Homebrew/Library/Taps/homebrew"
+    git clone --depth 1 https://github.com/Homebrew/linuxbrew-core "${BREW_PREFIX}/Homebrew/Library/Taps/homebrew/homebrew-core"
+    # Disable automatic updates as they are not allowed with shallow clone installation
+    updaterc "export HOMEBREW_NO_AUTO_UPDATE=1"
+fi
+"${BREW_PREFIX}/Homebrew/bin/brew" config
+mkdir "${BREW_PREFIX}/bin"
+ln -s "${BREW_PREFIX}/Homebrew/bin/brew" "${BREW_PREFIX}/bin"
+chown -R ${USERNAME} "${BREW_PREFIX}"
+
+# Add Homebrew binaries into PATH in bashrc/zshrc files (unless disabled)
+updaterc "$(cat << EOF
+if [[ "\${PATH}" != *"${BREW_PREFIX}/bin"* ]]; then export PATH="${BREW_PREFIX}/bin:\${PATH}"; fi
+if [[ "\${PATH}" != *"${BREW_PREFIX}/sbin"* ]]; then export PATH="${BREW_PREFIX}/sbin:\${PATH}"; fi
+EOF
+)"
+
+echo "Done!"

--- a/script-library/test/run-scripts.sh
+++ b/script-library/test/run-scripts.sh
@@ -36,6 +36,7 @@ if [ "${DISTRO}" = "debian" ]; then
     runScript ${SCRIPT_DIR}/github-${DISTRO}.sh
     runScript ${SCRIPT_DIR}/go-${DISTRO}.sh "1.14 /opt/go /go ${USERNAME} false"
     runScript ${SCRIPT_DIR}/gradle-${DISTRO}.sh "4.4 /usr/local/sdkman1 ${USERNAME} false"
+    runScript ${SCRIPT_DIR}/homebrew-${DISTRO}.sh "${USERNAME} false true /home/${USERNAME}/linuxbrew"
     runScript ${SCRIPT_DIR}/java-${DISTRO}.sh "13.0.2.j9-adpt /usr/local/sdkman2 ${USERNAME} false"
     runScript ${SCRIPT_DIR}/kubectl-helm-${DISTRO}.sh
     runScript ${SCRIPT_DIR}/maven-${DISTRO}.sh "3.6.3 /usr/local/sdkman3 ${USERNAME} false" 


### PR DESCRIPTION
This PR adds a Homebrew installation script in the script library.

The installation is performed using [the official instructions](https://docs.brew.sh/Homebrew-on-Linux) and [Homebrew CI Docker containers](https://github.com/Homebrew/brew/blob/master/Dockerfile) as references.

Additionally, this script allows installing a shallow cloned copy of Homebrew, which is lightweight but fixes the package index in stone. This useful if you're creating a lot of dev containers based on slightly different versions of upstream images (for example, different versions of `node` for a bunch of microservices) allowing you to save GBs of local storage.

Related: https://github.com/microsoft/vscode-dev-containers/issues/357