### PR TITLE
Add Terragrunt to Azure Terraform definition

### DIFF
--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -36,10 +36,11 @@ RUN if [ "${INSTALL_AZURE_CLI}" = "true" ]; then bash /tmp/library-scripts/azcli
     fi \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Terraform, tflint
+# Install Terraform, tflint, Terragrunt
 ARG TERRAFORM_VERSION=0.12.16
 ARG TFLINT_VERSION=0.8.2
-RUN bash /tmp/library-scripts/terraform-debian.sh "${TERRAFORM_VERSION}" "${TFLINT_VERSION}" \
+ARG TERRAGRUNT_VERSION=0.28.1
+RUN bash /tmp/library-scripts/terraform-debian.sh "${TERRAFORM_VERSION}" "${TFLINT_VERSION}" "${TERRAGRUNT_VERSION}" \
     && rm -rf /tmp/library-scripts
 
 

--- a/containers/azure-terraform/.devcontainer/devcontainer.json
+++ b/containers/azure-terraform/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		"args": { 
 			"TERRAFORM_VERSION": "0.12.29",
 			"TFLINT_VERSION": "0.18.0",
+			"TERRAGRUNT_VERSION": "0.28.1",
 			"INSTALL_AZURE_CLI": "true",
 			"INSTALL_DOCKER": "true",
 			"INSTALL_NODE": "true"

--- a/containers/azure-terraform/README.md
+++ b/containers/azure-terraform/README.md
@@ -23,11 +23,13 @@ You can also choose the specific version of Terraform installed by updating the 
 "arg": {
    "TERRAFORM_VERSION": "0.12.16"
    "TFLINT_VERSION": "0.8.2",
+   "TERRAGRUNT_VERSION": "0.28.1"
    "INSTALL_AZURE_CLI": "true",
    "INSTALL_DOCKER": "true",
    "INSTALL_NODE": "true"
 }
-`
+```
+
 If you plan to use the Azure Cloud Shell for all of your Terraform operations, you can set `"INSTALL_DOCKER": "false"`. Conversely, if you do not plan to use Cloud Shell, you can set `"INSTALL_DOCKER": "false"`. By default, both are installed so you can decide later.
 
 Beyond `git`, this `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.


### PR DESCRIPTION
Proposed change is to include [Terragrunt](https://github.com/gruntwork-io/terragrunt) in the Azure Terraform definition.

> Terragrunt is a thin wrapper for Terraform that provides extra tools for working with multiple Terraform modules.

How I tested it: opened the `containers/azure-terraform` in VSCode and ran "Reopen in Container".
Once container started, I confirmed Terragrunt was installed:

<img width="1102" alt="Screen Shot 2021-02-04 at 13 36 34" src="https://user-images.githubusercontent.com/1759643/106900106-0827ae80-66ee-11eb-852f-c99e3315be40.png">

I realize not everyone uses Terragrunt, so possibly we can set

```json
// containers/azure-terraform/.devcontainer/devcontainer.json

...
"args": {
    ...
    "TERRAGRUNT_VERSION": "none",
}
```

to not have it installed by default. If a developer wants to use it, they will have to change the argument to either a specific version or to `latest`.