### PR TITLE
Update welcome text for codespaces-linux

### DIFF
--- a/containers/codespaces-linux/.devcontainer/base.Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/base.Dockerfile
@@ -27,7 +27,7 @@ ENV SHELL=/bin/bash \
 ENV PATH="${ORIGINAL_PATH}:${NVM_DIR}/current/bin:${NPM_GLOBAL}/bin:${DOTNET_ROOT}:${DOTNET_ROOT}/tools:${SDKMAN_DIR}/bin:${SDKMAN_DIR}/candidates/gradle/current/bin:${SDKMAN_DIR}/java/current/bin:/opt/maven/lts:${CARGO_HOME}/bin:${GOROOT}/bin:${GOPATH}/bin:${PIPX_BIN_DIR}:/opt/conda/condabin:${ORYX_PATHS}"
 
 # Install needed utilities and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY library-scripts/* setup-user.sh /tmp/scripts/
+COPY library-scripts/* setup-user.sh first-run-notice.txt /tmp/scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Restore man command
     && yes | unminimize 2>&1 \ 
@@ -53,7 +53,10 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Build latest git from source
     && bash /tmp/scripts/git-from-src-debian.sh "latest" \
     # Clean up
-    && apt-get autoremove -y && apt-get clean -y
+    && apt-get autoremove -y && apt-get clean -y \
+    # Move first run notice to right spot
+    && mkdir -p /usr/local/etc/vscode-dev-containers/ \
+    && mv -f /tmp/scripts/first-run-notice.txt /usr/local/etc/vscode-dev-containers/
 
 # Install Python, PHP, Ruby utilities
 RUN bash /tmp/scripts/python-debian.sh "none" "/opt/python/latest" "${PIPX_HOME}" "${USERNAME}" "true" \

--- a/containers/codespaces-linux/.devcontainer/first-run-notice.txt
+++ b/containers/codespaces-linux/.devcontainer/first-run-notice.txt
@@ -1,0 +1,9 @@
+👋 Welcome to Codespaces! You are on our default image. This includes the latest versions of: 
+   - Python 
+   - Node.js
+   - Docker
+   - And more! To see the full list, go here: https://aka.ms/ghcs-default-image
+
+🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1)
+
+📝 Edit away, run your app as usual, and we'll automatically make it available for to you to access.

--- a/containers/codespaces-linux/.devcontainer/first-run-notice.txt
+++ b/containers/codespaces-linux/.devcontainer/first-run-notice.txt
@@ -1,4 +1,4 @@
-👋 Welcome to Codespaces! You are on our default image. This includes the latest versions of: 
+👋 Welcome to Codespaces! You are on our default image. This includes runtimes and tools for: 
    - Python 
    - Node.js
    - Docker

--- a/containers/codespaces-linux/.devcontainer/first-run-notice.txt
+++ b/containers/codespaces-linux/.devcontainer/first-run-notice.txt
@@ -7,3 +7,4 @@
 🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1)
 
 📝 Edit away, run your app as usual, and we'll automatically make it available for to you to access.
+

--- a/containers/codespaces-linux/.devcontainer/setup-user.sh
+++ b/containers/codespaces-linux/.devcontainer/setup-user.sh
@@ -33,9 +33,3 @@ sudo -u ${USERNAME} mkdir -p /home/${USERNAME}/.local/bin
 install -o ${USERNAME} -g ${USERNAME} -m 755 /tmp/scripts/git-ed.sh /home/${USERNAME}/.local/bin/git-ed.sh
 sudo -u ${USERNAME} git config --global core.editor "/home/${USERNAME}/.local/bin/git-ed.sh"
 rm -f /tmp/scripts/git-ed.sh
-
-# Add one time notice
-cat << 'EOF' > "/usr/local/etc/vscode-dev-containers/first-run-notice.txt"
-Welcome to Codespaces! Note that the default Codespaces image is now Ubuntu 20.04-based!
-If you need to use the old image (or a custom one) see https://aka.ms/ghcs-default-focal.
-EOF

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "1.2.2",
+	"definitionVersion": "1.2.3",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Re: https://github.com/github/codespaces/issues/2511

![image](https://user-images.githubusercontent.com/312252/111820655-fd406c00-889e-11eb-87ba-f70386674fb3.png)

The text is now externalized in a file, so anyone can tweak or make suggestions in the PR.  Right now the aka.ms link points to the codepsaces-linux definition since I don't think there's anywhere else. We can update the link if we get something into docs.

/cc: @2percentsilk @bailey @matthewisabel @jkeech