### PR TITLE
 docker composer v3.5 isn't support init flag.

### DIFF
--- a/containers/dapr-dotnetcore-3.1/.devcontainer/docker-compose.yml
+++ b/containers/dapr-dotnetcore-3.1/.devcontainer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.7'
 services:
   app:
     # Uncomment the next line to use a non-root user for all processes. You can also

--- a/containers/dapr-typescript-node/.devcontainer/docker-compose.yml
+++ b/containers/dapr-typescript-node/.devcontainer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.5'
+version: '3.7'
 services:
   app:
     build: 


### PR DESCRIPTION
When I open in dev container, then show the below error message:
The Compose file '/home/myname/dapr/quickstarts/hello-world/.devcontainer/docker-compose.yml' is invalid because:
Unsupported config option for services.app: 'init'
Just change version 3.5 to 3.7 will be work.
[Compose file version 3 reference](https://docs.docker.com/compose/compose-file/compose-file-v3/#init)