### PR TITLE
Bump pg-promise version

### DIFF
--- a/containers/javascript-node-postgres/test-project/package.json
+++ b/containers/javascript-node-postgres/test-project/package.json
@@ -11,6 +11,6 @@
 	"dependencies": {
 		"express": "^4.16.1",
 		"bluebird": "^3.5.5",
-		"pg-promise": "^8.7.2"
+		"pg-promise": "^10.9.1"
 	}
 }


### PR DESCRIPTION
Underlying pg library doesn't work on node 14 with this pg-promise version. Needs pg-promise bump to fix this: https://github.com/brianc/node-postgres/issues/2180