### PR TITLE
Ensure getting started info factors in codespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,39 +8,25 @@
 </td>
 </tr></table>
 
-A **development container** is a running [Docker](https://www.docker.com) container with a well-defined tool/runtime stack and its prerequisites. The [VS Code Remote - Containers](https://aka.ms/vscode-remote/download/containers) extension allows you to clone a repository or open any folder mounted into (or already inside) a dev container and take advantage of VS Code's full development feature set. [GitHub Codespaces](https://github.com/features/codespaces) both use this same concept to quickly create customized, cloud-based development environments accessible [from VS Code](https://aka.ms/vso-dl) or the web.
+A **development container** is a running [Docker](https://www.docker.com) container with a well-defined tool/runtime stack and its prerequisites. The [VS Code Remote - Containers](https://aka.ms/vscode-remote/download/containers) extension and [GitHub Codespaces](https://github.com/features/codespaces) allow you to open or clone code in a local or cloud-hosted dev container and take advantage of VS Code's full development feature set.
 
-This repository contains a set of **dev container definitions** to help get you up and running with a containerized environment. The definitions describe the appropriate container image, runtime arguments for starting the container, and VS Code extensions that should be installed. Each provides a container configuration file (`devcontainer.json`) and other needed files that you can drop into any existing folder as a starting point for containerizing your project.
+This repository contains a set of **dev container definitions** to help get you up and running with a containerized environment. The definitions describe the appropriate container image, runtime arguments for starting the container, and VS Code extensions that should be installed. Each provides a container configuration file (`devcontainer.json`) and other needed files that you can drop into any existing folder as a starting point for containerizing your project. You can use the the **Add Development Container Configuration Files...** command to add one to your project or codespace.
 
 The [vscode-remote-try-*](https://github.com/search?q=org%3Amicrosoft+vscode-remote-try-&type=Repositories) repositories may also be of interest if you are looking for complete sample projects.
 
-## Adding a definition to a local project
-
-To add a dev container definition in your project, you can either:
-
-Manually add it to your project folder:
-
-1. Clone this repository.
-2. Copy the contents of the `.devcontainer` folder from of one of the definitions in the [`containers` folder](containers) to your project folder. 
-3. See the definition's `README` for configuration details and options.
-4. Open the folder [locally with the Remote - Containers extension](vscode-remote/containers/getting-started/open) or commit the file to source control to [use it with Codespaces](https://docs.github.com/en/github/developing-online-with-codespaces/configuring-codespaces-for-your-project#using-a-pre-built-container-configuration).
-
-... or ...
-
-Add it using VS Code Remote - Containers:
+## Adding a definition to a project or codespace
   
-  1. [Set up your machine](https://aka.ms/vscode-remote/containers/getting-started) and then start VS Code and open your project folder.
-  2. Press <kbd>F1</kbd>, select the **Remote-Containers: Add Development Container Configuration Files...** command, and pick one of definitions from the list. (You may need to choose the **From a predefined container configuration definition...** option if your project has an existing Dockerfile or Docker Compose file.)
-  3. See the definition's `README` for configuration options. A link is available in the `.devcontainer/devcontainer.json` file added to your folder.
-  4. Run **Remote-Containers: Reopen in Container** to use it locally, or commit the file to source control to [use it with Codespaces](https://docs.github.com/en/github/developing-online-with-codespaces/configuring-codespaces-for-your-project#using-a-pre-built-container-configuration).
+  1. Either [create a codespace for your repository](https://aka.ms/ghcs-open-codespace) or [set up your local machine](https://aka.ms/vscode-remote/containers/getting-started) for use with the Remote - Containers extension, start VS Code, and open your project folder.
+  2. Press <kbd>F1</kbd>, select the **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+  3. Pick one of definitions from the list. (You may need to choose the **From a predefined container configuration definition...** option if your project has an existing Dockerfile or Docker Compose file.) Answer any questions that appear.
+  4. See the definition's `README` for configuration options. A link is available in the `.devcontainer/devcontainer.json` file added to your folder.
+  5. Run **Remote-Containers: Reopen in Container** to use it locally, or **Codespaces: Rebuild Container** from within a codespace.
 
 ### Adding a definition to a repository
 
 You can share a customized dev container definition for your project by adding the files under `.devcontainer` to source control.
 
-Anyone who then opens a local copy of your repo in VS Code will be prompted to reopen the folder in a container, provided they have the [Remote - Containers](https://aka.ms/vscode-remote/download/containers) extension installed.
-
-Additionally, if you reference your Git repository when creating a codespace [GitHub Codespaces](https://github.com/features/codespaces), the container definition will be used.
+Anyone who then opens a local copy of your repo in VS Code will be prompted to reopen the folder in a container, provided they have the [Remote - Containers](https://aka.ms/vscode-remote/download/containers) extension installed. Additionally, this will be used whenever someone creates a codespace in [GitHub Codespaces](https://github.com/features/codespaces) for the repository.
 
 Your team now has a consistent environment and tool-chain and new contributors or team members can be productive quickly. First-time contributors will require less guidance and there will be fewer issues related to environment setup.
 
@@ -68,7 +54,7 @@ If you want to try a sample project which already has a dev container, check out
 
 ### Can I just reuse an existing container image or Docker / Docker Compose configuration?
 
-Yes, if you want to use an existing Dockerfile as a starting point, use the [Remote - Containers extension](https://aka.ms/vscode-remote/download/containers), open a folder, and then run **Remote-Containers: Add Development Container Configuration Files...** from the Command Palette (<kbd>F1</kbd>). You'll be prompted to select a Dockerfile or Docker Compose file and customize from there. If you then commit these files to a Git repository, you can use it with [GitHub Codespaces](https://github.com/features/codespaces) as well. If you prefer, you can also start up the container manually and [attach to it](https://aka.ms/vscode-remote/containers/attach).
+Yes! If you have a Dockerfile or Docker Compose file in your project/repository, follow the [same steps to add a definition](#adding) and you'll be prompted to select a Dockerfile or Docker Compose file and customize from there. If you then commit these files to a Git repository, you can use it with [GitHub Codespaces](https://github.com/features/codespaces) as well. If you prefer, you can also start up the container manually and [attach to it](https://aka.ms/vscode-remote/containers/attach). However, note that many images will be missing things like `git` that you will want to use. There are scripts in the [script-library](script-library) like the [common script](script-library/docs/common.md) that can help adding these to your existing Dockerfile or image.
 
 ### What is the goal of `devcontainer.json`?
 

--- a/container-templates/docker-compose/README.md
+++ b/container-templates/docker-compose/README.md
@@ -18,7 +18,7 @@
 
 **[Give a more detailed description of the container if the summary does not provide enough info.]**
 
-## Using this definition with an existing folder
+## Using this definition
 
 **[Optional] Include any special setup requirements here. For example:**
 
@@ -38,25 +38,19 @@ You can add other services to your `docker-compose.yml` file [as described in Do
 network_mode: service:app
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
+2. Start VS Code and open your project folder or connect to a codespace.
 
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the **YOUR NAME HERE** definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
-
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## [Optional] Testing the definition
 

--- a/container-templates/dockerfile/README.md
+++ b/container-templates/dockerfile/README.md
@@ -18,7 +18,7 @@
 
 **[Give a more detailed description of the container if the summary does not provide enough info.]**
 
-## Using this definition with an existing folder
+## Using this definition
 
 **[Optional] Include any special setup requirements here. For example:**
 
@@ -28,23 +28,19 @@ While the definition itself works unmodified, you can select the version of **YO
 "args": { "VARIANT": "buster" }
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the **YOUR NAME HERE** definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## [Optional] Testing the definition
 

--- a/container-templates/image/README.md
+++ b/container-templates/image/README.md
@@ -18,27 +18,21 @@
 
 **[Give a more detailed description of the container if the summary does not provide enough info.]**
 
-## Using this definition with an existing folder
+## Using this definition
 
 **[Optional] Include any special setup requirements here.**
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Dart definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## [Optional] Testing the definition
 

--- a/containers/alpine/README.md
+++ b/containers/alpine/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Alpine Linux |
 | *Languages, platforms* | Any |
 
-## Using this definition with an existing folder
+## Using this definition
 
  While the definition itself works unmodified, you can select the version of Alpine the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -50,36 +50,24 @@ However, note that some extensions may not work in Alpine Linux due to `glibc` d
 
 See [Remote Development and Linux](https://aka.ms/vscode-remote/linux) for details.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
-
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
 2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Alpine definition.
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   3. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the contents of `containers/alpine/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
-
-## Testing the definition
-
-This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
-
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
-2. Clone this repository.
-3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
-4. Select the `containers/alpine` folder.
-5. Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> and type the following command to verify installation: `git --version`
-6. You should see the Git version and details about the version of Linux in the container.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/azure-ansible/README.md
+++ b/containers/azure-ansible/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure, Ansible |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While technically optional, this definition includes the Ansible extension. You may need an Azure account for your operations. You can create a [free trial account here](https://azure.microsoft.com/en-us/free/) and find out more about using [Ansible with Azure here](https://docs.microsoft.com/en-us/azure/ansible/ansible-overview).
 
@@ -32,23 +32,19 @@ If you plan to use the Azure Cloud Shell for all of your Ansible operations, you
 
 Beyond `git`, this `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Ansible definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-ansible/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/azure-bicep/README.md
+++ b/containers/azure-bicep/README.md
@@ -13,25 +13,21 @@
 | *Container host OS support* | Linux, macOS, Windows |
 | *Languages, platforms* | Azure |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/). Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure CLI definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-bicep/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-blockchain/README.md
+++ b/containers/azure-blockchain/README.md
@@ -14,25 +14,21 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Blockchain |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/). Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Blockchain definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-blockchain/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-cli/README.md
+++ b/containers/azure-cli/README.md
@@ -14,25 +14,21 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/). Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure CLI definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-cli/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-functions-dotnetcore-2.1/README.md
+++ b/containers/azure-functions-dotnetcore-2.1/README.md
@@ -14,25 +14,21 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Functions, .NET Core, C# |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/) and learn more about using [Azure Functions with VS Code here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code). Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Functions & C# (.NET Core 2.1) definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-functions-dotnetcore-2.1/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-functions-dotnetcore-3.1/README.md
+++ b/containers/azure-functions-dotnetcore-3.1/README.md
@@ -14,25 +14,21 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Functions, .NET Core, C# |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/) and learn more about using [Azure Functions with VS Code here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code). Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Functions & C# (.NET Core 3.1) definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-functions-dotnetcore-3.1/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-functions-java-11/README.md
+++ b/containers/azure-functions-java-11/README.md
@@ -14,25 +14,21 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Functions, Java |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/), learn more about using [Azure Functions with VS Code](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code) and [Java Azure Functions with VS Code](https://code.visualstudio.com/docs/java/java-azurefunctions) here. Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Functions & Java 11 definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-functions-java-11/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-functions-java-8/README.md
+++ b/containers/azure-functions-java-8/README.md
@@ -14,23 +14,21 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Functions, Java |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/), learn more about using [Azure Functions with VS Code](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code) and [Java Azure Functions with VS Code](https://code.visualstudio.com/docs/java/java-azurefunctions) here. Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Functions & Java 8 definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-functions-java-8/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
+
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
 

--- a/containers/azure-functions-node/README.md
+++ b/containers/azure-functions-node/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Functions, Node.js, JavaScript |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/) and learn more about using [Azure Functions with VS Code here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code).
 
@@ -31,21 +31,17 @@ While this definition should work unmodified, you can select the version of Node
 
 Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Functions & Node.js 12 definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-functions-node/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-functions-pwsh/README.md
+++ b/containers/azure-functions-pwsh/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Functions, .NET Core, PowerShell |
 
-## Using this definition with an existing folder
+## Using this definition
 
 ### Configuration
 
@@ -29,25 +29,21 @@ While the definition itself works unmodified, you can select the version of Powe
 
 Beyond PowerShell and `git`, this image / `Dockerfile` includes the Az PowerShell module and all required Az modules, Azure CLI, a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/) and learn more about using [Azure Functions with VS Code here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code). Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Functions & PowerShell definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-functions-pwsh/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-functions-python-3/README.md
+++ b/containers/azure-functions-python-3/README.md
@@ -14,25 +14,21 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Functions, Python |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/) and learn more about using [Azure Functions with VS Code here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code). Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Functions & Python 3 definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-functions-python-3/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/azure-machine-learning-python-3/README.md
+++ b/containers/azure-machine-learning-python-3/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Machine Learning, Python, Anaconda |
 
-## Using this definition with an existing folder
+## Using this definition
 
 There are a few notes for using this definition:
 
@@ -26,21 +26,17 @@ There are a few notes for using this definition:
 
 Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Machine Learning definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-machine-learning-python-3/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/azure-static-web-apps/README.md
+++ b/containers/azure-static-web-apps/README.md
@@ -15,7 +15,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure Functions, Python, C#, Node.js, JavaScript |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an Azure subscription to use. You can create a [free account here](https://azure.microsoft.com/en-us/free/serverless/) and learn more about using [Azure Functions with VS Code here](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-function-vs-code).
 
@@ -25,21 +25,17 @@ This definition includes Python, .NET Core, and Node.js. Node.js is installed us
 
 Once you have an Azure account, follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Azure Static Web Apps definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-static-web-apps/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 Take a look at the files inside `./test-project/.vscode.sample` to see if you need to adapt the settings for Live Server, or the Azure Functions Core Tools, specifically `settings.json` or `tasks.json`.
 

--- a/containers/azure-terraform/README.md
+++ b/containers/azure-terraform/README.md
@@ -16,7 +16,7 @@ This recipe allows you to get going quickly with Terraform in Azure. Includes Te
 | *Container OS* | Debian |
 | *Languages, platforms* | Azure, Terraform |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While technically optional, this definition includes the Azure Terraform extension which requires a few pre-requisites:
 
@@ -39,23 +39,19 @@ If you plan to use the Azure Cloud Shell for all of your Terraform operations, y
 
 Beyond `git`, this `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Open the Command Palette with `Ctrl/CMD+Shift+P` or press <kbd>F1</kbd> and select **Remote-Containers: Add Development Container Configuration Files**.
-   3. Select the **Azure Terraform** definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/azure-terraform/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Open the Command Palette with `Ctrl/CMD+Shift+P` or press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the Definition
 

--- a/containers/bash/README.md
+++ b/containers/bash/README.md
@@ -14,25 +14,21 @@
 | *Container OS*              | Debian                                       |
 | *Languages, platforms*      | Bash                                         |
 
-## Using this definition with an existing folder
+## Using this definition
 
 Just follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Bash definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/bazel/README.md
+++ b/containers/bazel/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Any |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While this definition works unmodified, you can set the Bazel version by updating the `BAZEL_VERSION` argument in `devcontainer.json`.
 
@@ -35,21 +35,17 @@ Optionally, you can validate the SHA256 checksum for `bazel-installer.sh` by add
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Dart definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/codespaces-linux-stretch/README.md
+++ b/containers/codespaces-linux-stretch/README.md
@@ -62,7 +62,7 @@ This container also includes a running SSH server that you can use to access the
 
 That's it! Use similar arguments to those in step 5 when executing `scp` or configuring SSHFS.
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can also directly reference pre-built versions of `.devcontainer/Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to:
 
@@ -70,25 +70,26 @@ While the definition itself works unmodified, you can also directly reference pr
 
 Alternatively, you can use the contents of the `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
+Given its size, we do not recommend extending this image. However, you can add it to a project or codespace as follows:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
 2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the **GitHub Codespaces (Default)** definition.
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   3. Select this definition.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the `.devcontainer` folder from the `containers/codespaces-linux` folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead (which can take upwards of 30 mins):
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/codespaces-linux/README.md
+++ b/containers/codespaces-linux/README.md
@@ -62,7 +62,7 @@ This container also includes a running SSH server that you can use to access the
 
 That's it! Use similar arguments to those in step 5 when executing `scp` or configuring SSHFS.
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can also directly reference pre-built versions of `.devcontainer/Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to:
 
@@ -70,25 +70,26 @@ While the definition itself works unmodified, you can also directly reference pr
 
 Alternatively, you can use the contents of the `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
+Given its size, we do not recommend extending this image. However, you can add it to a project or codespace as follows:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
 2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the **GitHub Codespaces (Default)** definition.
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   3. Select this definition.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the `.devcontainer` folder from the `containers/codespaces-linux` folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead (which can take upwards of 30 mins):
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.n.
 
 ## License
 

--- a/containers/cpp/README.md
+++ b/containers/cpp/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian, Ubuntu |
 | *Languages, platforms* | C++ |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Debian or Ubuntu the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -46,23 +46,24 @@ Alternatively, you can use the contents of `base.Dockerfile` to fully customize 
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the C++ definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   3. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/cpp/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/dapr-dotnet/README.md
+++ b/containers/dapr-dotnet/README.md
@@ -18,7 +18,7 @@
 
 When the dev container is created, the definition automatically initializes Dapr on a separate Docker network (to isolate it from Dapr instances running locally or in another Dapr dev container). This is done via the `postCreateCommand` in the `.devcontainer/devcontainer.json` and the `DAPR_NETWORK` environment variable in the `.devcontainer/docker-compose.yml`.
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, there are some tips that can help you deal with some of the defaults .NET Core uses.
 
@@ -70,21 +70,17 @@ If you've already opened your folder in a container, rebuild the container using
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Dapr with C# (.NET Core 3.1) definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/dapr-dotnetcore-3.1/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/dapr-javascript-node/README.md
+++ b/containers/dapr-javascript-node/README.md
@@ -18,29 +18,25 @@
 
 When the dev container is created, the definition automatically initializes Dapr on a separate Docker network (to isolate it from Dapr instances running locally or in another Dapr dev container). This is done via the `postCreateCommand` in the `.devcontainer/devcontainer.json` and the `DAPR_NETWORK` environment variable in the `.devcontainer/docker-compose.yml`.
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition installs `tslint` globally and includes the VS Code TSLint extension for backwards compatibility, but [TSLint has been deprecated](https://github.com/palantir/tslint/issues/4534) in favor of ESLint, so `eslint` and its corresponding extension has been included as well.
 
 Both `eslint`and `typescript` are installed globally for convenance, but [as of ESLint 6](https://eslint.org/docs/user-guide/migrating-to-6.0.0#-plugins-and-shareable-configs-are-no-longer-affected-by-eslints-location), you will need to install the following packages locally to lint TypeScript code: `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint`, `typescript`.
 
-To get started, follow these steps:
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Dapr with Node.js 12 & TypeScript definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/dapr-typescript-node-12/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/dart/README.md
+++ b/containers/dart/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Dart |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Dart the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -22,23 +22,19 @@ While the definition itself works unmodified, you can select the version of Dart
 "args": { "VARIANT": "2" }
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Dart definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/dart/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/debian/README.md
+++ b/containers/debian/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Any |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Debian the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -43,36 +43,26 @@ Alternatively, you can use the contents of `base.Dockerfile` to fully customize 
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
 Just follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
 2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Debian definition.
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the contents of `containers/debian/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
-
-## Testing the definition
-
-This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
-
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
-2. Clone this repository.
-3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
-4. Select the `containers/debian` folder.
-5. Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> and type the following command to verify installation: `apt-get update && apt-get install -y lsb-release && git --version && lsb_release -a`
-6. After lsb_release installs, you should see the Git version and details about the version of Linux in the container.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/deno/README.md
+++ b/containers/deno/README.md
@@ -14,26 +14,19 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Deno, TypeScript, JavaScript |
 
-## Using this definition with an existing folder
+## Using this definition
 
-This definition doesn't require any special steps to use. Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-1. To use VS Code's copy of this definition:
-    1. Start VS Code and open your project folder.
-    1. Press <kbd>F1</kbd> and select **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-    1. Select the **Deno** definition.
-        - If necessary, first select **Show All Definitions...**.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
 
-1. To use latest-and-greatest copy of this definition from the repository:
-    1. Clone this repository.
-    1. Copy the contents of `containers/deno/.devcontainer` to the root of your project folder.
-    1. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-1. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-1. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/docker-existing-docker-compose/README.md
+++ b/containers/docker-existing-docker-compose/README.md
@@ -14,7 +14,7 @@
 
 > **Note:** There is also a single [Dockerfile](../docker-existing-dockerfile) variation of this same definition.
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an existing `docker-compose.yml` file that you would prefer not to modify but still want to add additional ports, a volume mount, or override the default command so that the container does not shut down if you stop the application.  The `.devcontainer/docker-compose.yml` and `.devcontainer/devcontainer.json` file will needs to be modified for your scenario.
 

--- a/containers/docker-existing-dockerfile/README.md
+++ b/containers/docker-existing-dockerfile/README.md
@@ -14,7 +14,7 @@
 
 > **Note:** There is also a [Docker Compose](../docker-existing-docker-compose) variation of this same definition.
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition requires an existing `Dockerfile` in your project and outlines some settings in `.devcontainer/devcontainer.json` to consider when reusing one.
 

--- a/containers/docker-from-docker-compose/README.md
+++ b/containers/docker-from-docker-compose/README.md
@@ -191,25 +191,19 @@ Then reference the env var when running Docker commands from the terminal inside
 docker run -it --rm -v "${LOCAL_WORKSPACE_FOLDER//\\/\/}:/workspace" debian bash
 ```
 
-## Using this definition with an existing folder
+## Using this definition
 
-Just follow these steps to use the definition:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Docker from Docker Compose definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/docker-from-docker-compose/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/docker-from-docker/README.md
+++ b/containers/docker-from-docker/README.md
@@ -198,7 +198,7 @@ Then reference the env var when running Docker commands from the terminal inside
 docker run -it --rm -v "${LOCAL_WORKSPACE_FOLDER//\\/\/}:/workspace" debian bash
 ```
 
-## Using this definition with an existing folder
+## Using this definition
 
 There are no special setup steps are required, but note that the included `.devcontainer/Dockerfile` can be altered to work with other Debian/Ubuntu-based container images such as `node` or `python`. Just, update the `FROM` statement to reference the new base image. For example, you could use the pre-built `mcr.microsoft.com/vscode/devcontainers/python:3` image:
 
@@ -208,21 +208,17 @@ FROM mcr.microsoft.com/vscode/devcontainers/python:3
 
 Beyond that, just follow these steps to use the definition:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Docker from Docker definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/docker-from-docker/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/docker-in-docker/README.md
+++ b/containers/docker-in-docker/README.md
@@ -31,7 +31,7 @@ Running "Docker in Docker" requires the parent container to be run as `--privile
 "overrideCommand": false
 ```
 
-## Using this definition with an existing folder
+## Using this definition
 
 The included `.devcontainer/Dockerfile` can be altered to work with other Debian/Ubuntu-based container images such as `node` or `python`. You'll also need to update `remoteUser` in `.devcontainer/devcontainer.json` in cases where a `vscode` user does not exist in the image you select. For example, to use `mcr.microsoft.com/vscode/devcontainers/javascript-node`, update the `Dockerfile` as follows:
 
@@ -47,21 +47,17 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:14
 
 Beyond that, just follow these steps to use the definition:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Docker from Docker Compose definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/docker-from-docker-compose/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/dotnet-fsharp/README.md
+++ b/containers/dotnet-fsharp/README.md
@@ -15,7 +15,7 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | .NET, .NET Core, F# |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While this definition should work unmodified, you can select the version of .NET / .NET Core the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -134,21 +134,17 @@ If you've already opened your folder in a container, rebuild the container using
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the F# (.NET Core) definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/dotnetcore-fsharp/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/dotnet-mssql/README.md
+++ b/containers/dotnet-mssql/README.md
@@ -19,7 +19,7 @@
 ## Description
 This definition creates two containers, one for C# (.NET) and one for Microsoft SQL.  VS Code will attach to the .NET Core container, and from within that container the Microsoft SQL container will be available on **`localhost`** port 1433. By default, the `sa` user password is `P@ssw0rd`. For more on the configuration of MS SQL, see the section [MS SQL Configuration](#MS-SQL-Configuration)
 
-## Using this definition with an existing folder
+## Using this definition
 
 While this definition should work unmodified, you can select the version of .NET Core the container uses by updating the `VARIANT` arg in the included `docker-compose.yml` (and rebuilding if you've already created the container).
 
@@ -122,21 +122,17 @@ Alternatively, .dacpac files placed in the `./bin/Debug` folder will be publishe
 
 ## Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the C# (.NET Core) and MS SQL definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/dotnetcore/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | .NET, .NET Core, C# |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While this definition should work unmodified, you can select the version of .NET / .NET Core the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -137,21 +137,22 @@ If you've already opened your folder in a container, rebuild the container using
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the C# (.NET) definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/dotnet/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/elixir-phoenix-postgres/README.md
+++ b/containers/elixir-phoenix-postgres/README.md
@@ -13,7 +13,7 @@ _Develop Elixir/Phoenix based applications. Includes everything you need to get 
 | _Container host OS support_ | Linux, macOS, Windows |
 | _Languages, platforms_      | Elixir, Postgres DB   |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While this definition should work unmodified, you can select the version of Elixir the container uses by updating the `VARIANT` arg in the included `docker-compose.yml`. In the same way you can specify a Phoenix Version by modifying the `PHOENIX_VERSION`.
 
@@ -47,23 +47,17 @@ services:
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
+2. Start VS Code and open your project folder or connect to a codespace.
 
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Elixir, Phoenix, Node.js & PostgresSQL definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-   1. Clone this repository.
-   2. Copy the contents of `containers/elixir-phoenix-postgres/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
-
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/elm/README.md
+++ b/containers/elm/README.md
@@ -14,25 +14,19 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Elm |
 
-## Using this definition with an existing folder
+## Using this definition
 
-This definition does not require any special steps to use. Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the **Elm** definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/elm/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Go |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Go the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -54,23 +54,24 @@ Given JavaScript front-end web client code written for use in conjunction with a
 }
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Go definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/go/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/hugo/README.md
+++ b/containers/hugo/README.md
@@ -24,25 +24,19 @@ There are 3 configuration options in the `devcontainer.json` file:
 
 The `.vscode` folder additionally contains a sample `tasks.json` file that can be used to set up Visual Studio Code [tasks](https://code.visualstudio.com/docs/editor/tasks) for working with Hugo sites.
 
-## Using this definition with an existing folder
+## Using this definition
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Hugo definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/java-8/README.md
+++ b/containers/java-8/README.md
@@ -16,7 +16,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Java |
 
-## Using this definition with an existing folder
+## Using this definition
 
 > **Note:** A version of this [definition for **newer JDKs**](../java) is also available!
 
@@ -81,21 +81,22 @@ Given JavaScript front-end web client code written for use in conjunction with a
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Java definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/java/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/java/README.md
+++ b/containers/java/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Java |
 
-## Using this definition with an existing folder
+## Using this definition
 
 > **Note:** A version of this [definition for **JDK 8**](../java-8) is also available!
 
@@ -91,21 +91,22 @@ Given JavaScript front-end web client code written for use in conjunction with a
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Java definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/java/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/javascript-node-azurite/README.md
+++ b/containers/javascript-node-azurite/README.md
@@ -14,7 +14,7 @@ Everything you need to get started using Node with Azurite.
 | *Languages, platforms* | Azurite, Node.js |
 
 
-## Using this definition with an existing folder
+## Using this definition
 
 This setup creates two containers, one for Node.js and one for Azurite. Both will be accessable on localhost, Blob storage will be available on port 10000 and queue will be available on port 10001
 
@@ -25,24 +25,21 @@ You can add other services to your `docker-compose.yml` file [as described in Do
 ```yaml
 # Runs the service on the same network as the app container, allows "forwardPorts" in devcontainer.json function.
 network_mode: service:app
+```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the **YOUR NAME HERE** definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## [Optional] Testing the definition
 

--- a/containers/javascript-node-mongo/README.md
+++ b/containers/javascript-node-mongo/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Node.js, JavaScript, Mongo DB |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition creates two containers, one for Node.js and one for MongoDB. VS Code will attach to the Node.js container, and from within that container the MongoDB container will be available on on **`localhost`** port 27017 The MongoDB instance can be managed in VS Code via the automatically installed MongoDB extension. Database options can be configured in `.devcontainer/docker-compose.yml` and data is persisted in a volume called `mongo-data`.
 
@@ -43,25 +43,19 @@ You can add other services to your `docker-compose.yml` file [as described in Do
 network_mode: service:db
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Node.js & Mongo DB definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/javascript-node-mongo/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/javascript-node-postgres/README.md
+++ b/containers/javascript-node-postgres/README.md
@@ -43,25 +43,19 @@ You can add other services to your `docker-compose.yml` file [as described in Do
 network_mode: service:db
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Node.js & Postgres DB definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/javascript-node-postgres/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/javascript-node/README.md
+++ b/containers/javascript-node/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Node.js, JavaScript |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Node.js the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -44,25 +44,24 @@ Alternatively, you can use the contents of the `Dockerfile` to fully customize y
 
 Beyond Node.js and `git`, this image / `Dockerfile` includes `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development. [Node Version Manager](https://github.com/nvm-sh/nvm) (`nvm`) is also included in case you need to use a different version of Node.js than the one included in the image.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
-
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
 2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Node.js 14 definition.
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   3. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the contents of `containers/javascript-node/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/jekyll/README.md
+++ b/containers/jekyll/README.md
@@ -19,25 +19,19 @@ In addition to Ruby and Bundler, this development container installs Jekyll and 
 - If your Jekyll project contains a `Gemfile` in the root folder, the development container will install all gems at startup by running `bundle install`. This is the [recommended](https://jekyllrb.com/docs/step-by-step/10-deployment/#gemfile) approach as it allows you to specify the exact Jekyll version your project requires and list all additional Jekyll plugins.
 - If there's no `Gemfile`, the development container will install Jekyll automatically, picking the latest version. You might need to manually install the other dependencies your project relies on, including all relevant Jekyll plugins.
 
-## Using this definition with an existing folder
+## Using this definition
 
-Follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Jekyll definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/jekyll/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/julia/README.md
+++ b/containers/julia/README.md
@@ -14,25 +14,19 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Julia |
 
-## Using this definition with an existing folder
+## Using this definition
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Julia definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/kubernetes-helm/README.md
+++ b/containers/kubernetes-helm/README.md
@@ -221,6 +221,20 @@ A few notes on the definition:
 
 See the section below for your operating system for more detailed setup instructions.
 
+### GitHub Codespaces
+
+While you cannot sync or connect to your local Kubernetes configuration with Codespaces, you can use `kubectl`, Helm, and the Kubernetes extension.
+
+1. If this is your first time using a development container, please see [creating a codespace](https://aka.ms/ghcs-open-codespace) for information on using GitHub Codespaces.
+
+2. Create or connect to an existing codespace.
+
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Codespaces: Rebuild Container** to start using the definition.
+
 ### Windows / macOS
 
 1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
@@ -229,17 +243,11 @@ See the section below for your operating system for more detailed setup instruct
 
 3. Check **Kubernetes > Enable Kubernetes**
 
-4. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Docker from Docker Compose definition.
+4. Start VS Code and open your project folder.
 
-5. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/kubernetes-helm/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+5. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
 
-6. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+6.  Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
 7. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
 
@@ -255,17 +263,11 @@ See the section below for your operating system for more detailed setup instruct
     kubectl config set-context minikube
     ```
 
-4. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Docker from Docker Compose definition.
+4. Start VS Code and open your project folder.
 
-5. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/kubernetes-helm/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+5. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
 
-6. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+6.  Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
 7. Open `.devcontainer/devcontainer.json` and uncomment this line in the `runArgs` array:
 

--- a/containers/mit-scheme/README.md
+++ b/containers/mit-scheme/README.md
@@ -15,7 +15,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | MIT-Scheme |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of MIT-SCHEME uses by updating the `TARGET_SCHEME_VERSION` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -25,21 +25,21 @@ While the definition itself works unmodified, you can select the version of MIT-
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
 Just follow these steps:
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the contents of `containers/mit-scheme/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/perl/README.md
+++ b/containers/perl/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Perl |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Perl the container uses by updating the `VARIANT` arg in the included `devcontainer.json`:
 
@@ -22,23 +22,19 @@ While the definition itself works unmodified, you can select the version of Perl
 "args": { "VARIANT": "5" }
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Perl definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/perl/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/php-mariadb/README.md
+++ b/containers/php-mariadb/README.md
@@ -24,7 +24,7 @@ mariadb -h localhost -P 3306  --protocol=tcp -u root --password=mariadb -D maria
 
 The default database is called `mariadb` with a `mariadb` user whose password is `mariadb`, and if desired this may be changed in `docker-compose.yml`. Data is stored in a volume named `mariadb-data`. Note that you will **not** be able to access the MariaDB socket, so be sure to specify `--protocol=tcp` when using the command line.
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of PHP the container uses by updating the `VARIANT` arg in the included `.devcontainer/docker-compose.yml` (and rebuilding if you've already created the container).
 
@@ -82,23 +82,19 @@ If you want to wire in something directly from your source code into the `www` f
 sudo chmod a+x "$(pwd)" && sudo rm -rf /var/www/html && sudo ln -s "$(pwd)" /var/www/html
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the PHP & MariaDB definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use the latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/php/README.md
+++ b/containers/php/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | PHP |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of PHP the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -78,23 +78,24 @@ If you want to wire in something directly from your source code into the `www` f
 sudo chmod a+x "$(pwd)" && sudo rm -rf /var/www/html && sudo ln -s "$(pwd)" /var/www/html
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the PHP definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/php/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/powershell/README.md
+++ b/containers/powershell/README.md
@@ -14,25 +14,19 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | PowerShell |
 
-## Using this definition with an existing folder
+## Using this definition
 
-This definition does not require any special steps to use. Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the PowerShell definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/powershell/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/puppet/README.md
+++ b/containers/puppet/README.md
@@ -18,25 +18,19 @@
 
 Develop Puppet manifests, modules, and code using VS Code without installing any extra tools: `puppet-development-in-a-box`!
 
-## Using this definition with an existing folder
+## Using this definition
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Create Container Configuration File...** from the command palette.
-   3. Select the `Puppet` definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/python-3-anaconda/README.md
+++ b/containers/python-3-anaconda/README.md
@@ -16,7 +16,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python, Anaconda |
 
-## Using this definition with an existing folder
+## Using this definition
 
 ### Configuration
 
@@ -90,21 +90,22 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env up
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Python 3 - Anaconda definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/python-3-anaconda/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/python-3-device-simulator-express/README.md
+++ b/containers/python-3-device-simulator-express/README.md
@@ -15,7 +15,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python |
 
-## Using this definition with an existing folder
+## Using this definition
 
 ### Configuration
 
@@ -104,25 +104,19 @@ RUN if ! cat /etc/group | grep -e "^pip-global:" > /dev/null 2>&1; then groupadd
     && ( [ ! -f "/etc/profile.d/00-restore-env.sh" ] || sed -i -e "s/export PATH=/export PATH=\/usr\/local\/pip-global:/" /etc/profile.d/00-restore-env.sh )
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Python 3 definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the contents of `containers/python-3/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/python-3-miniconda/README.md
+++ b/containers/python-3-miniconda/README.md
@@ -16,7 +16,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python, Anaconda, Miniconda |
 
-## Using this definition with an existing folder
+## Using this definition
 
 ### Configuration
 
@@ -108,21 +108,22 @@ RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env up
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Python 3 - Miniconda definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/python-3-miniconda/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
-4. After following step 2 or 3, the *only* the contents of the `.devcontainer` folder in your project can be adapted to meet your needs. Ignore other files and folders.
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/python-3-postgres/README.md
+++ b/containers/python-3-postgres/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition creates two containers, one for Python and one for PostgreSQL. VS Code will attach to the Python container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `docker-compose.yml`. Data is stored in a volume named `postgres-data`.
 
@@ -125,21 +125,17 @@ RUN if ! cat /etc/group | grep -e "^pip-global:" > /dev/null 2>&1; then groupadd
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Python 3 & PostgreSQL definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/python-3-postgres/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the *only* the contents of the `.devcontainer` folder in your project can be adapted to meet your needs. Ignore other files and folders.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python |
 
-## Using this definition with an existing folder
+## Using this definition
 
 ### Configuration
 
@@ -141,25 +141,24 @@ RUN apt-get update && apt-get install --no-install-recommends -yq software-prope
      && pip3 install --no-cache-dir --upgrade pip setuptools wheel
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
-
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
 2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Python 3 definition.
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the contents of `containers/python-3/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/r/README.md
+++ b/containers/r/README.md
@@ -14,25 +14,19 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | R |
 
-## Using this definition with an existing folder
+## Using this definition
 
-This definition does not require any special steps to use. Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the R definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/R/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/reasonml/README.md
+++ b/containers/reasonml/README.md
@@ -16,26 +16,19 @@
 
 This image contains the development environment to work with [ReasonML](https://reasonml.github.io/) applications. It also includes [fish shell](https://fishshell.com/) to improve the CLI experience.
 
-## Using this definition with an existing folder
+## Using this definition
 
-To get started, follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the ReasonML definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/reasonml/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
-
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 ## Testing the definition
 
 This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:

--- a/containers/ruby-rails/README.md
+++ b/containers/ruby-rails/README.md
@@ -14,7 +14,7 @@ _Develop Ruby on Rails applications, includes everything you need to get up and 
 | _Container OS_              | Debian                |
 | _Languages, platforms_      | Ruby                  |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While this definition should work unmodified, you can select the version of Ruby the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -43,23 +43,17 @@ ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev <, YOUR_OTHER_ALLOWED_DOMAIN(S),
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To start then:
+2. Start VS Code and open your project folder or connect to a codespace.
 
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Ruby on Rails definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-   1. Clone this repository.
-   2. Copy the contents of `.devcontainer` and `.vscode` folders under `containers/ruby-rails/` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
-
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/ruby-sinatra/README.md
+++ b/containers/ruby-sinatra/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Ruby |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While this definition should work unmodified, you can select the version of Ruby the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -36,21 +36,17 @@ Given JavaScript front-end web client code written for use in conjunction with a
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To start then:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Ruby 2 definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/ruby-sinatra/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/ruby/README.md
+++ b/containers/ruby/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Ruby |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While this definition should work unmodified, you can select the version of Ruby the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -59,21 +59,22 @@ Given JavaScript front-end web client code written for use in conjunction with a
 
 ### Adding the definition to your folder
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Ruby definition.
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/ruby/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/rust/README.md
+++ b/containers/rust/README.md
@@ -16,7 +16,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Rust |
 
-## Using this definition with an existing folder
+## Using this definition
 
 This definition does not require any special steps to use. Note that the `Cargo.toml` file in the root of this folder is for the test project and can be ignored.
 
@@ -34,14 +34,14 @@ See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vs
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
 1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
 
 2. To use VS Code's copy of this definition:
    1. Start VS Code and open your project folder.
    2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Rust definition.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
 3. To use latest-and-greatest copy of this definition from the repository:
    1. Clone this repository.

--- a/containers/sfdx-project/README.md
+++ b/containers/sfdx-project/README.md
@@ -20,25 +20,19 @@ Remote development in container environment is powered by the official Salesforc
 
 You can learn more about remote development with Salesforce Extension [here](https://forcedotcom.github.io/salesforcedx-vscode/).
 
-## Using this definition with an existing folder
+## Using this definition
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> and run **Remote-Containers: Add Development Container Configuration Files...** from the Command Palette.
-   3. Select the Salesforce Project definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After step 2 or 3, edit the contents of the `.devcontainer` folder in your project, as required.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Start using the definition by running **Remote-Containers: Reopen Folder in Container** from the Command Palette.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/swift/README.md
+++ b/containers/swift/README.md
@@ -14,7 +14,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Swift |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Swift the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -32,23 +32,19 @@ Given how frequently web applications use Node.js for front end code, this conta
 }
 ```
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Swift definition.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of `containers/swift/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/typescript-node/README.md
+++ b/containers/typescript-node/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Node.js, TypeScript |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Node.js the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -46,25 +46,24 @@ Beyond TypeScript, Node.js, and `git`, this image / `Dockerfile` includes `eslin
 
 Note that, while `eslint`and `typescript` are installed globally for convenance, [as of ESLint 6](https://eslint.org/docs/user-guide/migrating-to-6.0.0#-plugins-and-shareable-configs-are-no-longer-affected-by-eslints-location), you will need to install the following packages locally to lint TypeScript code: `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint`, `typescript`.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
-
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
 2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Node.js 14 & TypeScript definition.
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   3. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the contents of `containers/typescript-node/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## Testing the definition
 

--- a/containers/ubuntu/README.md
+++ b/containers/ubuntu/README.md
@@ -17,7 +17,7 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | Any |
 
-## Using this definition with an existing folder
+## Using this definition
 
 While the definition itself works unmodified, you can select the version of Ubuntu the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
@@ -43,36 +43,24 @@ Alternatively, you can use the contents of the `base.Dockerfile` to fully custom
 
 Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
-### Adding the definition to your project
+### Adding the definition to a project or codespace
 
-Just follow these steps:
-
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
 2. To use the pre-built image:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Ubuntu definition.
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-3. To use the Dockerfile for this definition (*rather than the pre-built image*):
-   1. Clone this repository.
-   2. Copy the contents of `containers/ubuntu/.devcontainer` to the root of your project folder.
-   3. Start VS Code and open your project folder.
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json` to reference `"dockerfile": "base.Dockerfile"`.
 
 4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
-
-## Testing the definition
-
-This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
-
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
-2. Clone this repository.
-3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
-4. Select the `containers/ubuntu` folder.
-5. Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> and type the following command to verify installation: `git --version && lsb_release -a`
-6. After lsb_release installs, you should see the Git version and details about the version of Linux in the container.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 

--- a/containers/vue/README.md
+++ b/containers/vue/README.md
@@ -14,25 +14,19 @@
 | *Container OS*              | Debian                                       |
 | *Languages, platforms*      | Javascript                                   |
 
-## Using this definition with an existing folder
+## Using this definition
 
-Just follow these steps:
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
 
-1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Start VS Code and open your project folder or connect to a codespace.
 
-2. To use VS Code's copy of this definition:
-   1. Start VS Code and open your project folder.
-   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
-   3. Select the Hugo definition.
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
-3. To use latest-and-greatest copy of this definition from the repository:
-   1. Clone this repository.
-   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
-   3. Start VS Code and open your project folder.
+   > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
-4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
 
-5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
 
 ## License
 


### PR DESCRIPTION
This PR updates the directions in this repository to better factor in Codespaces now that the "Reopen Container" flow is available. Previously customers were directed to either use Remote - Containers to add content or copy the `.devcontainer` folder manually. This leads to a poor experience both because its harder to do and because it drags additional unneeded files.

Lots of files are updated because of the number of definitions, but there's really three core updates repeated:

1. The [Main README](https://github.com/microsoft/vscode-dev-containers/blob/clantz/update-instructions/README.md)
2. [READMEs for community definitions](https://github.com/microsoft/vscode-dev-containers/tree/clantz/update-instructions/containers/deno) or definitions w/o a pre-built image
3. [READMEs for definitions with pre-built images that include info about fully customizing](https://github.com/microsoft/vscode-dev-containers/blob/clantz/update-instructions/containers/javascript-node/README.md#adding-the-definition-to-a-project-or-codespace)

//cc: @matthewisabel since he'd mentioned the READMEs being out-of-whack. @bailey as FYI.

Right now the "Test" section is kept with Remote - Containers since those assets aren't included in end user scenarios.  LMK if anyone feels strongly we should tweak those instructions as well.