### PR TITLE
Minor doc fix for python install script

### DIFF
--- a/script-library/docs/python.md
+++ b/script-library/docs/python.md
@@ -33,7 +33,7 @@
         PIPX_BIN_DIR=/usr/local/py-utils/bin
     ENV PATH=${PYTHON_PATH}/bin:${PATH}:${PIPX_BIN_DIR}
     COPY .devcontainer/library-scripts/python-debian.sh /tmp/library-scripts/
-    RUN apt-get update && bash /tmp/library-scripts/python-debian.sh "3.8.3" "${PYTHON_PATH}" "${PIPX_HOME}" \
+    RUN apt-get update && bash /tmp/library-scripts/python-debian.sh "3.8.3" "${PYTHON_PATH}" "${PIPX_HOME}"
     ```
 
 That's it!


### PR DESCRIPTION
I found a super-minor issue in the python.md when reading it to setup a dev environment.  In a previous change, the line after the `RUN apt-get update && bash /tmp/library-scripts/python-debian.sh "3.8.3" "${PYTHON_PATH}" "${PIPX_HOME}" \ ` was removed, but the `\` was left.  If someone is copy-pasting to play with it, they'll get an error because of it.