### PR TITLE
Bump image version numbers for VS Code release, OMB sunset

### DIFF
--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.13", "3.12", "3.11", "3.10"],
-	"definitionVersion": "0.200.1",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",

--- a/containers/codespaces-linux-stretch/definition-manifest.json
+++ b/containers/codespaces-linux-stretch/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.22.3",
+	"definitionVersion": "0.23.0",
 	"build": {
 		"latest": false,
 		"versionedTagsOnly": true,

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "1.1.3",
+	"definitionVersion": "1.2.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/cpp/definition-manifest.json
+++ b/containers/cpp/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "focal", "bionic", "stretch"],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"parent": {

--- a/containers/debian/definition-manifest.json
+++ b/containers/debian/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "stretch"],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["5.0", "3.1", "2.1"],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["1", "1.16", "1.15"],
-	"definitionVersion": "0.201.1",
+	"definitionVersion": "0.202.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/java-8/definition-manifest.json
+++ b/containers/java-8/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "15", "11" ],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["14-buster", "12-buster", "10-buster","14-stretch", "12-stretch", "10-stretch"],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["8", "8.0", "7", "7.4", "7.3"],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3-anaconda/definition-manifest.json
+++ b/containers/python-3-anaconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3-miniconda/definition-manifest.json
+++ b/containers/python-3-miniconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3", "3.9", "3.8", "3.7", "3.6"],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3", "3.0", "2", "2.7", "2.6", "2.5"],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["focal", "bionic"],
-	"definitionVersion": "0.200.1",
+	"definitionVersion": "0.201.0",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",


### PR DESCRIPTION
This PR updates the version number for all images to:

1. Pick up the OMB sunset changes
2. Prepare for the VS Code release to stable where we want to get images to "current" including security patches

CC'ing others in case there's something else we think needs to get in before in the mean time.