### PR TITLE
Fix ELS crashing through config

### DIFF
--- a/containers/elm/.devcontainer/Dockerfile
+++ b/containers/elm/.devcontainer/Dockerfile
@@ -26,5 +26,5 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     fi \
     # Create the elm cache directory where we can mount a volume. If we don't create it like this
     # it is auto created by docker on volume creation but with root as owner which makes it unusable.
-    && mkdir /home/node/.elm \
-    && chown node:node /home/node/.elm
+    && mkdir /home/$USERNAME/.elm \
+    && chown $USERNAME:$USERNAME /home/$USERNAME/.elm

--- a/containers/elm/.devcontainer/Dockerfile
+++ b/containers/elm/.devcontainer/Dockerfile
@@ -23,4 +23,8 @@ RUN export DEBIAN_FRONTEND=noninteractive \
         groupmod --gid $USER_GID $USERNAME \
         && usermod --uid $USER_UID --gid $USER_GID $USERNAME \
         && chown -R $USER_UID:$USER_GID /home/$USERNAME; \
-    fi
+    fi \
+    # Create the elm cache directory where we can mount a volume. If we don't create it like this
+    # it is auto created by docker on volume creation but with root as owner which makes it unusable.
+    && mkdir /home/node/.elm \
+    && chown node:node /home/node/.elm

--- a/containers/elm/.devcontainer/devcontainer.json
+++ b/containers/elm/.devcontainer/devcontainer.json
@@ -18,7 +18,23 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "elm make",
-
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "node"
+	// Comment out to connect as root instead. In that case you may need to change the mounts
+	// configuration too. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	// Keeping the elm dependency cache mounted in a volume is both a small performance benefit
+	// when having rebuilt your container. It also solves a problem with the Elm Language Server.
+	// The Elm Language Server uses the dependency cache stored at ~/.elm.
+	// However, the elm compiler uses elm-stuff in the mounted directory which keeps timestamps
+	// telling the elm compiler whether elm.json changed since it last downloaded dependencies.
+	// This data is persisted, but without a volume the ~/.elm dependency cache itself is not
+	// persisted, resulting in a corruption of that relationship.
+	// The Elm Language Server expects the elm compiler to keep ~/.elm up to date, but because
+	// of this failure it will crash continuously when ~/.elm does not store the elm code for
+	// the dependencies. This will usually occur every time the container has been rebuilt
+	// and is manually fixed by deleting the elm-stuff directory which forces the compiler to
+	// redownload dependencies.
+	// Adding this volume will preserve the elm cache between rebuilds though, fixing this issue
+	"mounts": [
+		"source=vscode-devcontainer-elm-dependency-cache,target=/home/node/.elm,type=volume"
+	],
 }

--- a/containers/elm/.devcontainer/devcontainer.json
+++ b/containers/elm/.devcontainer/devcontainer.json
@@ -18,9 +18,11 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "elm make",
+
 	// Comment out to connect as root instead. In that case you may need to change the mounts
 	// configuration too. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",
+	
 	// Keeping the elm dependency cache mounted in a volume is both a small performance benefit
 	// when having rebuilt your container. It also solves a problem with the Elm Language Server.
 	// The Elm Language Server uses the dependency cache stored at ~/.elm.


### PR DESCRIPTION
See these issues for the problems with the new version of ELS:

elm-tooling/elm-language-server#461
elm-tooling/elm-language-server#457

This solves it through configuration. I added a pretty huge comment, let me know if instead I should maybe make it shorter and link to these issues or something like that? Or if I could phrase anything better? Most of my progress in thoughts and discussion about how best to handle this can be found in elm-tooling/elm-language-server#461 

Have a good day!

# Reproducing problem
1. On current master, open the elm folder here in the dev container, go to the HelloWorld.elm file and let ELS load, try hovering over something etc. You can verify that an `elm-stuff` folder should now have been created in the test-project directory
2. Run the rebuild container command that comes with the extension
3. Attempt the same thing, see that you get the message that the server crashed 5 times in 3 minutes and is not restarting

# Testing
I followed the above steps on my branch and it now works without issues