### PR TITLE
Use Pylance as default language server (#723)

### DIFF
--- a/containers/python-3-anaconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-anaconda/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/opt/conda/bin/python",
+		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.formatting.autopep8Path": "/opt/conda/bin/autopep8",
@@ -25,7 +26,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-python.python"
+		"ms-python.python",
+		"ms-python.vscode-pylance"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
+++ b/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/opt/vscode/extensions/ms-python.devicesimulatorexpress/venv/bin/python",
+		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
@@ -28,7 +29,8 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python",
-		"ms-python.devicesimulatorexpress"
+		"ms-python.devicesimulatorexpress",
+		"ms-python.vscode-pylance"
 	],
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/containers/python-3-miniconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-miniconda/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/opt/conda/bin/python",
+		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
@@ -28,7 +29,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-python.python"
+		"ms-python.python",
+		"ms-python.vscode-pylance"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/containers/python-3-postgres/.devcontainer/devcontainer.json
+++ b/containers/python-3-postgres/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
 			"password": "postgres"
 		}],
 		"python.pythonPath": "/usr/local/bin/python",
+		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
@@ -36,6 +37,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-python.python",
+		"ms-python.vscode-pylance",
 		"mtxr.sqltools",
 		"mtxr.sqltools-driver-pg"
 	],

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -16,6 +16,7 @@
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",
 		"python.pythonPath": "/usr/local/bin/python",
+		"python.languageServer": "Pylance",
 		"python.linting.enabled": true,
 		"python.linting.pylintEnabled": true,
 		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
@@ -31,7 +32,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-python.python"
+		"ms-python.python",
+		"ms-python.vscode-pylance"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
This fixes #723 
- Add `"ms-python.vscode-pylance"` (which in-turn will download the language server)
- Set workspace settings to use the extension's language server `"python.languageServer": "Pylance"`
