### PR TITLE
Fix first run text due to terminal refresh, OMB notice

### DIFF
--- a/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/alpine/.devcontainer/library-scripts/common-alpine.sh
+++ b/containers/alpine/.devcontainer/library-scripts/common-alpine.sh
@@ -149,15 +149,21 @@ else
     USER_RC_PATH="/home/${USERNAME}"
 fi
 
-# bashrc/zshrc snippet
-RC_SNIPPET="$(cat << EOF
-export USER=\$(whoami)
+# .bashrc/.zshrc snippet
+RC_SNIPPET="$(cat << 'EOF'
 
-export PATH=\$PATH:\$HOME/.local/bin
+if [ -z "${USER}"]; then export USER=$(whoami); fi
+if [[ "${PATH}" != *"$HOME/.local/bin"* ]]; then export PATH="${PATH}:$HOME/.local/bin"; fi
 
-if type code-insiders > /dev/null 2>&1 && ! type code > /dev/null 2>&1; then 
-    alias code=code-insiders
+# Display optional first run image specific notice if configured and terminal is interactive
+if [ -t 1 ] && [ -f "/usr/local/etc/vscode-dev-containers/first-run-notice.txt" ] && [ ! -f "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed" ]; then
+    cat /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+    mkdir -p $HOME/.config/vscode-dev-containers
+    # Mark first run notice as displayed after 10s to avoid problems with fast terminal refreshes hiding it
+    (sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") & >/dev/null 2>&1
+    disown %+
 fi
+
 EOF
 )"
 
@@ -166,25 +172,27 @@ cat << 'EOF' > /usr/local/bin/code
 #!/bin/sh
 
 get_in_path_except_current() {
-  which -a "$1" | grep -v "$0" | head -1
+    which -a "$1" | grep -A1 "$0" | grep -v "$0"
 }
 
 code="$(get_in_path_except_current code)"
 
 if [ -n "$code" ]; then
-  exec "$code" "$@"
+    exec "$code" "$@"
 elif [ "$(command -v code-insiders)" ]; then
-  exec code-insiders "$@"
+    exec code-insiders "$@"
 else
-  echo "code or code-insiders is not installed" >&2
-  exit 127
+    echo "code or code-insiders is not installed" >&2
+    exit 127
 fi
 EOF
 chmod +x /usr/local/bin/code
 
-# Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+# Codespaces bash and OMZ themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
 <<'EOF'
+
+# Codespaces bash prompt theme
 __bash_prompt() {
     local userpart='`export XIT=$? \
         && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
@@ -203,6 +211,7 @@ __bash_prompt() {
     unset -f __bash_prompt
 }
 __bash_prompt
+
 EOF
 )"
 CODESPACES_ZSH="$(cat \
@@ -229,18 +238,17 @@ EOF
 # Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
 OMB_README="$(cat \
 <<'EOF'
-"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still
-wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
+"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you 
+still wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
 You may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it
-See https://github.com/microsoft/vscode-dev-containers/issues/674#issuecomment-783474956
+See here for infomation on adding it to your image or dotfiles: https://aka.ms/codespaces/omb-remove
 EOF
 )"
 OMB_STUB="$(cat \
 <<'EOF'
 #!/usr/bin/env bash
-cd "$(dirname $0)"
 if [ -t 1 ]; then
-    cat README.md
+    cat $HOME/.oh-my-bash/README.md
 fi
 EOF
 )"

--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.13", "3.12", "3.11", "3.10"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",

--- a/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/azure-bicep/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-bicep/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/azure-blockchain/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-blockchain/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/bazel/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/bazel/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/codespaces-linux-stretch/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux-stretch/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/codespaces-linux-stretch/.devcontainer/setup-user.sh
+++ b/containers/codespaces-linux-stretch/.devcontainer/setup-user.sh
@@ -37,3 +37,11 @@ sudo -u ${USERNAME} mkdir -p /home/${USERNAME}/.local/bin
 install -o ${USERNAME} -g ${USERNAME} -m 755 /tmp/scripts/git-ed.sh /home/${USERNAME}/.local/bin/git-ed.sh
 sudo -u ${USERNAME} git config --global core.editor "/home/${USERNAME}/.local/bin/git-ed.sh"
 rm -f /tmp/scripts/git-ed.sh
+
+# Add one time notice
+cat << 'EOF' > "/usr/local/etc/vscode-dev-containers/first-run-notice.txt"
+Welcome to Codespaces! Note that this version of default Codespaces image is now depreicated.
+A new version of the image is available that uses Ubuntu 20.04 instead of Debian 9 with
+updated tools! So, change your devcontainer.json or Dockerfile to reference version 1-linux get 
+the latest. More information on the update can be found at: https://aka.ms/ghcs-default-focal.
+EOF

--- a/containers/codespaces-linux-stretch/.devcontainer/setup-user.sh
+++ b/containers/codespaces-linux-stretch/.devcontainer/setup-user.sh
@@ -40,8 +40,8 @@ rm -f /tmp/scripts/git-ed.sh
 
 # Add one time notice
 cat << 'EOF' > "/usr/local/etc/vscode-dev-containers/first-run-notice.txt"
-Welcome to Codespaces! Note that this version of default Codespaces image is now depreicated.
-A new version of the image is available that uses Ubuntu 20.04 instead of Debian 9 with
-updated tools! So, change your devcontainer.json or Dockerfile to reference version 1-linux get 
+Welcome to Codespaces! Note that this version of the Codespaces image is now depreicated.
+A new version of the image is available that uses Ubuntu 20.04 instead of Debian 9 with updated
+tools! So, change your devcontainer.json or Dockerfile to reference version 1-linux to get 
 the latest. More information on the update can be found at: https://aka.ms/ghcs-default-focal.
 EOF

--- a/containers/codespaces-linux-stretch/README.md
+++ b/containers/codespaces-linux-stretch/README.md
@@ -1,8 +1,8 @@
-# GitHub Codespaces - Stretch (Legacy)
+# GitHub Codespaces - Stretch (Deprecated)
 
 ## Summary
 
-*Legacy Debian 9 / Stretch based Codespaces universal default image. Use or extend the default, large, multi-language universal container for GitHub Codespaces.*
+*Deprecated Debian 9 / Stretch based Codespaces universal default image. Use or extend the default, large, multi-language universal container for GitHub Codespaces.*
 
 | Metadata | Value |  
 |----------|-------|
@@ -18,7 +18,7 @@
 
 ## Description
 
-> **Note:** This is the legacy Debian 9/Strech based image. See the [codespaces-linux definition](../codespaces-linux) for the current Ubuntu 20.04/Focal based image.
+> **Note:** This is the deprecated Debian 9/Strech based image. See the [codespaces-linux definition](../codespaces-linux) for the current Ubuntu 20.04/Focal based image.
 
 While language specific development containers can be useful, in some cases you may want to use more than one in a project without having to set them all up. In other cases you may be looking to create a general "sandbox" container you intend to use with multiple projects or repositories. The large container image generated here (`mcr.microsoft.com/vscode/devcontainers/universal:linux`) includes a number of runtime versions for popular languages lke Python, Node, PHP, Java, Go, C++, Ruby, Go, Rust and .NET Core/C# - many of which are [inherited from the Oryx build image](https://github.com/microsoft/oryx#supported-platforms) it is based on.
 

--- a/containers/codespaces-linux-stretch/definition-manifest.json
+++ b/containers/codespaces-linux-stretch/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.23.0",
+	"definitionVersion": "0.23.1",
 	"build": {
 		"latest": false,
 		"versionedTagsOnly": true,

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/codespaces-linux/.devcontainer/setup-user.sh
+++ b/containers/codespaces-linux/.devcontainer/setup-user.sh
@@ -35,10 +35,7 @@ sudo -u ${USERNAME} git config --global core.editor "/home/${USERNAME}/.local/bi
 rm -f /tmp/scripts/git-ed.sh
 
 # Add one time notice
-tee -a /etc/bash.bashrc /etc/zsh/zshrc << EOF
-if [ -t 1 ] && [ ! -f \$HOME/.config/vscode-dev-containers/first-run-notice ]; then
-  echo -e "Welcome to Codespaces! Note that the default Codespaces image is now Ubuntu 20.04-based!\nIf you need to use the old image (or a custom one) see https://aka.ms/ghcs-default-focal."
-  mkdir -p \$HOME/.config/vscode-dev-containers
-  touch \$HOME/.config/vscode-dev-containers/first-run-notice
-fi
+cat << 'EOF' > "/usr/local/etc/vscode-dev-containers/first-run-notice.txt"
+Welcome to Codespaces! Note that the default Codespaces image is now Ubuntu 20.04-based!
+If you need to use the old image (or a custom one) see https://aka.ms/ghcs-default-focal.
 EOF

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "1.2.0",
+	"definitionVersion": "1.2.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/cpp/definition-manifest.json
+++ b/containers/cpp/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "focal", "bionic", "stretch"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"parent": {

--- a/containers/dart/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dart/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/debian/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/debian/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/debian/definition-manifest.json
+++ b/containers/debian/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "stretch"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/docker-in-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-in-docker/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/dotnet/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dotnet/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["5.0", "3.1", "2.1"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/go/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["1", "1.16", "1.15"],
-	"definitionVersion": "0.202.0",
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/java-8/definition-manifest.json
+++ b/containers/java-8/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",

--- a/containers/java/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "15", "11" ],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["14-buster", "12-buster", "10-buster","14-stretch", "12-stretch", "10-stretch"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/perl/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/perl/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/php/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/php/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["8", "8.0", "7", "7.4", "7.3"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/powershell/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/powershell/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/python-3/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3", "3.9", "3.8", "3.7", "3.6"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/r/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/r/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/ruby/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3", "3.0", "2", "2.7", "2.6", "2.5"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/rust/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/rust/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/rust/definition-manifest.json
+++ b/containers/rust/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.200.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/swift/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/swift/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["14-buster", "12-buster", "10-buster", "14-stretch", "12-stretch", "10-stretch"],
-	"definitionVersion": "0.200.0",
+	"definitionVersion": "0.200.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["focal", "bionic"],
-	"definitionVersion": "0.201.0",
+	"definitionVersion": "0.201.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -149,15 +149,21 @@ else
     USER_RC_PATH="/home/${USERNAME}"
 fi
 
-# bashrc/zshrc snippet
-RC_SNIPPET="$(cat << EOF
-export USER=\$(whoami)
+# .bashrc/.zshrc snippet
+RC_SNIPPET="$(cat << 'EOF'
 
-export PATH=\$PATH:\$HOME/.local/bin
+if [ -z "${USER}"]; then export USER=$(whoami); fi
+if [[ "${PATH}" != *"$HOME/.local/bin"* ]]; then export PATH="${PATH}:$HOME/.local/bin"; fi
 
-if type code-insiders > /dev/null 2>&1 && ! type code > /dev/null 2>&1; then 
-    alias code=code-insiders
+# Display optional first run image specific notice if configured and terminal is interactive
+if [ -t 1 ] && [ -f "/usr/local/etc/vscode-dev-containers/first-run-notice.txt" ] && [ ! -f "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed" ]; then
+    cat /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+    mkdir -p $HOME/.config/vscode-dev-containers
+    # Mark first run notice as displayed after 10s to avoid problems with fast terminal refreshes hiding it
+    (sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") & >/dev/null 2>&1
+    disown %+
 fi
+
 EOF
 )"
 
@@ -166,25 +172,27 @@ cat << 'EOF' > /usr/local/bin/code
 #!/bin/sh
 
 get_in_path_except_current() {
-  which -a "$1" | grep -v "$0" | head -1
+    which -a "$1" | grep -A1 "$0" | grep -v "$0"
 }
 
 code="$(get_in_path_except_current code)"
 
 if [ -n "$code" ]; then
-  exec "$code" "$@"
+    exec "$code" "$@"
 elif [ "$(command -v code-insiders)" ]; then
-  exec code-insiders "$@"
+    exec code-insiders "$@"
 else
-  echo "code or code-insiders is not installed" >&2
-  exit 127
+    echo "code or code-insiders is not installed" >&2
+    exit 127
 fi
 EOF
 chmod +x /usr/local/bin/code
 
-# Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+# Codespaces bash and OMZ themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
 <<'EOF'
+
+# Codespaces bash prompt theme
 __bash_prompt() {
     local userpart='`export XIT=$? \
         && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
@@ -203,6 +211,7 @@ __bash_prompt() {
     unset -f __bash_prompt
 }
 __bash_prompt
+
 EOF
 )"
 CODESPACES_ZSH="$(cat \
@@ -229,18 +238,17 @@ EOF
 # Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
 OMB_README="$(cat \
 <<'EOF'
-"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still
-wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
+"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you 
+still wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
 You may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it
-See https://github.com/microsoft/vscode-dev-containers/issues/674#issuecomment-783474956
+See here for infomation on adding it to your image or dotfiles: https://aka.ms/codespaces/omb-remove
 EOF
 )"
 OMB_STUB="$(cat \
 <<'EOF'
 #!/usr/bin/env bash
-cd "$(dirname $0)"
 if [ -t 1 ]; then
-    cat README.md
+    cat $HOME/.oh-my-bash/README.md
 fi
 EOF
 )"

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -47,7 +47,7 @@ elif [ "${USERNAME}" = "none" ]; then
 fi
 
 # Load markers to see which steps have already run
-MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-script-run"
+MARKER_FILE="/usr/local/etc/vscode-dev-containers/common"
 if [ -f "${MARKER_FILE}" ]; then
     echo "Marker file found:"
     cat "${MARKER_FILE}"

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -143,15 +143,21 @@ else
     USER_RC_PATH="/home/${USERNAME}"
 fi
 
-# bashrc/zshrc snippet
-RC_SNIPPET="$(cat << EOF
-export USER=\$(whoami)
+# .bashrc/.zshrc snippet
+RC_SNIPPET="$(cat << 'EOF'
 
-export PATH=\$PATH:\$HOME/.local/bin
+if [ -z "${USER}"]; then export USER=$(whoami); fi
+if [[ "${PATH}" != *"$HOME/.local/bin"* ]]; then export PATH="${PATH}:$HOME/.local/bin"; fi
 
-if type code-insiders > /dev/null 2>&1 && ! type code > /dev/null 2>&1; then 
-    alias code=code-insiders
+# Display optional first run image specific notice if configured and terminal is interactive
+if [ -t 1 ] && [ -f "/usr/local/etc/vscode-dev-containers/first-run-notice.txt" ] && [ ! -f "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed" ]; then
+    cat /usr/local/etc/vscode-dev-containers/first-run-notice.txt
+    mkdir -p $HOME/.config/vscode-dev-containers
+    # Mark first run notice as displayed after 10s to avoid problems with fast terminal refreshes hiding it
+    (sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") & >/dev/null 2>&1
+    disown %+
 fi
+
 EOF
 )"
 
@@ -176,9 +182,11 @@ fi
 EOF
 chmod +x /usr/local/bin/code
 
-# Codespaces themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
+# Codespaces bash and OMZ themes - partly inspired by https://github.com/ohmyzsh/ohmyzsh/blob/master/themes/robbyrussell.zsh-theme
 CODESPACES_BASH="$(cat \
 <<'EOF'
+
+# Codespaces bash prompt theme
 __bash_prompt() {
     local userpart='`export XIT=$? \
         && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
@@ -197,6 +205,7 @@ __bash_prompt() {
     unset -f __bash_prompt
 }
 __bash_prompt
+
 EOF
 )"
 CODESPACES_ZSH="$(cat \
@@ -223,18 +232,17 @@ EOF
 # Add notice that Oh My Bash! has been removed from images and how to provide information on how to install manually
 OMB_README="$(cat \
 <<'EOF'
-"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you still
-wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
+"Oh My Bash!" has been removed from this image in favor of a simple shell prompt. If you 
+still wish to use it, remove "~/.oh-my-bash" and install it from: https://github.com/ohmybash/oh-my-bash
 You may also want to consider "Bash-it" as an alternative: https://github.com/bash-it/bash-it
-See https://github.com/microsoft/vscode-dev-containers/issues/674#issuecomment-783474956
+See here for infomation on adding it to your image or dotfiles: https://aka.ms/codespaces/omb-remove
 EOF
 )"
 OMB_STUB="$(cat \
 <<'EOF'
 #!/usr/bin/env bash
-cd "$(dirname $0)"
 if [ -t 1 ]; then
-    cat README.md
+    cat $HOME/.oh-my-bash/README.md
 fi
 EOF
 )"


### PR DESCRIPTION
This PR:

1. Moves the first run text code into `common-debian.sh` so it can be used in any image or Codepsaces by injecting a text file at `/usr/local/etc/vscode-dev-containers/first-run-notice.txt`
2. Marks the first notice as shown asynchronusly after 10s to avoid the issue where VS Code refreshes the terminal after extension installs. 
3. Fixes #775 while I was in there

I also bumped the breakfix version on the images so they go with the next release.