### PR TITLE
codespaces - utilize PROMPT_DIRTRIM to clean up PROMPT

### DIFF
--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -321,8 +321,10 @@ EOF
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
     echo "${RC_SNIPPET}" >> /etc/bash.bashrc
     echo "${CODESPACES_BASH}" >> "${USER_RC_PATH}/.bashrc"
+    echo 'export PROMPT_DIRTRIM=2' >> "${USER_RC_PATH}/.bashrc"
     if [ "${USERNAME}" != "root" ]; then
         echo "${CODESPACES_BASH}" >> "/root/.bashrc"
+        echo 'export PROMPT_DIRTRIM=2' >> "/root/.bashrc"
     fi
     chown ${USERNAME}:${USERNAME} "${USER_RC_PATH}/.bashrc"
     RC_SNIPPET_ALREADY_ADDED="true"
@@ -370,6 +372,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
             "https://github.com/ohmyzsh/ohmyzsh" "${OH_MY_INSTALL_DIR}" 2>&1
         echo -e "$(cat "${TEMPLATE_PATH}")\nDISABLE_AUTO_UPDATE=true\nDISABLE_UPDATE_PROMPT=true" > ${USER_RC_FILE}
         sed -i -e 's/ZSH_THEME=.*/ZSH_THEME="codespaces"/g' ${USER_RC_FILE}
+
         mkdir -p ${OH_MY_INSTALL_DIR}/custom/themes
         echo "${CODESPACES_ZSH}" > "${OH_MY_INSTALL_DIR}/custom/themes/codespaces.zsh-theme"
         # Shrink git while still enabling updates

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -322,10 +322,10 @@ EOF
 if [ "${RC_SNIPPET_ALREADY_ADDED}" != "true" ]; then
     echo "${RC_SNIPPET}" >> /etc/bash.bashrc
     echo "${CODESPACES_BASH}" >> "${USER_RC_PATH}/.bashrc"
-    echo 'export PROMPT_DIRTRIM=2' >> "${USER_RC_PATH}/.bashrc"
+    echo 'export PROMPT_DIRTRIM=4' >> "${USER_RC_PATH}/.bashrc"
     if [ "${USERNAME}" != "root" ]; then
         echo "${CODESPACES_BASH}" >> "/root/.bashrc"
-        echo 'export PROMPT_DIRTRIM=2' >> "/root/.bashrc"
+        echo 'export PROMPT_DIRTRIM=4' >> "/root/.bashrc"
     fi
     chown ${USERNAME}:${USERNAME} "${USER_RC_PATH}/.bashrc"
     RC_SNIPPET_ALREADY_ADDED="true"

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -287,8 +287,9 @@ __zsh_prompt() {
     else
         prompt_username="%n"
     fi
-    PROMPT="%{$fg[green]%}${prompt_username} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )"
-    PROMPT+='%{$fg_bold[blue]%}%~%{$reset_color%} $(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}'
+    PROMPT="%{$fg[green]%}${prompt_username} %(?:%{$reset_color%}➜ :%{$fg_bold[red]%}➜ )" # User/exit code arrow
+    PROMPT+='%{$fg_bold[blue]%}%(5~|%-1~/…/%3~|%4~)%{$reset_color%} ' # cwd
+    PROMPT+='$(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}' # Git status
     unset -f __zsh_prompt
 }
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"


### PR DESCRIPTION
Set `PROMPT_DIRTRIM` for the default codespaces prompt for a more tidy look.

See the `...` below.

![image](https://user-images.githubusercontent.com/23246594/113741572-c86e4a80-96cf-11eb-8d84-6b2b067ab825.png)


closes #808