### PR TITLE
update go container build script and devcontainer.json

### DIFF
--- a/containers/codespaces-linux-stretch/.devcontainer/devcontainer.json
+++ b/containers/codespaces-linux-stretch/.devcontainer/devcontainer.json
@@ -5,11 +5,10 @@
 	},
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"go.useGoProxyToCheckForToolUpdates": false,
+		"go.toolsManagement.checkForUpdates": "off",
 		"go.useLanguageServer": true,
 		"go.gopath": "/go",
 		"go.goroot": "/usr/local/go",
-		"go.toolsGopath": "/go/bin",
 		"python.pythonPath": "/opt/python/latest/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,

--- a/containers/codespaces-linux/.devcontainer/devcontainer.json
+++ b/containers/codespaces-linux/.devcontainer/devcontainer.json
@@ -5,11 +5,10 @@
 	},
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"go.useGoProxyToCheckForToolUpdates": false,
+		"go.toolsManagement.checkForUpdates": "off",
 		"go.useLanguageServer": true,
 		"go.gopath": "/go",
 		"go.goroot": "/usr/local/go",
-		"go.toolsGopath": "/go/bin",
 		"python.pythonPath": "/opt/python/latest/bin/python",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -15,11 +15,10 @@
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
-		"go.useGoProxyToCheckForToolUpdates": false,
+		"go.toolsManagement.checkForUpdates": "off",
 		"go.useLanguageServer": true,
 		"go.gopath": "/go",
 		"go.goroot": "/usr/local/go",
-		"go.toolsGopath": "/go/bin"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/repository-containers/github.com/terraform-providers/terraform-provider-azurerm/.devcontainer/devcontainer.json
+++ b/repository-containers/github.com/terraform-providers/terraform-provider-azurerm/.devcontainer/devcontainer.json
@@ -21,19 +21,8 @@
 			"apiVersion": 2,
 			"showGlobalVariables": true
 		},
-		"[go]": {
-			"editor.snippetSuggestions": "none",
-			"editor.formatOnSave": true,
-			"editor.codeActionsOnSave": {
-				"source.organizeImports": true,
-			}
-		},
 		"gopls": {
-			"usePlaceholders": true, // add parameter placeholders when completing a function
-			// Experimental settings
-			"completeUnimported": true, // autocomplete unimported packages
-			"watchFileChanges": true, // watch file changes outside of the editor
-			"deepCompletion": true, // enable deep completion
+			"ui.usePlaceholders": true, // add parameter placeholders when completing a function
 		},
 		"files.eol": "\n", // formatting only supports LF line endings	
 	},

--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -84,28 +84,16 @@ else
     echo "Go already installed. Skipping."
 fi
 
-# Install Go tools
+# Install Go tools that are isImportant && !replacedByGopls based on
+# https://github.com/golang/vscode-go/blob/0c6dce4a96978f61b022892c1376fe3a00c27677/src/goTools.ts#L188
 GO_TOOLS_WITH_MODULES="\
     golang.org/x/tools/gopls \
     honnef.co/go/tools/... \
-    golang.org/x/tools/cmd/gorename \
-    golang.org/x/tools/cmd/goimports \
-    golang.org/x/tools/cmd/guru \
     golang.org/x/lint/golint \
-    github.com/mdempsky/gocode \
-    github.com/cweill/gotests/... \
-    github.com/haya14busa/goplay/cmd/goplay \
-    github.com/sqs/goreturns \
-    github.com/josharian/impl \
-    github.com/davidrjenni/reftools/cmd/fillstruct \
+    github.com/golangci/golangci-lint/cmd/golangci-lint \
+    github.com/mgechev/revive \
     github.com/uudashr/gopkgs/v2/cmd/gopkgs \
     github.com/ramya-rao-a/go-outline \
-    github.com/acroca/go-symbols \
-    github.com/godoctor/godoctor \
-    github.com/rogpeppe/godef \
-    github.com/zmb3/gogetdoc \
-    github.com/fatih/gomodifytags \
-    github.com/mgechev/revive \
     github.com/go-delve/delve/cmd/dlv"
 if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     echo "Installing common Go tools..."

--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -86,11 +86,11 @@ fi
 
 # Install Go tools that are isImportant && !replacedByGopls based on
 # https://github.com/golang/vscode-go/blob/0c6dce4a96978f61b022892c1376fe3a00c27677/src/goTools.ts#L188
-GO_TOOLS_WITH_MODULES="\
+# exception: golangci-lint is installed using their install script below.
+GO_TOOLS="\
     golang.org/x/tools/gopls \
     honnef.co/go/tools/... \
     golang.org/x/lint/golint \
-    github.com/golangci/golangci-lint/cmd/golangci-lint \
     github.com/mgechev/revive \
     github.com/uudashr/gopkgs/v2/cmd/gopkgs \
     github.com/ramya-rao-a/go-outline \
@@ -105,19 +105,13 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
 
     # Go tools w/module support
     export GO111MODULE=on
-    (echo "${GO_TOOLS_WITH_MODULES}" | xargs -n 1 go get -v )2>&1
-
-    # gocode-gomod
-    export GO111MODULE=auto
-    go get -v -d github.com/stamblerre/gocode 2>&1
-    go build -o gocode-gomod github.com/stamblerre/gocode
+    (echo "${GO_TOOLS}" | xargs -n 1 go get -v )2>&1
 
     # golangci-lint
     curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ${TARGET_GOPATH}/bin 2>&1
 
     # Move Go tools into path and clean up
     mv /tmp/gotools/bin/* ${TARGET_GOPATH}/bin/
-    mv gocode-gomod ${TARGET_GOPATH}/bin/
     rm -rf /tmp/gotools
     chown -R ${USERNAME} "${TARGET_GOPATH}"
 fi


### PR DESCRIPTION
Reduce the number of pre-installed go tools - gopls is the
default language feature provider for golang.go since its
v0.22.0, so preinstall only the required tools with the
default settings. For additional tools, the extension will
prompt users to install when necessary.

Also, clean up devcontainer's go extension settings.
Some gopls settings are outdated. Some [go] settings are
unnecessary because the extension sets them up by default,
and the gopls update setting is now obsolete.