### PR TITLE
Bump image versions for upcoming VS Code release

### DIFF
--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.13", "3.12", "3.11", "3.10"],
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",

--- a/containers/codespaces-linux-stretch/definition-manifest.json
+++ b/containers/codespaces-linux-stretch/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.23.4",
+	"definitionVersion": "0.23.5",
 	"build": {
 		"latest": false,
 		"versionedTagsOnly": true,

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "1.3.2",
+	"definitionVersion": "1.3.3",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/cpp/definition-manifest.json
+++ b/containers/cpp/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "focal", "bionic", "stretch"],
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"parent": {

--- a/containers/debian/definition-manifest.json
+++ b/containers/debian/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "stretch"],
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["5.0", "3.1", "2.1"],
-	"definitionVersion": "0.201.5",
+	"definitionVersion": "0.201.6",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["1", "1.16", "1.15"],
-	"definitionVersion": "0.202.4",
+	"definitionVersion": "0.202.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/java-8/definition-manifest.json
+++ b/containers/java-8/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "15", "11" ],
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["16-buster", "14-buster", "12-buster", "10-buster","14-stretch", "12-stretch", "10-stretch"],
-	"definitionVersion": "0.202.0",
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["8", "8.0", "7", "7.4", "7.3"],
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3-anaconda/definition-manifest.json
+++ b/containers/python-3-anaconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.201.3",
+	"definitionVersion": "0.201.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3-miniconda/definition-manifest.json
+++ b/containers/python-3-miniconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.201.3",
+	"definitionVersion": "0.201.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3", "3.9", "3.8", "3.7", "3.6"],
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3", "3.0", "2", "2.7", "2.6", "2.5"],
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/rust/definition-manifest.json
+++ b/containers/rust/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.200.3",
+	"definitionVersion": "0.200.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["16-buster", "14-buster", "12-buster", "10-buster", "14-stretch", "12-stretch", "10-stretch"],
-	"definitionVersion": "0.202.0",
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["focal", "bionic"],
-	"definitionVersion": "0.201.4",
+	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",


### PR DESCRIPTION
/cc @2percentsilk @joshspicer  @alexr00 @chrmarti @jkeech 

PR'ing this for awareness. Given we're in endgame week for VS Code, we should get a monthly update of all images to pick up patches.  This will also land the `devcontainer-info` command into each image along with labels from #828.

I'll cut a 0.175.0 release here to get the changes out.