### PR TITLE
Sunset Oh My Bash

### DIFF
--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -225,14 +225,24 @@ EOF
 )"
 
 # Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
+OMB_README="$(cat \
+<<'EOF'
+"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still
+wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
+You may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it
+See https://github.com/microsoft/vscode-dev-containers/issues/674#issuecomment-783474956
+EOF
+)"
 OMB_STUB="$(cat \
 <<'EOF'
 #!/usr/bin/env bash
+cd "$(dirname $0)"
 if [ -t 1 ]; then
-    echo -e '"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still\nwish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash\nYou may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it'
+    cat README.md
 fi
 EOF
 )"
+
 
 # Adapted Oh My Zsh! install step to work with both "Oh Mys" rather than relying on an installer script
 # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
@@ -285,9 +295,11 @@ fi
 # Add stub for Oh My Bash!
 if [ ! -d "${USER_RC_PATH}/.oh-my-bash}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
     mkdir -p "${USER_RC_PATH}/.oh-my-bash" "/root/.oh-my-bash"
+    echo "${OMB_README}" >> "${USER_RC_PATH}/.oh-my-bash/README.md"
     echo "${OMB_STUB}" >> "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
     chmod +x "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
     if [ "${USERNAME}" != "root" ]; then
+        echo "${OMB_README}" >> "/root/.oh-my-bash/README.md"
         echo "${OMB_STUB}" >> "/root/.oh-my-bash/oh-my-bash.sh"
         chmod +x "/root/.oh-my-bash/oh-my-bash.sh"
     fi

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -184,46 +184,53 @@ chmod +x /usr/local/bin/code
 
 # Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
-<<EOF
-#!/usr/bin/env bash
-prompt() {
-    if [ "\$?" != "0" ]; then
-        local arrow_color=\${bold_red}
-    else
-        local arrow_color=\${reset_color}
-    fi
-    if [ ! -z "\${GITHUB_USER}" ]; then
-        local USERNAME="gh:@\${GITHUB_USER}"
-    else
-        local USERNAME="\$(whoami)"
-    fi
-    local cwd="\$(pwd | sed "s|^\${HOME}|~|")"
-    PS1="\${green}\${USERNAME} \${arrow_color}➜\${reset_color} \${bold_blue}\${cwd}\${reset_color} \$(scm_prompt_info)\${white}$ \${reset_color}"
+<<'EOF'
+__bash_prompt() {
+    local userpart='`export XIT=$? \
+        && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
+        && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
+    local gitbranch='`export BRANCH=$(git describe --contains --all HEAD 2>/dev/null); \
+        if [ "${BRANCH}" != "" ]; then \
+            echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
+            && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
+                    echo -n " \[\033[1;33m\]✗"; \
+            fi \
+            && echo -n "\[\033[0;36m\]) "; \
+        fi`'
+    local lightblue='\[\033[1;34m\]'
+    local removecolor='\[\033[0m\]'
+    PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
+    unset -f __bash_prompt
 }
-SCM_THEME_PROMPT_PREFIX="\${reset_color}\${cyan}(\${bold_red}"
-SCM_THEME_PROMPT_SUFFIX="\${reset_color} "
-SCM_THEME_PROMPT_DIRTY=" \${bold_yellow}✗\${reset_color}\${cyan})"
-SCM_THEME_PROMPT_CLEAN="\${reset_color}\${cyan})"
-SCM_GIT_SHOW_MINIMAL_INFO="true"
-safe_append_prompt_command prompt
+__bash_prompt
 EOF
 )"
 CODESPACES_ZSH="$(cat \
-<<EOF
+<<'EOF'
 prompt() {
-    if [ ! -z "\${GITHUB_USER}" ]; then
-        local USERNAME="gh:@\${GITHUB_USER}"
+    if [ "${GITHUB_USER}" != "" ]; then
+        local USERNAME="@${GITHUB_USER}"
     else
-        local USERNAME="\$(whoami)"
+        local USERNAME="%n"
     fi
-    PROMPT="%{\$fg[green]%}\${USERNAME} %(?:%{\$reset_color%}➜ :%{\$fg_bold[red]%}➜ )"
-    PROMPT+='%{\$fg_bold[blue]%}%~%{\$reset_color%} \$(git_prompt_info)%{\$fg[white]%}$ %{\$reset_color%}'
+    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT+='%{$fg_bold[blue]%}%~%{$reset_color%} $(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}'
 }
-ZSH_THEME_GIT_PROMPT_PREFIX="%{\$fg_bold[cyan]%}(%{\$fg_bold[red]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{\$reset_color%} "
-ZSH_THEME_GIT_PROMPT_DIRTY=" %{\$fg_bold[yellow]%}✗%{\$fg_bold[cyan]%})"
-ZSH_THEME_GIT_PROMPT_CLEAN="%{\$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 prompt
+EOF
+)"
+
+# Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
+OMB_STUB="$(cat \
+<<'EOF'
+#!/usr/bin/env bash
+if [ -t 1 ]; then
+    echo -e '"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still\nwish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash\nYou may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it'
+fi
 EOF
 )"
 
@@ -249,32 +256,43 @@ install-oh-my()
         -c fsck.zeroPaddedFilemode=ignore \
         -c fetch.fsck.zeroPaddedFilemode=ignore \
         -c receive.fsck.zeroPaddedFilemode=ignore \
-        ${OH_MY_GIT_URL} ${OH_MY_INSTALL_DIR} 2>&1
+        "${OH_MY_GIT_URL}" "${OH_MY_INSTALL_DIR}" 2>&1
     echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
-    if [ "${OH_MY}" = "bash" ]; then
-        sed -i -e 's/OSH_THEME=.*/OSH_THEME="codespaces"/g' ${USER_RC_FILE}
-        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes/codespaces
-        echo "${CODESPACES_BASH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces/codespaces.theme.sh
-    else
-        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
-        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
-        echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
-    fi
+    sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+    mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+    echo "${CODESPACES_ZSH}" > "${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme"
     # Shrink git while still enabling updates
-    cd ${OH_MY_INSTALL_DIR} 
+    cd "${OH_MY_INSTALL_DIR}"
     git repack -a -d -f --depth=1 --window=1
 
     if [ "${USERNAME}" != "root" ]; then
-        cp -rf ${USER_RC_FILE} ${OH_MY_INSTALL_DIR} /root
-        chown -R ${USERNAME}:${USERNAME} ${USER_RC_PATH}
+        cp -rf "${USER_RC_FILE}" "${OH_MY_INSTALL_DIR}" /root
+        chown -R ${USERNAME}:${USERNAME} "${USER_RC_PATH}"
     fi
 }
 
+# Add RS snippet and custom bash prompt
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
     echo "${RC_SNIPPET}" >> /etc/bash.bashrc
+    echo "${CODESPACES_BASH}" >> "${USER_RC_PATH}/.bashrc"
+    if [ "${USERNAME}" != "root" ]; then
+        echo "${CODESPACES_BASH}" >> "/root/.bashrc"
+    fi
+    chown ${USERNAME}:${USERNAME} "${USER_RC_PATH}/.bashrc"
     RC_SNIPPET_ALREADY_ADDED="true"
 fi
-install-oh-my bash bashrc.osh-template https://github.com/ohmybash/oh-my-bash
+
+# Add stub for Oh My Bash!
+if [ ! -d "${USER_RC_PATH}/.oh-my-bash}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
+    mkdir -p "${USER_RC_PATH}/.oh-my-bash" "/root/.oh-my-bash"
+    echo "${OMB_STUB}" >> "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
+    chmod +x "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
+    if [ "${USERNAME}" != "root" ]; then
+        echo "${OMB_STUB}" >> "/root/.oh-my-bash/oh-my-bash.sh"
+        chmod +x "/root/.oh-my-bash/oh-my-bash.sh"
+    fi
+    chown -R "${USERNAME}:${USERNAME}" "${USER_RC_PATH}/.oh-my-bash"
+fi
 
 # Optionally install and configure zsh and Oh My Zsh!
 if [ "${INSTALL_ZSH}" = "true" ]; then

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -256,11 +256,20 @@ EOF
 )"
 
 # Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
+OMB_README="$(cat \
+<<'EOF'
+"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still
+wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
+You may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it
+See https://github.com/microsoft/vscode-dev-containers/issues/674#issuecomment-783474956
+EOF
+)"
 OMB_STUB="$(cat \
 <<'EOF'
 #!/usr/bin/env bash
+cd "$(dirname $0)"
 if [ -t 1 ]; then
-    echo -e '"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still\nwish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash\nYou may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it'
+    cat README.md
 fi
 EOF
 )"
@@ -316,9 +325,11 @@ fi
 # Add stub for Oh My Bash!
 if [ ! -d "${USER_RC_PATH}/.oh-my-bash}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
     mkdir -p "${USER_RC_PATH}/.oh-my-bash" "/root/.oh-my-bash"
+    echo "${OMB_README}" >> "${USER_RC_PATH}/.oh-my-bash/README.md"
     echo "${OMB_STUB}" >> "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
     chmod +x "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
     if [ "${USERNAME}" != "root" ]; then
+        echo "${OMB_README}" >> "/root/.oh-my-bash/README.md"
         echo "${OMB_STUB}" >> "/root/.oh-my-bash/oh-my-bash.sh"
         chmod +x "/root/.oh-my-bash/oh-my-bash.sh"
     fi

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -215,54 +215,53 @@ chmod +x /usr/local/bin/code
 
 # Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
-<<EOF
-#!/usr/bin/env bash
-prompt() {
-    if [ "\$?" != "0" ]; then
-        local arrow_color=\${bold_red}
-    else
-        local arrow_color=\${reset_color}
-    fi
-    if [ ! -z "\${GITHUB_USER}" ]; then
-        local USERNAME="@\${GITHUB_USER}"
-    else
-        local USERNAME="\\u"
-    fi
-    local cwd="\$(pwd | sed "s|^\${HOME}|~|")"
-    PS1="\${green}\${USERNAME} \${arrow_color}➜\${reset_color} \${bold_blue}\${cwd}\${reset_color} \$(scm_prompt_info)\${white}$ \${reset_color}"
-    
-    # Prepend Python virtual env version to prompt
-    if [[ -n \$VIRTUAL_ENV ]]; then
-        if [ -z "\${VIRTUAL_ENV_DISABLE_PROMPT:-}" ]; then
-            PS1="(\`basename \"\$VIRTUAL_ENV\"\`) \${PS1:-}"
-        fi
-    fi
+<<'EOF'
+__bash_prompt() {
+    local userpart='`export XIT=$? \
+        && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
+        && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
+    local gitbranch='`export BRANCH=$(git describe --contains --all HEAD 2>/dev/null); \
+        if [ "${BRANCH}" != "" ]; then \
+            echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
+            && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
+                    echo -n " \[\033[1;33m\]✗"; \
+            fi \
+            && echo -n "\[\033[0;36m\]) "; \
+        fi`'
+    local lightblue='\[\033[1;34m\]'
+    local removecolor='\[\033[0m\]'
+    PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
+    unset -f __bash_prompt
 }
-
-SCM_THEME_PROMPT_PREFIX="\${reset_color}\${cyan}(\${bold_red}"
-SCM_THEME_PROMPT_SUFFIX="\${reset_color} "
-SCM_THEME_PROMPT_DIRTY=" \${bold_yellow}✗\${reset_color}\${cyan})"
-SCM_THEME_PROMPT_CLEAN="\${reset_color}\${cyan})"
-SCM_GIT_SHOW_MINIMAL_INFO="true"
-safe_append_prompt_command prompt
+__bash_prompt
 EOF
 )"
 CODESPACES_ZSH="$(cat \
-<<EOF
+<<'EOF'
 prompt() {
-    if [ ! -z "\${GITHUB_USER}" ]; then
-        local USERNAME="@\${GITHUB_USER}"
+    if [ "${GITHUB_USER}" != "" ]; then
+        local USERNAME="@${GITHUB_USER}"
     else
         local USERNAME="%n"
     fi
-    PROMPT="%{\$fg[green]%}\${USERNAME} %(?:%{\$reset_color%}➜ :%{\$fg_bold[red]%}➜ )"
-    PROMPT+='%{\$fg_bold[blue]%}%~%{\$reset_color%} \$(git_prompt_info)%{\$fg[white]%}$ %{\$reset_color%}'
+    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT+='%{$fg_bold[blue]%}%~%{$reset_color%} $(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}'
 }
-ZSH_THEME_GIT_PROMPT_PREFIX="%{\$fg_bold[cyan]%}(%{\$fg_bold[red]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{\$reset_color%} "
-ZSH_THEME_GIT_PROMPT_DIRTY=" %{\$fg_bold[yellow]%}✗%{\$fg_bold[cyan]%})"
-ZSH_THEME_GIT_PROMPT_CLEAN="%{\$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 prompt
+EOF
+)"
+
+# Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
+OMB_STUB="$(cat \
+<<'EOF'
+#!/usr/bin/env bash
+if [ -t 1 ]; then
+    echo -e '"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still\nwish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash\nYou may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it'
+fi
 EOF
 )"
 
@@ -288,32 +287,43 @@ install-oh-my()
         -c fsck.zeroPaddedFilemode=ignore \
         -c fetch.fsck.zeroPaddedFilemode=ignore \
         -c receive.fsck.zeroPaddedFilemode=ignore \
-        ${OH_MY_GIT_URL} ${OH_MY_INSTALL_DIR} 2>&1
+        "${OH_MY_GIT_URL}" "${OH_MY_INSTALL_DIR}" 2>&1
     echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
-    if [ "${OH_MY}" = "bash" ]; then
-        sed -i -e 's/OSH_THEME=.*/OSH_THEME="codespaces"/g' ${USER_RC_FILE}
-        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes/codespaces
-        echo "${CODESPACES_BASH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces/codespaces.theme.sh
-    else
-        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
-        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
-        echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
-    fi
+    sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+    mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+    echo "${CODESPACES_ZSH}" > "${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme"
     # Shrink git while still enabling updates
-    cd ${OH_MY_INSTALL_DIR} 
+    cd "${OH_MY_INSTALL_DIR}"
     git repack -a -d -f --depth=1 --window=1
 
     if [ "${USERNAME}" != "root" ]; then
-        cp -rf ${USER_RC_FILE} ${OH_MY_INSTALL_DIR} /root
-        chown -R ${USERNAME}:${USERNAME} ${USER_RC_PATH}
+        cp -rf "${USER_RC_FILE}" "${OH_MY_INSTALL_DIR}" /root
+        chown -R ${USERNAME}:${USERNAME} "${USER_RC_PATH}"
     fi
 }
 
+# Add RS snippet and custom bash prompt
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
     echo "${RC_SNIPPET}" >> /etc/bash.bashrc
+    echo "${CODESPACES_BASH}" >> "${USER_RC_PATH}/.bashrc"
+    if [ "${USERNAME}" != "root" ]; then
+        echo "${CODESPACES_BASH}" >> "/root/.bashrc"
+    fi
+    chown ${USERNAME}:${USERNAME} "${USER_RC_PATH}/.bashrc"
     RC_SNIPPET_ALREADY_ADDED="true"
 fi
-install-oh-my bash bashrc.osh-template https://github.com/ohmybash/oh-my-bash
+
+# Add stub for Oh My Bash!
+if [ ! -d "${USER_RC_PATH}/.oh-my-bash}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
+    mkdir -p "${USER_RC_PATH}/.oh-my-bash" "/root/.oh-my-bash"
+    echo "${OMB_STUB}" >> "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
+    chmod +x "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
+    if [ "${USERNAME}" != "root" ]; then
+        echo "${OMB_STUB}" >> "/root/.oh-my-bash/oh-my-bash.sh"
+        chmod +x "/root/.oh-my-bash/oh-my-bash.sh"
+    fi
+    chown -R "${USERNAME}:${USERNAME}" "${USER_RC_PATH}/.oh-my-bash"
+fi
 
 # Optionally install and configure zsh and Oh My Zsh!
 if [ "${INSTALL_ZSH}" = "true" ]; then

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -6,7 +6,7 @@
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
 #
-# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My *! flag]
+# Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag]
 
 INSTALL_ZSH=${1:-"true"}
 USERNAME=${2:-"automatic"}
@@ -238,20 +238,22 @@ EOF
 )"
 CODESPACES_ZSH="$(cat \
 <<'EOF'
-prompt() {
-    if [ "${GITHUB_USER}" != "" ]; then
-        local USERNAME="@${GITHUB_USER}"
+__zsh_prompt() {
+    local prompt_username
+    if [ ! -z "${GITHUB_USER}" ]; then 
+        prompt_username="@${GITHUB_USER}"
     else
-        local USERNAME="%n"
+        prompt_username="%n"
     fi
-    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT="%{$fg[green]%}${prompt_username} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
     PROMPT+='%{$fg_bold[blue]%}%~%{$reset_color%} $(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}'
+    unset -f __zsh_prompt
 }
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
-prompt
+__zsh_prompt
 EOF
 )"
 
@@ -274,44 +276,7 @@ fi
 EOF
 )"
 
-# Adapted Oh My Zsh! install step to work with both "Oh Mys" rather than relying on an installer script
-# See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
-install-oh-my()
-{
-    local OH_MY=$1
-    local OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-${OH_MY}"
-    local TEMPLATE="${OH_MY_INSTALL_DIR}/templates/$2"
-    local OH_MY_GIT_URL=$3
-    local USER_RC_FILE="${USER_RC_PATH}/.${OH_MY}rc"
-
-    if [ -d "${OH_MY_INSTALL_DIR}" ] || [ "${INSTALL_OH_MYS}" != "true" ]; then
-        return 0
-    fi
-
-    umask g-w,o-w
-    mkdir -p ${OH_MY_INSTALL_DIR}
-    git clone --depth=1 \
-        -c core.eol=lf \
-        -c core.autocrlf=false \
-        -c fsck.zeroPaddedFilemode=ignore \
-        -c fetch.fsck.zeroPaddedFilemode=ignore \
-        -c receive.fsck.zeroPaddedFilemode=ignore \
-        "${OH_MY_GIT_URL}" "${OH_MY_INSTALL_DIR}" 2>&1
-    echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
-    sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
-    mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
-    echo "${CODESPACES_ZSH}" > "${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme"
-    # Shrink git while still enabling updates
-    cd "${OH_MY_INSTALL_DIR}"
-    git repack -a -d -f --depth=1 --window=1
-
-    if [ "${USERNAME}" != "root" ]; then
-        cp -rf "${USER_RC_FILE}" "${OH_MY_INSTALL_DIR}" /root
-        chown -R ${USERNAME}:${USERNAME} "${USER_RC_PATH}"
-    fi
-}
-
-# Add RS snippet and custom bash prompt
+# Add RC snippet and custom bash prompt
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
     echo "${RC_SNIPPET}" >> /etc/bash.bashrc
     echo "${CODESPACES_BASH}" >> "${USER_RC_PATH}/.bashrc"
@@ -346,7 +311,35 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
         echo "${RC_SNIPPET}" >> /etc/zsh/zshrc
         ZSH_ALREADY_INSTALLED="true"
     fi
-    install-oh-my zsh zshrc.zsh-template https://github.com/ohmyzsh/ohmyzsh
+
+    # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
+    if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
+        TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"
+        USER_RC_FILE="${USER_RC_PATH}/.zshrc"
+        umask g-w,o-w
+        mkdir -p ${OH_MY_INSTALL_DIR}
+        git clone --depth=1 \
+            -c core.eol=lf \
+            -c core.autocrlf=false \
+            -c fsck.zeroPaddedFilemode=ignore \
+            -c fetch.fsck.zeroPaddedFilemode=ignore \
+            -c receive.fsck.zeroPaddedFilemode=ignore \
+            "https://github.com/ohmyzsh/ohmyzsh" "${OH_MY_INSTALL_DIR}" 2>&1
+        echo -e "$(cat "${TEMPLATE_PATH}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
+        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+        echo "${CODESPACES_ZSH}" > "${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme"
+        # Shrink git while still enabling updates
+        cd "${OH_MY_INSTALL_DIR}"
+        git repack -a -d -f --depth=1 --window=1
+        # Copy to non-root user if one is specified
+        if [ "${USERNAME}" != "root" ]; then
+            cp -rf "${USER_RC_FILE}" "${OH_MY_INSTALL_DIR}" /root
+            chown -R ${USERNAME}:${USERNAME} "${USER_RC_PATH}"
+        fi
+    fi
 fi
 
 # Write marker file

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -84,7 +84,6 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         libicu \
         zlib \
         sudo \
-        coreutils \
         sed \
         grep \
         which \
@@ -156,48 +155,76 @@ fi
 EOF
 )"
 
+# code shim, it fallbacks to code-insiders if code is not available
+cat << 'EOF' > /usr/local/bin/code
+#!/bin/sh
+
+get_in_path_except_current() {
+    which -a "$1" | grep -A1 "$0" | grep -v "$0"
+}
+
+code="$(get_in_path_except_current code)"
+
+if [ -n "$code" ]; then
+    exec "$code" "$@"
+elif [ "$(command -v code-insiders)" ]; then
+    exec code-insiders "$@"
+else
+    echo "code or code-insiders is not installed" >&2
+    exit 127
+fi
+EOF
+chmod +x /usr/local/bin/code
+
 # Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
-<<EOF
-#!/usr/bin/env bash
-prompt() {
-    if [ "\$?" != "0" ]; then
-        local arrow_color=\${bold_red}
-    else
-        local arrow_color=\${reset_color}
-    fi
-    if [ ! -z "\${GITHUB_USER}" ]; then
-        local USERNAME="gh:@\${GITHUB_USER}"
-    else
-        local USERNAME="\$(whoami)"
-    fi
-    local cwd="\$(pwd | sed "s|^\${HOME}|~|")"
-    PS1="\${green}\${USERNAME} \${arrow_color}➜\${reset_color} \${bold_blue}\${cwd}\${reset_color} \$(scm_prompt_info)\${white}$ \${reset_color}"
+<<'EOF'
+__bash_prompt() {
+    local userpart='`export XIT=$? \
+        && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
+        && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
+    local gitbranch='`export BRANCH=$(git describe --contains --all HEAD 2>/dev/null); \
+        if [ "${BRANCH}" != "" ]; then \
+            echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
+            && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
+                    echo -n " \[\033[1;33m\]✗"; \
+            fi \
+            && echo -n "\[\033[0;36m\]) "; \
+        fi`'
+    local lightblue='\[\033[1;34m\]'
+    local removecolor='\[\033[0m\]'
+    PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
+    unset -f __bash_prompt
 }
-SCM_THEME_PROMPT_PREFIX="\${reset_color}\${cyan}(\${bold_red}"
-SCM_THEME_PROMPT_SUFFIX="\${reset_color} "
-SCM_THEME_PROMPT_DIRTY=" \${bold_yellow}✗\${reset_color}\${cyan})"
-SCM_THEME_PROMPT_CLEAN="\${reset_color}\${cyan})"
-SCM_GIT_SHOW_MINIMAL_INFO="true"
-safe_append_prompt_command prompt
+__bash_prompt
 EOF
 )"
 CODESPACES_ZSH="$(cat \
-<<EOF
+<<'EOF'
 prompt() {
-    if [ ! -z "\${GITHUB_USER}" ]; then
-        local USERNAME="gh:@\${GITHUB_USER}"
+    if [ "${GITHUB_USER}" != "" ]; then
+        local USERNAME="@${GITHUB_USER}"
     else
-        local USERNAME="\$(whoami)"
+        local USERNAME="%n"
     fi
-    PROMPT="%{\$fg[green]%}\${USERNAME} %(?:%{\$reset_color%}➜ :%{\$fg_bold[red]%}➜ )"
-    PROMPT+='%{\$fg_bold[blue]%}%~%{\$reset_color%} \$(git_prompt_info)%{\$fg[white]%}$ %{\$reset_color%}'
+    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT+='%{$fg_bold[blue]%}%~%{$reset_color%} $(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}'
 }
-ZSH_THEME_GIT_PROMPT_PREFIX="%{\$fg_bold[cyan]%}(%{\$fg_bold[red]%}"
-ZSH_THEME_GIT_PROMPT_SUFFIX="%{\$reset_color%} "
-ZSH_THEME_GIT_PROMPT_DIRTY=" %{\$fg_bold[yellow]%}✗%{\$fg_bold[cyan]%})"
-ZSH_THEME_GIT_PROMPT_CLEAN="%{\$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
+ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
+ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
+ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 prompt
+EOF
+)"
+
+# Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
+OMB_STUB="$(cat \
+<<'EOF'
+#!/usr/bin/env bash
+if [ -t 1 ]; then
+    echo -e '"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still\nwish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash\nYou may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it'
+fi
 EOF
 )"
 
@@ -223,32 +250,43 @@ install-oh-my()
         -c fsck.zeroPaddedFilemode=ignore \
         -c fetch.fsck.zeroPaddedFilemode=ignore \
         -c receive.fsck.zeroPaddedFilemode=ignore \
-        ${OH_MY_GIT_URL} ${OH_MY_INSTALL_DIR} 2>&1
+        "${OH_MY_GIT_URL}" "${OH_MY_INSTALL_DIR}" 2>&1
     echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
-    if [ "${OH_MY}" = "bash" ]; then
-        sed -i -e 's/OSH_THEME=.*/OSH_THEME="codespaces"/g' ${USER_RC_FILE}
-        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes/codespaces
-        echo "${CODESPACES_BASH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces/codespaces.theme.sh
-    else
-        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
-        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
-        echo "${CODESPACES_ZSH}" > ${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme
-    fi
+    sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+    mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+    echo "${CODESPACES_ZSH}" > "${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme"
     # Shrink git while still enabling updates
-    cd ${OH_MY_INSTALL_DIR} 
+    cd "${OH_MY_INSTALL_DIR}"
     git repack -a -d -f --depth=1 --window=1
 
     if [ "${USERNAME}" != "root" ]; then
-        cp -rf ${USER_RC_FILE} ${OH_MY_INSTALL_DIR} /root
-        chown -R ${USERNAME}:${USERNAME} ${USER_RC_PATH}
+        cp -rf "${USER_RC_FILE}" "${OH_MY_INSTALL_DIR}" /root
+        chown -R ${USERNAME}:${USERNAME} "${USER_RC_PATH}"
     fi
 }
 
+# Add RS snippet and custom bash prompt
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
-    echo "${RC_SNIPPET}" >> /etc/bashrc
+    echo "${RC_SNIPPET}" >> /etc/bash.bashrc
+    echo "${CODESPACES_BASH}" >> "${USER_RC_PATH}/.bashrc"
+    if [ "${USERNAME}" != "root" ]; then
+        echo "${CODESPACES_BASH}" >> "/root/.bashrc"
+    fi
+    chown ${USERNAME}:${USERNAME} "${USER_RC_PATH}/.bashrc"
     RC_SNIPPET_ALREADY_ADDED="true"
 fi
-install-oh-my bash bashrc.osh-template https://github.com/ohmybash/oh-my-bash
+
+# Add stub for Oh My Bash!
+if [ ! -d "${USER_RC_PATH}/.oh-my-bash}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
+    mkdir -p "${USER_RC_PATH}/.oh-my-bash" "/root/.oh-my-bash"
+    echo "${OMB_STUB}" >> "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
+    chmod +x "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
+    if [ "${USERNAME}" != "root" ]; then
+        echo "${OMB_STUB}" >> "/root/.oh-my-bash/oh-my-bash.sh"
+        chmod +x "/root/.oh-my-bash/oh-my-bash.sh"
+    fi
+    chown -R "${USERNAME}:${USERNAME}" "${USER_RC_PATH}/.oh-my-bash"
+fi
 
 # Optionally install and configure zsh and Oh My Zsh!
 if [ "${INSTALL_ZSH}" = "true" ]; then

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -201,20 +201,22 @@ EOF
 )"
 CODESPACES_ZSH="$(cat \
 <<'EOF'
-prompt() {
-    if [ "${GITHUB_USER}" != "" ]; then
-        local USERNAME="@${GITHUB_USER}"
+__zsh_prompt() {
+    local prompt_username
+    if [ ! -z "${GITHUB_USER}" ]; then 
+        prompt_username="@${GITHUB_USER}"
     else
-        local USERNAME="%n"
+        prompt_username="%n"
     fi
-    PROMPT="%{$fg[green]%}${USERNAME} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
+    PROMPT="%{$fg[green]%}${prompt_username} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
     PROMPT+='%{$fg_bold[blue]%}%~%{$reset_color%} $(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}'
+    unset -f __zsh_prompt
 }
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
-prompt
+__zsh_prompt
 EOF
 )"
 
@@ -237,44 +239,7 @@ fi
 EOF
 )"
 
-# Adapted Oh My Zsh! install step to work with both "Oh Mys" rather than relying on an installer script
-# See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
-install-oh-my()
-{
-    local OH_MY=$1
-    local OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-${OH_MY}"
-    local TEMPLATE="${OH_MY_INSTALL_DIR}/templates/$2"
-    local OH_MY_GIT_URL=$3
-    local USER_RC_FILE="${USER_RC_PATH}/.${OH_MY}rc"
-
-    if [ -d "${OH_MY_INSTALL_DIR}" ] || [ "${INSTALL_OH_MYS}" != "true" ]; then
-        return 0
-    fi
-
-    umask g-w,o-w
-    mkdir -p ${OH_MY_INSTALL_DIR}
-    git clone --depth=1 \
-        -c core.eol=lf \
-        -c core.autocrlf=false \
-        -c fsck.zeroPaddedFilemode=ignore \
-        -c fetch.fsck.zeroPaddedFilemode=ignore \
-        -c receive.fsck.zeroPaddedFilemode=ignore \
-        "${OH_MY_GIT_URL}" "${OH_MY_INSTALL_DIR}" 2>&1
-    echo -e "$(cat "${TEMPLATE}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
-    sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
-    mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
-    echo "${CODESPACES_ZSH}" > "${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme"
-    # Shrink git while still enabling updates
-    cd "${OH_MY_INSTALL_DIR}"
-    git repack -a -d -f --depth=1 --window=1
-
-    if [ "${USERNAME}" != "root" ]; then
-        cp -rf "${USER_RC_FILE}" "${OH_MY_INSTALL_DIR}" /root
-        chown -R ${USERNAME}:${USERNAME} "${USER_RC_PATH}"
-    fi
-}
-
-# Add RS snippet and custom bash prompt
+# Add RC snippet and custom bash prompt
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
     echo "${RC_SNIPPET}" >> /etc/bash.bashrc
     echo "${CODESPACES_BASH}" >> "${USER_RC_PATH}/.bashrc"
@@ -308,7 +273,35 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
         echo "${RC_SNIPPET}" >> /etc/zshrc
         ZSH_ALREADY_INSTALLED="true"
     fi
-    install-oh-my zsh zshrc.zsh-template https://github.com/ohmyzsh/ohmyzsh
+
+    # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
+    if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
+        TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"
+        USER_RC_FILE="${USER_RC_PATH}/.zshrc"
+        umask g-w,o-w
+        mkdir -p ${OH_MY_INSTALL_DIR}
+        git clone --depth=1 \
+            -c core.eol=lf \
+            -c core.autocrlf=false \
+            -c fsck.zeroPaddedFilemode=ignore \
+            -c fetch.fsck.zeroPaddedFilemode=ignore \
+            -c receive.fsck.zeroPaddedFilemode=ignore \
+            "https://github.com/ohmyzsh/ohmyzsh" "${OH_MY_INSTALL_DIR}" 2>&1
+        echo -e "$(cat "${TEMPLATE_PATH}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
+        sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+        mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
+        echo "${CODESPACES_ZSH}" > "${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme"
+        # Shrink git while still enabling updates
+        cd "${OH_MY_INSTALL_DIR}"
+        git repack -a -d -f --depth=1 --window=1
+        # Copy to non-root user if one is specified
+        if [ "${USERNAME}" != "root" ]; then
+            cp -rf "${USER_RC_FILE}" "${OH_MY_INSTALL_DIR}" /root
+            chown -R ${USERNAME}:${USERNAME} "${USER_RC_PATH}"
+        fi
+    fi
 fi
 
 # Write marker file

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -219,11 +219,20 @@ EOF
 )"
 
 # Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
+OMB_README="$(cat \
+<<'EOF'
+"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still
+wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
+You may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it
+See https://github.com/microsoft/vscode-dev-containers/issues/674#issuecomment-783474956
+EOF
+)"
 OMB_STUB="$(cat \
 <<'EOF'
 #!/usr/bin/env bash
+cd "$(dirname $0)"
 if [ -t 1 ]; then
-    echo -e '"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still\nwish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash\nYou may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it'
+    cat README.md
 fi
 EOF
 )"
@@ -279,9 +288,11 @@ fi
 # Add stub for Oh My Bash!
 if [ ! -d "${USER_RC_PATH}/.oh-my-bash}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
     mkdir -p "${USER_RC_PATH}/.oh-my-bash" "/root/.oh-my-bash"
+    echo "${OMB_README}" >> "${USER_RC_PATH}/.oh-my-bash/README.md"
     echo "${OMB_STUB}" >> "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
     chmod +x "${USER_RC_PATH}/.oh-my-bash/oh-my-bash.sh"
     if [ "${USERNAME}" != "root" ]; then
+        echo "${OMB_README}" >> "/root/.oh-my-bash/README.md"
         echo "${OMB_STUB}" >> "/root/.oh-my-bash/oh-my-bash.sh"
         chmod +x "/root/.oh-my-bash/oh-my-bash.sh"
     fi

--- a/script-library/docs/common.md
+++ b/script-library/docs/common.md
@@ -9,9 +9,9 @@
 ## Syntax
 
 ```text
-./common-debian.sh [Install zsh flag] [Non-root user] [User UID] [User GID] [Upgrade packages flag] [Install Oh My *! flag]
-./common-redhat.sh [Install zsh flag] [Non-root user] [User UID] [User GID] [Upgrade packages flag] [Install Oh My *! flag]
-./common-alpine.sh [Install zsh flag] [Non-root user] [User UID] [User GID] [Install Oh My *! flag]
+./common-debian.sh [Install zsh flag] [Non-root user] [User UID] [User GID] [Upgrade packages flag] [Install Oh My Zsh! flag]
+./common-redhat.sh [Install zsh flag] [Non-root user] [User UID] [User GID] [Upgrade packages flag] [Install Oh My Zsh! flag]
+./common-alpine.sh [Install zsh flag] [Non-root user] [User UID] [User GID] [Install Oh My Zsh! flag]
 ```
 
 > **Note:** `common-redhat.sh` is community supported.
@@ -23,7 +23,9 @@
 |User UID|`automatic`| A specific UID (e.g. `1000`) for the user that will be created modified. A value of `automatic` will pick a free one if the user is created. |
 |User GID|`automatic`| A specific GID (e.g. `1000`) for the user's group that will be created modified. A value of `automatic` will pick a free one if the group is created. |
 | Upgrade packages flag | `true` | A `true`/`false` flag that indicates whether packages should be upgraded to the latest for the distro. |
-| Install Oh My *! flag | `true` | A `true`/`false` flag that indicates whether Oh My Bash! and Oh My Zsh! should be installed. |
+| Install Oh My Zsh! flag | `true` | A `true`/`false` flag that indicates whether Oh My Zsh! should be installed. |
+
+> **Note:** Previous versions of this script also installed Oh My Bash! but this has been dropped in favor of a simplified, default PS1 since it conflicted with common user configuration. A stub is added to let those who referenced it in their dotfiles or other content about the change.
 
 ## Usage
 

--- a/script-library/docs/common.md
+++ b/script-library/docs/common.md
@@ -1,6 +1,6 @@
 # Common Utility and Non-Root User Install Script
 
-*Installs a set of common command line utilities, Oh My Bash!, Oh My Zsh!, and sets up a non-root user.*
+*Installs a set of common command line utilities, Oh My Zsh!, and sets up a non-root user.*
 
 **Script status**: Stable
 

--- a/script-library/docs/common.md
+++ b/script-library/docs/common.md
@@ -25,7 +25,7 @@
 | Upgrade packages flag | `true` | A `true`/`false` flag that indicates whether packages should be upgraded to the latest for the distro. |
 | Install Oh My Zsh! flag | `true` | A `true`/`false` flag that indicates whether Oh My Zsh! should be installed. |
 
-> **Note:** Previous versions of this script also installed Oh My Bash! but this has been dropped in favor of a simplified, default PS1 since it conflicted with common user configuration. A stub is added to let those who referenced it in their dotfiles or other content about the change.
+> **Note:** Previous versions of this script also installed Oh My Bash! but this has been dropped in favor of a simplified, default PS1 since it conflicted with common user configuration. A stub has been added so those that may have referenced it in places like their dotfiles are informed of the change and how to add it back if needed.
 
 ## Usage
 


### PR DESCRIPTION
This PR moves away from using Oh My Bash! by default and replaces it with a PS1 script that does exactly what the default prompt did.  This should resolve conflicts described in #674 and drop a dependency.  The Python extension's prefixing should also work by default with this update.

A stub script is left in the image under `~/.oh-my-bash/oh-my-bash.sh` that lets people know this has happened in the event OMB is referenced in their `dotfiles` and by extension their `~/.bashrc` or `~/.bash_profile` files.

The only downside with doing this is you need to remove the folder before installing OMB if you want it. At the moment its erroring on the side of awareness despite that fact.  I expect that after a few months we can remove this stub.

//cc: @matthewisabel @lostintangent @bamurtaugh