### PR TITLE
Fix comment referring to MongoDB

### DIFF
--- a/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_DB: postgres
 
-    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward MongoDB locally.
+    # Add "forwardPorts": ["5432"] to **devcontainer.json** to forward PostgreSQL locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
 volumes:


### PR DESCRIPTION
Just replaced _MongoDB_ with _PostgreSQL_ in a comment line