### PR TITLE
Update F# to use .NET 5 only

### DIFF
--- a/containers/dotnet-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnet-fsharp/.devcontainer/Dockerfile
@@ -1,6 +1,4 @@
-# [Choice] .NET version: 5.0, 3.1, 2.1
-ARG VARIANT=3.1
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:dev-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:dev-5.0
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"

--- a/containers/dotnet-fsharp/.devcontainer/devcontainer.json
+++ b/containers/dotnet-fsharp/.devcontainer/devcontainer.json
@@ -2,9 +2,7 @@
 	"name": "F# (.NET)",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": { 
-			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
-			"VARIANT": "3.1",
+		"args": {
 			// Options
 			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*",
@@ -13,11 +11,8 @@
 		}
 	},
 
-	// Set container specific defaults for F# in .NET (Core) 2.1+
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"FSharp.fsacRuntime": "netcore",
-		"FSharp.useSdkScripts": true
+		"terminal.integrated.shell.linux": "/bin/bash"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/containers/dotnet-fsharp/test-project/Program.fs
+++ b/containers/dotnet-fsharp/test-project/Program.fs
@@ -3,13 +3,9 @@
 // Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 // ----------------------------------------------------------------------------------------
 
-open System
-
 [<EntryPoint>]
 let main argv =
     let from = "F# Container"
     let target = "Remote World"
-    let message = "Hello " + target + " from the " + from + "!"
-    printfn "%s" message
-    
+    printfn $"Hello {target} from the {from}!"
     0 // return an integer exit code

--- a/containers/dotnet-fsharp/test-project/app.fsproj
+++ b/containers/dotnet-fsharp/test-project/app.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Program.fs" />


### PR DESCRIPTION
The latest Ionide plugin (5.x) requires the .NET 5 SDK. F# developers also tend to update things very quickly, so I think we can just drop the other .NET Core SDK options. Otherwise, to make this function with the other SDKs, we'd have to install specific versions of the plugin.