### PR TITLE
php-mariadb: install pdo_mysql driver

### DIFF
--- a/containers/php-mariadb/.devcontainer/Dockerfile
+++ b/containers/php-mariadb/.devcontainer/Dockerfile
@@ -24,3 +24,5 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
 
+# Install php-mysql driver
+RUN docker-php-ext-install mysqli pdo pdo_mysql

--- a/containers/php-mariadb/.devcontainer/Dockerfile
+++ b/containers/php-mariadb/.devcontainer/Dockerfile
@@ -12,6 +12,9 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
 
+# Install php-mysql driver
+RUN docker-php-ext-install mysqli pdo pdo_mysql
+
 # [Optional] Install a version of Node.js using nvm for front end dev
 ARG INSTALL_NODE="true"
 ARG NODE_VERSION="lts/*"
@@ -24,5 +27,3 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
 
-# Install php-mysql driver
-RUN docker-php-ext-install mysqli pdo pdo_mysql


### PR DESCRIPTION
The PHP+MariaDB image does not install any PHP extension.

This PR adds the pdo_mysql extension since the user will likely want to connect to the database in the app.