### PR TITLE
Bugfix: Restore Terragrunt in Azure Terraform definition

### DIFF
--- a/containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh
@@ -7,10 +7,11 @@
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/terraform.md
 # Maintainer: The VS Code and Codespaces Teams
 #
-# Syntax: ./terraform-debian.sh [terraform version] [tflint version]
+# Syntax: ./terraform-debian.sh [terraform version] [tflint version] [terragrunt version]
 
 TERRAFORM_VERSION=${1:-"latest"}
 TFLINT_VERSION=${2:-"latest"}
+TERRAGRUNT_VERSION=${3:-"latest"}
 
 set -e
 
@@ -28,6 +29,11 @@ if [ "${TFLINT_VERSION}" = "latest" ] || [ "${TFLINT_VERSION}" = "lts" ] || [ "$
     TFLINT_VERSION=$(echo ${LATEST_RELEASE} | grep -oE 'tag_name":\s*"v[^"]+' | sed -n '/tag_name":\s*"v/s///p')
 fi
 
+if [ "${TERRAGRUNT_VERSION}" = "latest" ] || [ "${TERRAGRUNT_VERSION}" = "lts" ] || [ "${TERRAGRUNT_VERSION}" = "current" ]; then
+    LATEST_RELEASE=$(curl -sSL -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/gruntwork-io/terragrunt/releases?per_page=1&page=1")
+    TERRAGRUNT_VERSION=$(echo ${LATEST_RELEASE} | grep -oE 'tag_name":\s*"v[^"]+' | sed -n '/tag_name":\s*"v/s///p')
+fi
+
 # Install curl, unzip if missing
 if ! dpkg -s curl ca-certificates unzip > /dev/null 2>&1; then
     export DEBIAN_FRONTEND=noninteractive
@@ -37,7 +43,7 @@ if ! dpkg -s curl ca-certificates unzip > /dev/null 2>&1; then
     apt-get -y install --no-install-recommends curl ca-certificates unzip
 fi
 
-# Install Terraform, tflint
+# Install Terraform, tflint, Terragrunt
 echo "Downloading terraform..."
 mkdir -p /tmp/tf-downloads
 curl -sSL -o /tmp/tf-downloads/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
@@ -49,6 +55,13 @@ if [ "${TFLINT_VERSION}" != "none" ]; then
     curl -sSL -o /tmp/tf-downloads/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip
     unzip /tmp/tf-downloads/tflint.zip
     mv -f tflint /usr/local/bin/
+fi
+
+if [ "${TERRAGRUNT_VERSION}" != "none" ]; then
+    echo "Downloading Terragrunt..."
+    curl -sSL -o /tmp/tf-downloads/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64
+    chmod a+x /tmp/tf-downloads/terragrunt
+    mv -f /tmp/tf-downloads/terragrunt /usr/local/bin/
 fi
 
 rm -rf /tmp/tf-downloads

--- a/script-library/terraform-debian.sh
+++ b/script-library/terraform-debian.sh
@@ -7,10 +7,11 @@
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/terraform.md
 # Maintainer: The VS Code and Codespaces Teams
 #
-# Syntax: ./terraform-debian.sh [terraform version] [tflint version]
+# Syntax: ./terraform-debian.sh [terraform version] [tflint version] [terragrunt version]
 
 TERRAFORM_VERSION=${1:-"latest"}
 TFLINT_VERSION=${2:-"latest"}
+TERRAGRUNT_VERSION=${3:-"latest"}
 
 set -e
 
@@ -28,6 +29,11 @@ if [ "${TFLINT_VERSION}" = "latest" ] || [ "${TFLINT_VERSION}" = "lts" ] || [ "$
     TFLINT_VERSION=$(echo ${LATEST_RELEASE} | grep -oE 'tag_name":\s*"v[^"]+' | sed -n '/tag_name":\s*"v/s///p')
 fi
 
+if [ "${TERRAGRUNT_VERSION}" = "latest" ] || [ "${TERRAGRUNT_VERSION}" = "lts" ] || [ "${TERRAGRUNT_VERSION}" = "current" ]; then
+    LATEST_RELEASE=$(curl -sSL -H "Accept: application/vnd.github.v3+json" "https://api.github.com/repos/gruntwork-io/terragrunt/releases?per_page=1&page=1")
+    TERRAGRUNT_VERSION=$(echo ${LATEST_RELEASE} | grep -oE 'tag_name":\s*"v[^"]+' | sed -n '/tag_name":\s*"v/s///p')
+fi
+
 # Install curl, unzip if missing
 if ! dpkg -s curl ca-certificates unzip > /dev/null 2>&1; then
     export DEBIAN_FRONTEND=noninteractive
@@ -37,7 +43,7 @@ if ! dpkg -s curl ca-certificates unzip > /dev/null 2>&1; then
     apt-get -y install --no-install-recommends curl ca-certificates unzip
 fi
 
-# Install Terraform, tflint
+# Install Terraform, tflint, Terragrunt
 echo "Downloading terraform..."
 mkdir -p /tmp/tf-downloads
 curl -sSL -o /tmp/tf-downloads/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
@@ -49,6 +55,13 @@ if [ "${TFLINT_VERSION}" != "none" ]; then
     curl -sSL -o /tmp/tf-downloads/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip
     unzip /tmp/tf-downloads/tflint.zip
     mv -f tflint /usr/local/bin/
+fi
+
+if [ "${TERRAGRUNT_VERSION}" != "none" ]; then
+    echo "Downloading Terragrunt..."
+    curl -sSL -o /tmp/tf-downloads/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64
+    chmod a+x /tmp/tf-downloads/terragrunt
+    mv -f /tmp/tf-downloads/terragrunt /usr/local/bin/
 fi
 
 rm -rf /tmp/tf-downloads


### PR DESCRIPTION
Context: a month ago I created a pull request that added **Terragrunt support to the Azure Terraform definition**: https://github.com/microsoft/vscode-dev-containers/pull/737

I've just realized I made a **mistake**. My bad I've updated the code in `containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh` **but not in** `script-library/terraform-debian.sh`. 

Recent automated updates to the script library **overwrote my changes**: https://github.com/microsoft/vscode-dev-containers/commits/master/containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh

Currently Azure Terraform definition is **inconsistent**: `devcontainer.json` and `Dockerfile` mention Terragrunt, but it's not supported by `terraform-debian.sh`.

This pull request fixes the problem by adding Terragrunt installation steps **to both** `containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh` and `script-library/terraform-debian.sh`.

I apologize for the inconvenience!