### PR TITLE
Updates for new versions of Go, Alpine

### DIFF
--- a/containers/alpine/.devcontainer/Dockerfile
+++ b/containers/alpine/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-# [Choice] Alpine version: 3.12, 3.11, 3.10
-ARG VARIANT=3.12
-FROM mcr.microsoft.com/vscode/devcontainers/base:alpine-${VARIANT}
+# [Choice] Alpine version: 3.13, 3.12, 3.11, 3.10
+ARG VARIANT=3.13
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-alpine-${VARIANT}
 
 # ** [Optional] Uncomment this section to install additional packages. **
 # RUN apk update \

--- a/containers/alpine/.devcontainer/base.Dockerfile
+++ b/containers/alpine/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Alpine version: 3.12, 3.11, 3.10
-ARG VARIANT=3.12
+# [Choice] Alpine version: 3.13, 3.12, 3.11, 3.10
+ARG VARIANT=3.13
 FROM alpine:${VARIANT}
 
 # [Option] Install zsh

--- a/containers/alpine/.devcontainer/devcontainer.json
+++ b/containers/alpine/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "Alpine",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12
+		// Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12, 3.13
 		"args": { "VARIANT": "3.12" }
 	},
 	

--- a/containers/alpine/README.md
+++ b/containers/alpine/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Other |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/base:alpine |
-| *Available image variants* | 3.10, 3.11, 3.12 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
+| *Available image variants* | 3.10, 3.11, 3.12, 3.13 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |

--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,6 +1,6 @@
 {
-	"variants": ["3.12", "3.11", "3.10"],
-	"definitionVersion": "0.200.0",
+	"variants": ["3.13", "3.12", "3.11", "3.10"],
+	"definitionVersion": "0.200.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-# [Choice] Go version: 1, 1.15, 1.14
+# [Choice] Go version: 1, 1.16, 1.15
 ARG VARIANT=1
-FROM mcr.microsoft.com/vscode/devcontainers/go:dev-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"

--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version: 1, 1.15, 1.14
+# [Choice] Go version: 1, 1.16, 1.15
 ARG VARIANT=1
 FROM golang:${VARIANT}
 

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update the VARIANT arg to pick a version of Go: 1, 1.15, 1.14
+			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.15
 			"VARIANT": "1",
 			// Options
 			"INSTALL_NODE": "false",

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,6 +1,6 @@
 {
-	"variants": ["1", "1.15", "1.14"],
-	"definitionVersion": "0.201.0",
+	"variants": ["1", "1.16", "1.15"],
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Go 1.16 is out, so we can now build it. 1.14 is no longer receiving security patches, so that image version is now deprecated.

Alpine 3.13 is out, but 3.10 is not yet out of support, so this is just an addition.