### PR TITLE
hardcode azure dns for docker daemon in docker-in-docker

### DIFF
--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -159,7 +159,7 @@ fi
 ## Dind wrapper over.
 
 # Start docker/moby engine
-( sudoIf dockerd > /tmp/dockerd.log 2>&1 ) &
+( sudoIf dockerd --dns 168.63.129.16 > /tmp/dockerd.log 2>&1 ) &
 
 set +e
 

--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -160,7 +160,7 @@ fi
 
 # Handle DNS
 set +e
-cat /etc/resolv.conf | grep -i '^nameserver 127.0.0.53'
+cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
 if [ $? -eq 0 ]
 then
   echo "Setting Azure DNS."

--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -158,8 +158,21 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
 fi
 ## Dind wrapper over.
 
+# Handle DNS
+set +e
+cat /etc/resolv.conf | grep -i '^nameserver 127.0.0.53'
+if [ $? -eq 0 ]
+then
+  echo "Setting Azure DNS."
+  CUSTOMDNS="--dns 168.63.129.16"
+else
+  echo "Not setting any DNS manually."
+  CUSTOMDNS=""
+fi
+set -e
+
 # Start docker/moby engine
-( sudoIf dockerd --dns 168.63.129.16 > /tmp/dockerd.log 2>&1 ) &
+( sudoIf dockerd $CUSTOMDNS > /tmp/dockerd.log 2>&1 ) &
 
 set +e
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vssaas-planning/issues/2499

This DNS address was taken from: 
https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances#considerations
> The Azure DNS IP address is 168.63.129.16. This is a static IP address and will not change.
