### PR TITLE
Add Node 16

### DIFF
--- a/containers/javascript-node/.devcontainer/Dockerfile
+++ b/containers/javascript-node/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Node.js version: 14, 12, 10
+# [Choice] Node.js version: 16, 14, 12, 10
 ARG VARIANT=14
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 

--- a/containers/javascript-node/.devcontainer/base.Dockerfile
+++ b/containers/javascript-node/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Node.js version: 14, 12, 10
+# [Choice] Node.js version: 16, 14, 12, 10
 ARG VARIANT=14-buster
 FROM node:${VARIANT}
 
@@ -29,7 +29,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && usermod -a -G npm ${USERNAME} \
     && umask 0002 \
     && mkdir -p ${NPM_GLOBAL} \
-    && chown ${USERNAME}:npm ${NPM_GLOBAL} \
+    && touch /usr/local/etc/npmrc \
+    && chown ${USERNAME}:npm ${NPM_GLOBAL} /usr/local/etc/npmrc \
     && chmod g+s ${NPM_GLOBAL} \
     && npm config -g set prefix ${NPM_GLOBAL} \
     && sudo -u ${USERNAME} npm config -g set prefix ${NPM_GLOBAL} \

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "Node.js",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14
+		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 16
 		"args": { "VARIANT": "14" }
 	},
 

--- a/containers/javascript-node/README.md
+++ b/containers/javascript-node/README.md
@@ -10,12 +10,14 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/javascript-node |
-| *Available image variants* | 10, 12, 14 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
+| *Available image variants* | 10, 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Node.js, JavaScript |
+
+See **[history](history)** for information on the contents of published images.
 
 ## Using this definition
 
@@ -28,19 +30,20 @@ While the definition itself works unmodified, you can select the version of Node
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node` (latest)
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:16`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:14`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:12`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:10`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0-11`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.200-11`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.200.0-11`
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0-12`
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202-12`
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202.0-12`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
 
-Alternatively, you can use the contents of the `Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
+Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 
 Beyond Node.js and `git`, this image / `Dockerfile` includes `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development. [Node Version Manager](https://github.com/nvm-sh/nvm) (`nvm`) is also included in case you need to use a different version of Node.js than the one included in the image.
 

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
-	"variants": ["14-buster", "12-buster", "10-buster","14-stretch", "12-stretch", "10-stretch"],
-	"definitionVersion": "0.201.4",
+	"variants": ["16-buster", "14-buster", "12-buster", "10-buster","14-stretch", "12-stretch", "10-stretch"],
+	"definitionVersion": "0.202.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
@@ -8,6 +8,7 @@
 			"javascript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
+			"16-buster": [ "javascript-node:${VERSION}-16" ],
 			"14-buster": [ "javascript-node:${VERSION}-14" ],
 			"12-buster": [ "javascript-node:${VERSION}-12" ],
 			"10-buster": [ "javascript-node:${VERSION}-10" ]

--- a/containers/typescript-node/.devcontainer/Dockerfile
+++ b/containers/typescript-node/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Node.js version: 14, 12, 10
+# [Choice] Node.js version: 16, 14, 12, 10
 ARG VARIANT=14
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}
 

--- a/containers/typescript-node/.devcontainer/base.Dockerfile
+++ b/containers/typescript-node/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Node.js version: 14, 12, 10
+# [Choice] Node.js version: 16, 14, 12, 10
 ARG VARIANT=14-buster
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "Node.js & TypeScript",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14
+		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 16
 		"args": { 
 			"VARIANT": "14"
 		}

--- a/containers/typescript-node/README.md
+++ b/containers/typescript-node/README.md
@@ -10,12 +10,14 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/typescript-node |
-| *Available image variants* | 10, 12, 14 (([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list)) |
+| *Available image variants* | 10, 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Node.js, TypeScript |
+
+See **[history](history)** for information on the contents of published images.
 
 ## Using this definition
 
@@ -28,19 +30,20 @@ While the definition itself works unmodified, you can select the version of Node
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node` (latest)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:16`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:14`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:12`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:10`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-11`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.200-11`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.200.0-11`
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12`
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202-12`
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202.0-12`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
 
-Alternatively, you can use the contents of the `Dockerfile` or the [JavaScript and Node.js `Dockerfile`](../javascript-node/.devcontainer/base.Dockerfile) to fully customize your container's contents.
+Alternatively, you can use the contents of the `base.Dockerfile` or the [JavaScript and Node.js `base.Dockerfile`](../javascript-node/.devcontainer/base.Dockerfile) to fully customize your container's contents.
 
 Beyond TypeScript, Node.js, and `git`, this image / `Dockerfile` includes `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development. Since `tslint` is [now fully depreicated](https://github.com/palantir/tslint/issues/4534), the definition includes `tslint-to-eslint-config` globally to help you migrate.
 

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
-	"variants": ["14-buster", "12-buster", "10-buster", "14-stretch", "12-stretch", "10-stretch"],
-	"definitionVersion": "0.201.4",
+	"variants": ["16-buster", "14-buster", "12-buster", "10-buster", "14-stretch", "12-stretch", "10-stretch"],
+	"definitionVersion": "0.202.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
@@ -9,6 +9,7 @@
 			"typescript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
+			"16-buster": [ "typescript-node:${VERSION}-16" ],
 			"14-buster": [ "typescript-node:${VERSION}-14" ],
 			"12-buster": [ "typescript-node:${VERSION}-12" ],
 			"10-buster": [ "typescript-node:${VERSION}-10" ]


### PR DESCRIPTION
This PR adds Node.js 16 which was recently released. However, we're currently blocked by the upstream image due to https://github.com/nodejs/docker-node/issues/1466, https://github.com/docker-library/official-images/pull/10030. But we can expect a new `node:16` image soon, and we can merge at that point.  I also pointed out the history files we now have in the READMEs and made a couple corrections.

/cc: @joshspicer @2percentsilk for an example of this kind of update.