### PR TITLE
Update R Docker image and vscode-r recommended settings

### DIFF
--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -1,19 +1,35 @@
-FROM rocker/r-apt:bionic
+# [Choice] R version: latest, ... ,4.0.1 , 4.0.0
+ARG VARIANT="latest"
+FROM rocker/r-ver:${VARIANT}
 
+# Use the [Option] comment to specify true/false arguments that should appear in VS Code UX
+#
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="false"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-ARG USERNAME=docker
+ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 COPY library-scripts/*.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
-    && apt-get -y install libzip-dev \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && usermod -a -G staff ${USERNAME} \
+    && apt-get -y install \
+        python3-pip \
+        libgit2-dev \
+        libcurl4-openssl-dev \
+        libssl-dev \
+        libxml2-dev \
+        libxt-dev \
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts \
+    && python3 -m pip --no-cache-dir install radian \
+    && install2.r --error --skipinstalled --repos ${CRAN} --ncpus -1 \
+        devtools \
+        languageserver \
+    && rm -rf /tmp/downloaded_packages
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -36,5 +36,5 @@
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "docker"
+	"remoteUser": "vscode"
 }

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -2,17 +2,25 @@
 	"name": "R (Community)",
 	"build": {
 		"dockerfile": "Dockerfile",
+		// Update VARIANT to pick a specific R version: latest, ... ,4.0.1 , 4.0.0
+		"args": { "VARIANT": "latest" }
 	},
-	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"r.rterm.linux": "/usr/local/bin/radian",
+		"r.bracketedPaste": true,
+		"r.sessionWatcher": true,
+		"[r]": {
+			"editor.wordSeparators": "`~!@#%$^&*()-=+[{]}\\|;:'\",<>/?"
+		}
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ikuyadeu.r"
+		"ikuyadeu.r",
+		"reditorsupport.r-lsp"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
@@ -20,6 +28,12 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "R --version",
+
+	// Uncomment to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker.
+	// "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "docker"

--- a/containers/r/README.md
+++ b/containers/r/README.md
@@ -6,7 +6,7 @@
 
 | Metadata | Value |  
 |----------|-------|
-| *Contributors* | [kmehant](mailto:kmehant@gmail.com) |
+| *Contributors* | [kmehant](mailto:kmehant@gmail.com), [eitsupi](https://github.com/eitsupi) |
 | *Categories* | Community, Languages |
 | *Definition type* | Dockerfile |
 | *Works in Codespaces* | No |


### PR DESCRIPTION
This pull request updates R to latest version and add [`vscode-R`](https://github.com/Ikuyadeu/vscode-R) recommended settings.

- Change base image `rocker/r-apt:bionic`(R 3.6.3) to [`rocker/r-ver`](https://github.com/rocker-org/rocker-versioned2), which provide specific version R (4.0.0 ~ 4.0.4) based on Ubuntu LTS.
- Change not to install `libzip-dev`. (`libzip-dev` was needed for [R Tools](https://github.com/MikhailArkhipov/vscode-r) #60, which is not included by #473 ).
- Install `libxt-dev`, for to plot without warning.
- Add vscode-R recommended settings and packages.
  - Install [`R LSP Client`](https://github.com/REditorSupport/vscode-r-lsp) and [`R Language Server`](https://github.com/REditorSupport/languageserver).
    - Install `libcurl4-openssl-dev`, `libssl-dev`, `libxml2-dev`, for to install `R Language Server`.
  - Install [`devtools`](https://github.com/r-lib/devtools)
    - Upgrade OS packages and install `libgit2-dev`, for to install `devtools`
  - Install [`radian`](https://github.com/randy3k/radian).
    - Install `python3-pip`, for to install `radian`.
- Add vscode-R recommended settings.
