### PR TITLE
Add version metadata, command into pre-built images, do not overwrite existing history files

### DIFF
--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -161,4 +161,4 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           -H "Content-Type: application/json" \
           https://api.github.com/repos/${{ github.repository }}/actions/workflows/version-history.yml/dispatches \
-          --data "{\"ref\": \"master\", \"inputs\": {\"release\": \"${{ steps.get_tag_name.outputs.tag }}\", \"cg\": \"false\", \"push\": \"true\"}"
+          --data "{\"ref\": \"master\", \"inputs\": {\"release\": \"${{ steps.get_tag_name.outputs.tag }}\", \"cg\": \"false\", \"push\": \"true\", \"overwrite\": \"false\"}"

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -138,5 +138,5 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           -H "Content-Type: application/json" \
           https://api.github.com/repos/${{ github.repository }}/actions/workflows/version-history.yml/dispatches \
-          --data "{\"ref\": \"${{ github.ref }}\", \"inputs\": {\"release\": \"$GIT_BRANCH\", \"cg\": \"true\", \"push\": \"true\"}"
+          --data "{\"ref\": \"${{ github.ref }}\", \"inputs\": {\"release\": \"$GIT_BRANCH\", \"cg\": \"true\", \"push\": \"true\", \"overwrite\": \"true\"}"
 

--- a/.github/workflows/version-history.yml
+++ b/.github/workflows/version-history.yml
@@ -15,6 +15,10 @@ on:
         description: 'Update repository with results'
         required: true
         default: 'true'
+      push:
+        description: 'Overwrite existing files'
+        required: true
+        default: 'true'
       definition:
         description: 'Definition ID (Optional)'
         required: false
@@ -85,6 +89,7 @@ jobs:
                           --stub-registry ${{ secrets.STUB_REGISTRY }} \
                           --stub-registry-path ${{ secrets.STUB_REGISTRY_BASE_PATH }} \
                           --output-path "$GITHUB_WORKSPACE/ref" \
+                          $(if [ "${{ github.event.inputs.overwrite }}" = "false" ]; then echo '--no-overwrite'; else echo '--overwrite'; fi) \
                           $(if [ "${{ github.event.inputs.cg }}" = "false" ]; then echo '--no-cg'; else echo '--cg'; fi) \
                           ${{ github.event.inputs.definition }}
 

--- a/.github/workflows/version-history.yml
+++ b/.github/workflows/version-history.yml
@@ -15,7 +15,7 @@ on:
         description: 'Update repository with results'
         required: true
         default: 'true'
-      push:
+      overwrite:
         description: 'Overwrite existing files'
         required: true
         default: 'true'

--- a/build/.vscode/launch.json
+++ b/build/.vscode/launch.json
@@ -11,7 +11,7 @@
 			"program": "${workspaceFolder}/vscdc",
 			"args": [
 				"push",
-				"go",
+				"debian",
 				"--no-push",
 				"--page", "1",
 				"--page-total", "1",
@@ -42,14 +42,17 @@
 		}, {
 			"type": "node",
 			"request": "launch",
-			"name": "Run CG Manifest Script",
+			"name": "Run CG/Info Script",
 			"program": "${workspaceFolder}/vscdc",
 			"args": [
-				"cg",
-				"codespaces-linux-stretch",
+				"info",
+				"codespaces-linux",
 				"--no-build",
 				"--markdown",
-				"--release", "v0.166.2",
+				"--cg",
+				"--overwrite",
+				"--prune",
+				"--release", "master",
 				"--github-repo", "microsoft/vscode-dev-containers",
 				"--registry", "mcr.microsoft.com",
 				"--registryPath", "vscode/devcontainers"

--- a/build/assets/meta.env
+++ b/build/assets/meta.env
@@ -1,0 +1,6 @@
+VERSION='{{version}}'
+CONTENTS_URL='{{contentsUrl}}'
+DEFINITION_ID='{{definitionId}}'
+VARIANT='{{variant}}'
+GIT_REPOSITORY='{{gitRepository}}'
+GIT_REPOSITORY_RELEASE='{{gitRepositoryRelease}}'

--- a/build/config.json
+++ b/build/config.json
@@ -10,6 +10,9 @@
 	"repoContainersToBuildPath": "repository-containers/images",
 	"scriptLibraryPathInRepo": "script-library",
 	"scriptLibraryFolderNameInDefinition": "library-scripts",
+	"historyUrlPrefix": "https://github.com/microsoft/vscode-dev-containers/tree/master/containers/",
+	"repositoryUrl": "https://github.com/microsoft/vscode-dev-containers/",
+	"imageLabelPrefix": "com.visualstudio.code.devcontainers",
 	"definitionBuildConfigFile": "definition-manifest.json",
 
 	"devContainerJsonPreamble": "For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:\n// ",

--- a/build/src/package.js
+++ b/build/src/package.js
@@ -56,7 +56,7 @@ async function package(repo, release, updateLatest, registry, registryPath, stub
     let outputPath = null;
     console.log('(*) Moving package...');
     outputPath = path.join(__dirname, '..', '..', `${packageJson.name}-${packageJsonVersion}.tgz`);
-    await asyncUtils.rename(path.join(stagingFolder, `${packageJson.name}-${packageJsonVersion}.tgz`), outputPath);
+    await asyncUtils.copyFile(path.join(stagingFolder, `${packageJson.name}-${packageJsonVersion}.tgz`), outputPath);
 
     if (cleanWhenDone) {
         // And finally clean up

--- a/build/src/push.js
+++ b/build/src/push.js
@@ -9,6 +9,8 @@ const asyncUtils = require('./utils/async');
 const configUtils = require('./utils/config');
 const prep = require('./prep');
 
+const imageLabelPrefix = configUtils.getConfig('imageLabelPrefix', 'com.microsoft.vscode.devcontainers');
+
 async function push(repo, release, updateLatest, registry, registryPath, stubRegistry,
     stubRegistryPath, pushImages, prepOnly, definitionsToSkip, page, pageTotal, replaceImages, definitionId) {
 
@@ -47,7 +49,7 @@ async function pushImage(definitionId, repo, release, updateLatest,
     const dockerFileExists = await asyncUtils.exists(path.join(dotDevContainerPath, 'Dockerfile'));
     const baseDockerFileExists = await asyncUtils.exists(path.join(dotDevContainerPath, 'base.Dockerfile'));
     const dockerFilePath = path.join(dotDevContainerPath, `${baseDockerFileExists ? 'base.' : ''}Dockerfile`);
-
+    
     // Make sure there's a Dockerfile present
     if (!await asyncUtils.exists(dockerFilePath)) {
         throw `Invalid path ${dockerFilePath}`;
@@ -90,7 +92,16 @@ async function pushImage(definitionId, repo, release, updateLatest,
                 const buildParams = (variant ? ['--build-arg', `VARIANT=${variant}`] : [])
                     .concat(versionTags.reduce((prev, current) => prev.concat(['-t', current]), []));
                 const spawnOpts = { stdio: 'inherit', cwd: workingDir, shell: true };
-                await asyncUtils.spawn('docker', ['build', workingDir, '-f', dockerFilePath].concat(buildParams), spawnOpts);
+                await asyncUtils.spawn('docker', [
+                        'build', 
+                        workingDir,
+                        '-f', dockerFilePath, 
+                        '--label', `version=${prepResult.meta.version}`,
+                        `--label`, `${imageLabelPrefix}.id=${prepResult.meta.definitionId}`,
+                        '--label', `${imageLabelPrefix}.variant=${prepResult.meta.variant}`,
+                        '--label', `${imageLabelPrefix}.release=${prepResult.meta.gitRepositoryRelease}`,
+                        '--label', `${imageLabelPrefix}.source=${prepResult.meta.gitRepository}`
+                    ].concat(buildParams), spawnOpts);
 
                 // Push
                 if (pushImages) {
@@ -104,7 +115,6 @@ async function pushImage(definitionId, repo, release, updateLatest,
             } else {
                 console.log(`(*) Version already published. Skipping.`);
             }
-
         }
     }
 

--- a/build/src/utils/component-formatter-factory.js
+++ b/build/src/utils/component-formatter-factory.js
@@ -82,7 +82,7 @@ function pipComponentFormatter(packageInfo) {
     return  {
         "Component": {
             "Type": "Pip",
-            "Npm": {
+            "Pip": {
                 "Name": packageInfo.name,
                 "Version": packageInfo.version
             }

--- a/build/vscdc
+++ b/build/vscdc
@@ -215,6 +215,11 @@ require('yargs')
                 'output-path': {
                     describe: 'path to where extracted information should be stored',
                     default: path.resolve(__dirname, '..', configUtils.getConfig('informationFileOutputPath', '.'))
+                },
+                'overwrite': {
+                    describe: 'whether to overwrite cgmanifest.json or markdown files',
+                    type: 'boolean',
+                    default: true
                 }
             })
     }, imageInfoCommand)
@@ -274,6 +279,11 @@ require('yargs')
                 'output-path': {
                     describe: 'path to where extracted information should be stored',
                     default: path.resolve(__dirname, '..', configUtils.getConfig('informationFileOutputPath', '.'))
+                },
+                'overwrite': {
+                    describe: 'whether to overwrite cgmanifest.json or markdown files',
+                    type: 'boolean',
+                    default: false
                 }
             })
     }, imageInfoCommand)
@@ -351,8 +361,8 @@ function copyLibraryScriptsCommand() {
 }
 
 function imageInfoCommand(argv) {
-    generateImageInformationFiles(argv.githubRepo, argv.release, argv.registry, argv.registryPath, 
-        argv.stubRegistry, argv.stubRegistryPath, argv.build, argv.prune, argv.cg, argv.markdown, argv.outputPath, argv.devcontainer)
+    generateImageInformationFiles(argv.githubRepo, argv.release, argv.registry, argv.registryPath, argv.stubRegistry, argv.stubRegistryPath, 
+        argv.build, argv.prune, argv.cg, argv.markdown, argv.overwrite, argv.outputPath, argv.devcontainer)
         .catch((reason) => {
             console.error(`(!) Image information file generation failed - ${reason}`);
             if(reason.stack) {

--- a/container-templates/docker-compose/.devcontainer/Dockerfile
+++ b/container-templates/docker-compose/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY library-scripts/*.sh /tmp/library-scripts/
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     #

--- a/container-templates/docker-compose/.npmignore
+++ b/container-templates/docker-compose/.npmignore
@@ -2,6 +2,7 @@ README.md
 test-project
 history
 .devcontainer/library-scripts/README.md
+.devcontainer/library-scripts/meta.env
 definition-manifest.json
 .vscode
 .npmignore

--- a/container-templates/dockerfile/.devcontainer/Dockerfile
+++ b/container-templates/dockerfile/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# Use the [Choice] comment to indicate option arguments that should appear in VS Code UX
+# Use the [Choice] comment to indicate option arguments that should appear in VS Code UX. Use a comma separated list.
 #
 # [Choice] Debian OS version: buster, stretch
 ARG VARIANT="buster"
@@ -15,7 +15,7 @@ ARG UPGRADE_PACKAGES="false"
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/*.sh /tmp/library-scripts/
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true"\
     #

--- a/container-templates/dockerfile/.npmignore
+++ b/container-templates/dockerfile/.npmignore
@@ -2,6 +2,7 @@ README.md
 test-project
 history
 .devcontainer/library-scripts/README.md
+.devcontainer/library-scripts/meta.env
 definition-manifest.json
 .vscode
 .npmignore

--- a/containers/alpine/.devcontainer/base.Dockerfile
+++ b/containers/alpine/.devcontainer/base.Dockerfile
@@ -9,7 +9,7 @@ ARG INSTALL_ZSH="true"
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/*.sh /tmp/library-scripts/
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 RUN apk update && ash /tmp/library-scripts/common-alpine.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" \
     && rm -rf /tmp/library-scripts
 

--- a/containers/alpine/.devcontainer/devcontainer.json
+++ b/containers/alpine/.devcontainer/devcontainer.json
@@ -3,12 +3,12 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12, 3.13
-		"args": { "VARIANT": "3.12" }
+		"args": { "VARIANT": "3.13" }
 	},
 	
 	// Set *default* container specific settings.json values on container create. 
 	"settings": {
-		"terminal.integrated.shell.linux": "/bin/ash"
+		"terminal.integrated.shell.linux": "/bin/bash"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/containers/alpine/.devcontainer/library-scripts/meta.env
+++ b/containers/alpine/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/codespaces-linux-stretch/.devcontainer/base.Dockerfile
+++ b/containers/codespaces-linux-stretch/.devcontainer/base.Dockerfile
@@ -27,7 +27,7 @@ ENV PATH="${NVM_DIR}/current/bin:${DOTNET_ROOT}/tools:${SDKMAN_DIR}/bin:${SDKMAN
 
 # Install needed utilities and setup non-root user. Use a separate RUN statement to add your own dependencies.
 COPY library-scripts/azcli-debian.sh library-scripts/common-debian.sh library-scripts/git-lfs-debian.sh library-scripts/github-debian.sh \
-    library-scripts/kubectl-helm-debian.sh library-scripts/sshd-debian.sh setup-user.sh /tmp/scripts/
+    library-scripts/kubectl-helm-debian.sh library-scripts/sshd-debian.sh library-scripts/*.env setup-user.sh /tmp/scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove buster list to avoid unexpected errors given base image is stretch
     && rm /etc/apt/sources.list.d/buster.list \

--- a/containers/codespaces-linux/.devcontainer/library-scripts/meta.env
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/cpp/.devcontainer/base.Dockerfile
+++ b/containers/cpp/.devcontainer/base.Dockerfile
@@ -3,6 +3,7 @@ ARG VARIANT=buster
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 # Install needed packages. Use a separate RUN statement to add your own dependencies.
+COPY library-scripts/meta.env /usr/local/etc/vscode-dev-containers
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*

--- a/containers/cpp/.devcontainer/library-scripts/README.md
+++ b/containers/cpp/.devcontainer/library-scripts/README.md
@@ -1,0 +1,5 @@
+# Warning: Folder contents may be replaced
+
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+
+To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/cpp/.devcontainer/library-scripts/meta.env
+++ b/containers/cpp/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/cpp/.npmignore
+++ b/containers/cpp/.npmignore
@@ -2,5 +2,6 @@ README.md
 test-project
 history
 definition-manifest.json
+library-scripts
 .vscode
 .npmignore

--- a/containers/debian/.devcontainer/base.Dockerfile
+++ b/containers/debian/.devcontainer/base.Dockerfile
@@ -6,12 +6,11 @@ FROM buildpack-deps:${VARIANT}-curl
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/*.sh /tmp/library-scripts/
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 

--- a/containers/debian/.devcontainer/library-scripts/meta.env
+++ b/containers/debian/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/dotnet/.devcontainer/Dockerfile
+++ b/containers/dotnet/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/l
 
 # [Option] Install Azure CLI
 ARG INSTALL_AZURE_CLI="false"
-COPY library-scripts/azcli-debian.sh /tmp/library-scripts/
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 RUN if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 

--- a/containers/dotnet/.devcontainer/base.Dockerfile
+++ b/containers/dotnet/.devcontainer/base.Dockerfile
@@ -2,18 +2,19 @@
 ARG VARIANT="3.1"
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}-focal
 
+# Copy library scripts to execute
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/common-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"
@@ -21,15 +22,16 @@ ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-COPY library-scripts/node-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Azure CLI
 ARG INSTALL_AZURE_CLI="false"
-COPY library-scripts/azcli-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Remove library scripts for final image
+RUN rm -rf /tmp/library-scripts
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/dotnet/.devcontainer/library-scripts/meta.env
+++ b/containers/dotnet/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/dotnet/.npmignore
+++ b/containers/dotnet/.npmignore
@@ -5,5 +5,6 @@ definition-manifest.json
 .devcontainer/library-scripts/README.md
 .devcontainer/library-scripts/common-debian.sh
 .devcontainer/library-scripts/node-debian.sh
+.devcontainer/library-scripts/meta.env
 .vscode
 .npmignore

--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -2,24 +2,24 @@
 ARG VARIANT=1
 FROM golang:${VARIANT}
 
+# Copy library scripts to execute
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/common-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install Go tools
 ENV GO111MODULE=auto
-COPY library-scripts/go-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/go-debian.sh "none" "/usr/local/go" "${GOPATH}" "${USERNAME}" "false" \
-    && apt-get clean -y && rm -rf /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"
@@ -27,9 +27,11 @@ ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-COPY library-scripts/node-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Remove library scripts for final image
+RUN rm -rf /tmp/library-scripts
 
 # [Optional] Uncomment the next line to use go get to install anything else you need
 # RUN go get -x <your-dependency-or-tool>

--- a/containers/go/.devcontainer/library-scripts/meta.env
+++ b/containers/go/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/java-8/.devcontainer/base.Dockerfile
+++ b/containers/java-8/.devcontainer/base.Dockerfile
@@ -6,6 +6,7 @@ ARG INSTALL_MAVEN="false"
 ARG MAVEN_VERSION=""
 ARG INSTALL_GRADLE="false"
 ARG GRADLE_VERSION=""
+COPY library-scripts/meta.env /usr/local/etc/vscode-dev-containers
 RUN su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && if [ "${JDK8_VERSION}" = "" ]; then \
         sdk install java \$(sdk ls java | grep -m 1 -o ' 8.*.hs-adpt ' | awk '{print \$NF}'); \
         else sdk install java '${JDK8_VERSION}'; fi" \

--- a/containers/java-8/.devcontainer/library-scripts/README.md
+++ b/containers/java-8/.devcontainer/library-scripts/README.md
@@ -1,0 +1,5 @@
+# Warning: Folder contents may be replaced
+
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+
+To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/java-8/.devcontainer/library-scripts/meta.env
+++ b/containers/java-8/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -2,19 +2,20 @@
 ARG VARIANT=11
 FROM openjdk:${VARIANT}-jdk-buster
 
+# Copy library scripts to execute
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/common-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && if [ ! -d "/docker-java-home" ]; then ln -s "${JAVA_HOME}" /docker-java-home; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Maven
 ARG INSTALL_MAVEN="false"
@@ -24,11 +25,10 @@ ARG INSTALL_GRADLE="false"
 ARG GRADLE_VERSION=""
 ENV SDKMAN_DIR="/usr/local/sdkman"
 ENV PATH="${PATH}:${SDKMAN_DIR}/java/current/bin:${SDKMAN_DIR}/maven/current/bin:${SDKMAN_DIR}/gradle/current/bin"
-COPY library-scripts/java-debian.sh library-scripts/maven-debian.sh library-scripts/gradle-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/java-debian.sh "none" "${SDKMAN_DIR}" "${USERNAME}" "true" \
     && if [ "${INSTALL_MAVEN}" = "true" ]; then bash /tmp/library-scripts/maven-debian.sh "${MAVEN_VERSION:-latest}" "${SDKMAN_DIR}" ${USERNAME} "true"; fi \
     && if [ "${INSTALL_GRADLE}" = "true" ]; then bash /tmp/library-scripts/gradle-debian.sh "${GRADLE_VERSION:-latest}" "${SDKMAN_DIR}" ${USERNAME} "true"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"
@@ -36,9 +36,11 @@ ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH="${NVM_DIR}/current/bin:${PATH}"
-COPY library-scripts/node-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Remove library scripts for final image
+RUN rm -rf /tmp/library-scripts
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/java/.devcontainer/library-scripts/meta.env
+++ b/containers/java/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/javascript-node/.devcontainer/base.Dockerfile
+++ b/containers/javascript-node/.devcontainer/base.Dockerfile
@@ -15,7 +15,7 @@ ARG NPM_GLOBAL=/usr/local/share/npm-global
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \ 
     PATH=${NPM_GLOBAL}/bin:${NVM_DIR}/current/bin:${PATH}
-COPY library-scripts/*.sh /tmp/library-scripts/
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \

--- a/containers/javascript-node/.devcontainer/library-scripts/meta.env
+++ b/containers/javascript-node/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/php/.devcontainer/base.Dockerfile
+++ b/containers/php/.devcontainer/base.Dockerfile
@@ -2,22 +2,23 @@
 ARG VARIANT=7
 FROM php:${VARIANT}-apache
 
+# Copy library scripts to execute
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/common-debian.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get -y install --no-install-recommends lynx \
     && usermod -aG www-data ${USERNAME} \
     && sed -i -e "s/Listen 80/Listen 80\\nListen 8080/g" /etc/apache2/ports.conf \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install xdebug
 RUN yes | pecl install xdebug \
@@ -38,9 +39,11 @@ ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-COPY library-scripts/node-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_NODE" = "true" ]; then /bin/bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Remove library scripts for final image
+RUN rm -rf /tmp/library-scripts
 
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/php/.devcontainer/library-scripts/meta.env
+++ b/containers/php/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/python-3-anaconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/base.Dockerfile
@@ -1,7 +1,7 @@
 FROM continuumio/anaconda3
 
 # Copy library scripts to execute
-COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+COPY .devcontainer/library-scripts/*.sh .devcontainer/library-scripts/*.env /tmp/library-scripts/
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/containers/python-3-anaconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/base.Dockerfile
@@ -1,18 +1,19 @@
 FROM continuumio/anaconda3
 
+# Copy library scripts to execute
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY .devcontainer/library-scripts/*.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"
@@ -20,9 +21,11 @@ ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-COPY .devcontainer/library-scripts/node-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Remove library scripts for final image
+RUN rm -rf /tmp/library-scripts
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/meta.env
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/python-3-anaconda/.npmignore
+++ b/containers/python-3-anaconda/.npmignore
@@ -2,7 +2,7 @@ README.md
 test-project
 history
 definition-manifest.json
-.devcontainer/library-scripts/README.md
+.devcontainer/library-scripts
 environment.yml
 .vscode
 .npmignore

--- a/containers/python-3-miniconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/base.Dockerfile
@@ -1,18 +1,19 @@
 FROM continuumio/miniconda3
 
+# Copy library scripts to execute
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY .devcontainer/library-scripts/common-debian.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Optional] Uncomment to install a different version of Python than the default
 # RUN conda install -y python=3.6
@@ -21,9 +22,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 ENV PIPX_HOME=/usr/local/py-utils \
     PIPX_BIN_DIR=/usr/local/py-utils/bin
 ENV PATH=${PATH}:${PIPX_BIN_DIR}
-COPY .devcontainer/library-scripts/python-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/python-debian.sh "none" "/opt/conda" "${PIPX_HOME}" "${USERNAME}" "false" \ 
-    && apt-get clean -y && rm -rf /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"
@@ -31,9 +31,11 @@ ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-COPY .devcontainer/library-scripts/node-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+ # Remove library scripts for final image
+RUN rm -rf /tmp/library-scripts
 
 # Copy environment.yml (if found) to a temp locaition so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/containers/python-3-miniconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/base.Dockerfile
@@ -1,7 +1,7 @@
 FROM continuumio/miniconda3
 
 # Copy library scripts to execute
-COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+COPY .devcontainer/library-scripts/*.sh .devcontainer/library-scripts/*.env /tmp/library-scripts/
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/meta.env
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/python-3-miniconda/.npmignore
+++ b/containers/python-3-miniconda/.npmignore
@@ -2,6 +2,6 @@ README.md
 test-project
 history
 definition-manifest.json
-.devcontainer/library-scripts/README.md
+.devcontainer/library-scripts
 .vscode
 .npmignore

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -3,7 +3,7 @@ ARG VARIANT=3
 FROM python:${VARIANT}
 
 # Copy library scripts to execute
-COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+COPY .devcontainer/library-scripts/*.sh .devcontainer/library-scripts/*.env /tmp/library-scripts/
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -2,30 +2,30 @@
 ARG VARIANT=3
 FROM python:${VARIANT}
 
+# Copy library scripts to execute
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY .devcontainer/library-scripts/common-debian.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install common packages, non-root user
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Setup default python tools in a venv via pipx to avoid conflicts
 ENV PIPX_HOME=/usr/local/py-utils \
     PIPX_BIN_DIR=/usr/local/py-utils/bin
 ENV PATH=${PATH}:${PIPX_BIN_DIR}
-COPY .devcontainer/library-scripts/python-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/python-debian.sh "none" "/usr/local" "${PIPX_HOME}" "${USERNAME}" \ 
-    && apt-get clean -y && rm -rf /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="true"
@@ -33,9 +33,11 @@ ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-COPY .devcontainer/library-scripts/node-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+# Remove library scripts for final image
+RUN rm -rf /tmp/library-scripts
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/containers/python-3/.devcontainer/library-scripts/meta.env
+++ b/containers/python-3/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -2,23 +2,24 @@
 ARG VARIANT=2
 FROM ruby:${VARIANT}
 
+# Copy library scripts to execute
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
+
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="true"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/common-debian.sh library-scripts/ruby-debian.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \
     # Install common packages, non-root user, rvm, core build tools
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && bash /tmp/library-scripts/ruby-debian.sh "none" "${USERNAME}" "true" "true" \
-    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Node.js 
 ARG INSTALL_NODE="true"
@@ -26,9 +27,11 @@ ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-COPY library-scripts/node-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+
+ # Remove library scripts for final image
+RUN rm -rf /tmp/library-scripts
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/ruby/.devcontainer/library-scripts/meta.env
+++ b/containers/ruby/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/rust/.devcontainer/base.Dockerfile
+++ b/containers/rust/.devcontainer/base.Dockerfile
@@ -4,12 +4,11 @@ FROM rust:1
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="false"
-
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
-COPY library-scripts/*.sh /tmp/library-scripts/
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Remove imagemagick due to https://security-tracker.debian.org/tracker/CVE-2019-10131
     && apt-get purge -y imagemagick imagemagick-6-common \

--- a/containers/rust/.devcontainer/library-scripts/meta.env
+++ b/containers/rust/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/typescript-node/.devcontainer/base.Dockerfile
+++ b/containers/typescript-node/.devcontainer/base.Dockerfile
@@ -4,6 +4,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # Install tslint, typescript. eslint is installed by javascript image
 ARG NODE_MODULES="tslint-to-eslint-config typescript"
+COPY library-scripts/meta.env /usr/local/etc/vscode-dev-containers
 RUN su node -c "umask 0002 && npm install -g ${NODE_MODULES}" \
     && npm cache clean --force > /dev/null 2>&1
 

--- a/containers/typescript-node/.devcontainer/library-scripts/README.md
+++ b/containers/typescript-node/.devcontainer/library-scripts/README.md
@@ -1,0 +1,5 @@
+# Warning: Folder contents may be replaced
+
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+
+To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/typescript-node/.devcontainer/library-scripts/meta.env
+++ b/containers/typescript-node/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/containers/ubuntu/.devcontainer/base.Dockerfile
+++ b/containers/ubuntu/.devcontainer/base.Dockerfile
@@ -9,7 +9,7 @@ ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-COPY library-scripts/*.sh /tmp/library-scripts/
+COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 RUN yes | unminimize 2>&1 \ 
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts

--- a/containers/ubuntu/.devcontainer/library-scripts/meta.env
+++ b/containers/ubuntu/.devcontainer/library-scripts/meta.env
@@ -1,0 +1,1 @@
+VERSION='dev'

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -325,6 +325,44 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 fi
 
+# Persist image metadata info, script if meta.env found in same directory
+META_INFO_SCRIPT="$(cat << 'EOF'
+#!/bin/sh
+. /usr/local/etc/vscode-dev-containers/meta.env
+
+# Minimal output
+if [ "$1" = "version" ] || [ "$1" = "image-version" ]; then
+    echo "${VERSION}"
+    exit 0
+elif [ "$1" = "release" ]; then
+    echo "${GIT_REPOSITORY_RELEASE}"
+    exit 0
+elif [ "$1" = "content" ] || [ "$1" = "content-url" ] || [ "$1" = "contents" ] || [ "$1" = "contents-url" ]; then
+    echo "${CONTENTS_URL}"
+    exit 0
+fi
+
+#Full output
+echo
+echo "Development container image information"
+echo
+if [ ! -z "${VERSION}" ]; then echo "- Image version: ${VERSION}"; fi
+if [ ! -z "${DEFINITION_ID}" ]; then echo "- Definition ID: ${DEFINITION_ID}"; fi
+if [ ! -z "${VARIANT}" ]; then echo "- Variant: ${VARIANT}"; fi
+if [ ! -z "${GIT_REPOSITORY}" ]; then echo "- Source code repository: ${GIT_REPOSITORY}"; fi
+if [ ! -z "${GIT_REPOSITORY_RELEASE}" ]; then echo "- Source code release/branch: ${GIT_REPOSITORY_RELEASE}"; fi
+if [ ! -z "${CONTENTS_URL}" ]; then echo && echo "More info: ${CONTENTS_URL}"; fi
+echo
+EOF
+)"
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+if [ -f "${SCRIPT_DIR}/meta.env" ]; then
+    mkdir -p /usr/local/etc/vscode-dev-containers/
+    cp -f "${SCRIPT_DIR}/meta.env" /usr/local/etc/vscode-dev-containers/meta.env
+     echo "${META_INFO_SCRIPT}" > /usr/local/bin/devcontainer-info
+    chmod +x /usr/local/bin/devcontainer-info
+fi
+
 # Write marker file
 mkdir -p "$(dirname "${MARKER_FILE}")"
 echo -e "\

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -319,6 +319,44 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 fi
 
+# Persist image metadata info, script if meta.env found in same directory
+META_INFO_SCRIPT="$(cat << 'EOF'
+#!/bin/sh
+. /usr/local/etc/vscode-dev-containers/meta.env
+
+# Minimal output
+if [ "$1" = "version" ] || [ "$1" = "image-version" ]; then
+    echo "${VERSION}"
+    exit 0
+elif [ "$1" = "release" ]; then
+    echo "${GIT_REPOSITORY_RELEASE}"
+    exit 0
+elif [ "$1" = "content" ] || [ "$1" = "content-url" ] || [ "$1" = "contents" ] || [ "$1" = "contents-url" ]; then
+    echo "${CONTENTS_URL}"
+    exit 0
+fi
+
+#Full output
+echo
+echo "Development container image information"
+echo
+if [ ! -z "${VERSION}" ]; then echo "- Image version: ${VERSION}"; fi
+if [ ! -z "${DEFINITION_ID}" ]; then echo "- Definition ID: ${DEFINITION_ID}"; fi
+if [ ! -z "${VARIANT}" ]; then echo "- Variant: ${VARIANT}"; fi
+if [ ! -z "${GIT_REPOSITORY}" ]; then echo "- Source code repository: ${GIT_REPOSITORY}"; fi
+if [ ! -z "${GIT_REPOSITORY_RELEASE}" ]; then echo "- Source code release/branch: ${GIT_REPOSITORY_RELEASE}"; fi
+if [ ! -z "${CONTENTS_URL}" ]; then echo && echo "More info: ${CONTENTS_URL}"; fi
+echo
+EOF
+)"
+SCRIPT_DIR="$(cd $(dirname $0) && pwd)"
+if [ -f "${SCRIPT_DIR}/meta.env" ]; then
+    mkdir -p /usr/local/etc/vscode-dev-containers/
+    cp -f "${SCRIPT_DIR}/meta.env" /usr/local/etc/vscode-dev-containers/meta.env
+     echo "${META_INFO_SCRIPT}" > /usr/local/bin/devcontainer-info
+    chmod +x /usr/local/bin/devcontainer-info
+fi
+
 # Write marker file
 mkdir -p "$(dirname "${MARKER_FILE}")"
 echo -e "\


### PR DESCRIPTION
This PR adds build system capabilities to help developers understand what version of an image they are using - both for triage purposes and just their own information.  It:

1. Adds metadata and a `devcontainer-info` command inside containers that surfaces the injected information.
2. Adds labels to the image to help identify before you get into the image. (e.g. if you download 1-linux you can see in a label what the real version is)
3. Avoids accidently overwriting the "release" value in the history files we write on release - this is essentially a bug, but could cause further confusion.

Most of the PR is actually then adding a stub `meta.env` file into various definitions that is copied in. The build system generates the real one at build time and the common-*.sh scripts optionally add the command to run them.

Example output of the command:

```
$ devcontainer-info

Development container image information

- Image version: 0.201.4
- Definition ID: debian
- Variant: buster
- Source code repository: https://github.com/microsoft/vscode-dev-containers/
- Source code release/branch: v0.167.0

More info: https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian/history/0.201.4.md
```

Then for scriptability:
```
$ devcontainer-info version
0.201.4
$ devcontainer-info release
v0.167.0
$ devcontainer-info content-url
https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian/history/0.201.4.md
```