### PR TITLE
Update go version in the terraform azure provider

### DIFF
--- a/repository-containers/github.com/terraform-providers/terraform-provider-azurerm/.devcontainer/Dockerfile
+++ b/repository-containers/github.com/terraform-providers/terraform-provider-azurerm/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-buster
+FROM golang:1.16-buster
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Update to go version 1.16, fixes https://github.com/terraform-providers/terraform-provider-azurerm/issues/11048