### PR TITLE
Improve script docs to improve visibility to maintainer

### DIFF
--- a/script-library/README.md
+++ b/script-library/README.md
@@ -12,30 +12,30 @@ Script names end in the Linux distribution "tree" they support. The majority are
 
 Some scripts have special installation instructions (like `desktop-lite-debian.sh`). Consult the following documents for more information (in order of the script name):
 
-| Document | Script |
-|----------|--------|
-| [Azure CLI Install Script](docs/azcli.md) | `azcli-debian.sh` |
-| [Common Script](docs/common.md) | `common-debian.sh`<br />`common-alpine.sh`<br />`common-redhat.sh` (Community) |
-| [Desktop (Lightweight) Install Script](docs/desktop-lite.md) | `desktop-lite-debian.sh` |
-| [Docker-from-Docker Install Script](docs/docker.md) | `docker-debian.sh`<br />`docker-redhat.sh` (Community) |
-| [Docker-in-Docker Install Script](docs/docker-in-docker.md) | `docker-in-docker-debian.sh` |
-| [fish Install Script](docs/fish.md) | `fish-debian.sh` |
-| [Git Build/Install from Source Script](docs/git-from-src.md) | `git-from-src-debian.sh` |
-| [Git LFS Install Script](docs/git-lfs.md) | `git-lfs-debian.sh` |
-| [GitHub CLI Install Script](docs/github.md) | `github-debian.sh` |
-| [Go (golang) Install Script](docs/go.md) | `go-debian.sh` |
-| [Gradle Install Script](docs/gradle.md) | `gradle-debian.sh` |
-| [Homebrew Install Script](docs/homebrew.md) | `homebrew-debian.sh` |
-| [Java Install Script](docs/java.md) | `java-debian.sh` |
-| [Kubectl and Helm Install Script](docs/kubectl-helm.md) | `kubectl-helm-debian.sh` |
-| [Maven Install Script](docs/maven.md) | `maven-debian.sh` |
-| [Node.js Install Script](docs/node.md) | `node-debian.sh` |
-| [PowerShell Install Script](docs/powershell.md) | `powershell-debian.sh` |
-| [Python Install Script](docs/python.md) | `python-debian.sh` |
-| [Ruby Install Script](docs/ruby.md) | `ruby-debian.sh` |
-| [Rust (rustlang) Install Script](docs/rust.md) | `rust-debian.sh` |
-| [SSH Server Install Script](docs/sshd.md) | `sshd-debian.sh` |
-| [Terraform CLI Install Script](docs/terraform.md) | `terraform-debian.sh` |
+| Document | Script | Maintainers |
+|----------|--------|------------|
+| [Azure CLI Install Script](docs/azcli.md) | `azcli-debian.sh` | VS Code and GitHub Codespaces teams |
+| [Common Script](docs/common.md) | `common-debian.sh`<br />`common-alpine.sh`<br />`common-redhat.sh` (Community) | VS Code and GitHub Codespaces teams |
+| [Desktop (Lightweight) Install Script](docs/desktop-lite.md) | `desktop-lite-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Docker-in-Docker Install Script](docs/docker-in-docker.md) | `docker-in-docker-debian.sh` | VS Code and GitHub Codespaces teams |
+| [Docker-from-Docker Install Script](docs/docker.md) | `docker-debian.sh`<br />`docker-redhat.sh` (Community) | VS Code and GitHub Codespaces teams, [@smankoo](https://github.com/smankoo) (`docker-redhat.sh`) |
+| [fish Install Script](docs/fish.md) | `fish-debian.sh` (Community) | [@andreiborisov](https://github.com/andreiborisov) |
+| [Git Build/Install from Source Script](docs/git-from-src.md) | `git-from-src-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Git LFS Install Script](docs/git-lfs.md) | `git-lfs-debian.sh` | VS Code and GitHub Codespaces teams|
+| [GitHub CLI Install Script](docs/github.md) | `github-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Go (golang) Install Script](docs/go.md) | `go-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Gradle Install Script](docs/gradle.md) | `gradle-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Homebrew Install Script](docs/homebrew.md) | `homebrew-debian.sh` (Community) | [@andreiborisov](https://github.com/andreiborisov) |
+| [Java Install Script](docs/java.md) | `java-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Kubectl and Helm Install Script](docs/kubectl-helm.md) | `kubectl-helm-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Maven Install Script](docs/maven.md) | `maven-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Node.js Install Script](docs/node.md) | `node-debian.sh` | VS Code and GitHub Codespaces teams|
+| [PowerShell Install Script](docs/powershell.md) | `powershell-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Python Install Script](docs/python.md) | `python-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Ruby Install Script](docs/ruby.md) | `ruby-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Rust (rustlang) Install Script](docs/rust.md) | `rust-debian.sh` | VS Code and GitHub Codespaces teams|
+| [SSH Server Install Script](docs/sshd.md) | `sshd-debian.sh` | VS Code and GitHub Codespaces teams|
+| [Terraform CLI Install Script](docs/terraform.md) | `terraform-debian.sh` | VS Code and GitHub Codespaces teams|
 
 ## Using a script
 

--- a/script-library/azcli-debian.sh
+++ b/script-library/azcli-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh
 

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-alpine.sh [install zsh flag] [username] [user UID] [user GID] [install Oh My Zsh! flag]
 

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag]
 

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -4,11 +4,11 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
+# ** This script is community supported **
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Maintainer: The VS Code and Codespaces Teams
 #
-# Community supported RedHat based version of common-debian.sh
-#
-# Syntax: ./common-redhat.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My *! flag]
+# Syntax: ./common-redhat.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag]
 
 INSTALL_ZSH=${1:-"true"}
 USERNAME=${2:-"automatic"}

--- a/script-library/desktop-lite-debian.sh
+++ b/script-library/desktop-lite-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/desktop-lite.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./desktop-lite-debian.sh [non-root user] [vnc password] [install no vnc flag]
 

--- a/script-library/docker-debian.sh
+++ b/script-library/docker-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]
 

--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-in-docker-debian.sh [enable non-root docker access flag] [non-root user] [use moby]
 

--- a/script-library/docker-redhat.sh
+++ b/script-library/docker-redhat.sh
@@ -4,9 +4,9 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
+# ** This script is community supported **
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
-#
-# Community supported RedHat based version of docker-debian.sh
+# Maintainer: @smankoo
 #
 # Syntax: ./docker-redhat.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user]
 

--- a/script-library/docs/azcli.md
+++ b/script-library/docs/azcli.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/common.md
+++ b/script-library/docs/common.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, Alpine 3.9+, CentOS/RHEL 7+ (community supported) and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/desktop-lite.md
+++ b/script-library/docs/desktop-lite.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 > **Note:** When using a VNC Viewer client, you may need to set the quality level to get high color since it can default to "low" with some clients.
 
 ## Syntax

--- a/script-library/docs/docker-in-docker.md
+++ b/script-library/docs/docker-in-docker.md
@@ -4,7 +4,11 @@
 
 *Create child containers _inside_ a container, independent from the host's docker instance. Installs Docker extension in the container along with needed CLIs.* 
 
+**Script status:** Stable
+
 **OS support**: Debian 9+, Ubuntu 20.04+, and downstream distros.
+
+**Maintainer:** The VS Code and GitHub Codespaces teams
 
 ## Syntax
 

--- a/script-library/docs/docker.md
+++ b/script-library/docs/docker.md
@@ -6,14 +6,16 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, CentOS/RHEL 7+ (community supported) and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams, [@smankoo](https://github.com/smankoo) (`docker-redhat.sh`)
+
+> **Note:** `docker-redhat.sh` is community supported.
+
 ## Syntax
 
 ```text
 ./docker-debian.sh [Non-root access flag] [Source socket] [Target socket] [Non-root user] [Use Moby]
 ./docker-redhat.sh [Non-root access flag] [Source socket] [Target socket] [Non-root user]
 ```
-
-> **Note:** `docker-redhat.sh` is community supported.
 
 |Argument|Default|Description|
 |--------|-------|-----------|

--- a/script-library/docs/fish.md
+++ b/script-library/docs/fish.md
@@ -1,10 +1,14 @@
 # fish Install Script
 
+> **Note:** This is a community contributed and maintained script.
+
 *Adds [fish shell](https://github.com/fish-shell/fish-shell) to a container.*
 
 **Script status**: Stable
 
 **OS support**: Debian 9+, Ubuntu 16.04+.
+
+**Maintainer:** [@andreiborisov](https://github.com/andreiborisov)
 
 ## Syntax
 

--- a/script-library/docs/git-from-src.md
+++ b/script-library/docs/git-from-src.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/git-lfs.md
+++ b/script-library/docs/git-lfs.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/github.md
+++ b/script-library/docs/github.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/go.md
+++ b/script-library/docs/go.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/gradle.md
+++ b/script-library/docs/gradle.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/homebrew.md
+++ b/script-library/docs/homebrew.md
@@ -1,10 +1,14 @@
 # Homebrew Install Script
 
+> **Note:** This is a community contributed and maintained script.
+
 *Adds Homebrew to a container.*
 
 **Script status**: Stable
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
+
+**Maintainer:** [@andreiborisov](https://github.com/andreiborisov)
 
 ## Syntax
 

--- a/script-library/docs/java.md
+++ b/script-library/docs/java.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/kubectl-helm.md
+++ b/script-library/docs/kubectl-helm.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/maven.md
+++ b/script-library/docs/maven.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/node.md
+++ b/script-library/docs/node.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/powershell.md
+++ b/script-library/docs/powershell.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/python.md
+++ b/script-library/docs/python.md
@@ -2,9 +2,11 @@
 
 *Installs Python, PIPX, and common Python utilities.*
 
-**Script status**: Draft
+**Script status**: Stable
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
+
+**Maintainer:** The VS Code and GitHub Codespaces teams
 
 ## Syntax
 

--- a/script-library/docs/ruby.md
+++ b/script-library/docs/ruby.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/rust.md
+++ b/script-library/docs/rust.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/sshd.md
+++ b/script-library/docs/sshd.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/docs/terraform.md
+++ b/script-library/docs/terraform.md
@@ -6,6 +6,8 @@
 
 **OS support**: Debian 9+, Ubuntu 16.04+, and downstream distros.
 
+**Maintainer:** The VS Code and GitHub Codespaces teams
+
 ## Syntax
 
 ```text

--- a/script-library/fish-debian.sh
+++ b/script-library/fish-debian.sh
@@ -4,7 +4,9 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
+# ** This script is community supported **
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/homebrew.md
+# Maintainer: @andreiborisov
 #
 # Syntax: ./fish-debian.sh [whether to install Fisher] [non-root user]
 

--- a/script-library/git-from-src-debian.sh
+++ b/script-library/git-from-src-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/git-from-src.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./git-from-src-debian.sh [version]
 

--- a/script-library/git-lfs-debian.sh
+++ b/script-library/git-lfs-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/git-lfs.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./git-lfs-debian.sh
 

--- a/script-library/github-debian.sh
+++ b/script-library/github-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/github.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./github-debian.sh [version]
 

--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/go.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./go-debian.sh [Go version] [GOROOT] [GOPATH] [non-root user] [Add GOPATH, GOROOT to rc files flag] [Install tools flag]
 

--- a/script-library/gradle-debian.sh
+++ b/script-library/gradle-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/gradle.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./gradle-debian.sh [Gradle version] [SDKMAN_DIR] [non-root user] [Update rc files flag]
 

--- a/script-library/homebrew-debian.sh
+++ b/script-library/homebrew-debian.sh
@@ -4,7 +4,9 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
+# ** This script is community supported **
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/homebrew.md
+# Maintainer: @andreiborisov
 #
 # Syntax: ./homebrew-debian.sh [non-root user] [add Homebrew binaries to PATH] [whether to use shallow clone] [where to install Homebrew]
 

--- a/script-library/java-debian.sh
+++ b/script-library/java-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/java.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./java-debian.sh [JDK version] [SDKMAN_DIR] [non-root user] [Add to rc files flag]
 

--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/kubectl-helm.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./kubectl-helm-debian.sh
 

--- a/script-library/maven-debian.sh
+++ b/script-library/maven-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/maven.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./maven-debian.sh [maven version] [SDKMAN_DIR] [non-root user] [Update rc files flag]
 

--- a/script-library/node-debian.sh
+++ b/script-library/node-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]
 

--- a/script-library/powershell-debian.sh
+++ b/script-library/powershell-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/powershell.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./powershell-debian.sh
 

--- a/script-library/python-debian.sh
+++ b/script-library/python-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/python.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./python-debian.sh [Python Version] [Python intall path] [PIPX_HOME] [non-root user] [Update rc files flag] [install tools]
 

--- a/script-library/ruby-debian.sh
+++ b/script-library/ruby-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/ruby.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./ruby-debian.sh [Ruby version] [non-root user] [Add to rc files flag] [Install tools flag]
 

--- a/script-library/rust-debian.sh
+++ b/script-library/rust-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/rust.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./rust-debian.sh [CARGO_HOME] [RUSTUP_HOME] [non-root user] [add CARGO/RUSTUP_HOME to rc files flag] [whether to update rust]
 

--- a/script-library/sshd-debian.sh
+++ b/script-library/sshd-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/sshd.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./sshd-debian.sh [SSH Port (don't use 22)] [non-root user] [start sshd now flag] [new password for user]
 #

--- a/script-library/terraform-debian.sh
+++ b/script-library/terraform-debian.sh
@@ -5,6 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/terraform.md
+# Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./terraform-debian.sh [terraform version] [tflint version]
 


### PR DESCRIPTION
Now that we're starting to see 3rd party maintained scripts like we have for dev containers, we should raise visibility to owners and maintainers in docs and comments in the scripts.

This PR updates the table to reference maintainers, adds the maintainer to the docs, and indicates the maintainer and whether or not the script is community maintained in the comments of the script itself.