### PR TITLE
Fix 'official' typo in common-*.sh scripts

### DIFF
--- a/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/alpine/.devcontainer/library-scripts/common-alpine.sh
+++ b/containers/alpine/.devcontainer/library-scripts/common-alpine.sh
@@ -296,7 +296,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/azure-bicep/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-bicep/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/azure-blockchain/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-blockchain/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/bazel/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/bazel/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/codespaces-linux-stretch/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux-stretch/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/dart/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dart/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/debian/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/debian/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/docker-in-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-in-docker/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/dotnet/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dotnet/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/go/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/java/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/mit-scheme/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/mit-scheme/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/perl/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/perl/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/php/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/php/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/powershell/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/powershell/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/python-3/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/r/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/r/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/ruby/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/rust/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/rust/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/swift/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/swift/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -296,7 +296,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -357,7 +357,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -290,7 +290,7 @@ if [ "${INSTALL_ZSH}" = "true" ]; then
     fi
 
     # Adapted, simplified inline Oh My Zsh! install steps that adds, defaults to a codespaces theme.
-    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for offical script.
+    # See https://github.com/ohmyzsh/ohmyzsh/blob/master/tools/install.sh for official script.
     OH_MY_INSTALL_DIR="${USER_RC_PATH}/.oh-my-zsh"
     if [ ! -d "${OH_MY_INSTALL_DIR}" ] && [ "${INSTALL_OH_MYS}" = "true" ]; then
         TEMPLATE_PATH="${OH_MY_INSTALL_DIR}/templates/zshrc.zsh-template"


### PR DESCRIPTION
Found thanks to https://github.com/client9/misspell/ used in https://github.com/open-telemetry/opentelemetry-dotnet/blob/6b7f2dd77cf9d37260a853fcc95f7b77e296065d/.github/workflows/sanitycheck.yml