### PR TITLE
Set "userEnvProbe": "interactiveShell" by default

### DIFF
--- a/container-templates/docker-compose/.devcontainer/devcontainer.json
+++ b/container-templates/docker-compose/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	"dockerComposeFile": "docker-compose.yml",
 
+	// Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+	"userEnvProbe": "interactiveShell",
+
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "app",

--- a/container-templates/dockerfile/.devcontainer/devcontainer.json
+++ b/container-templates/dockerfile/.devcontainer/devcontainer.json
@@ -8,6 +8,9 @@
 		"args": { "VARIANT": "buster" }
 	},
 
+	// Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+	"userEnvProbe": "interactiveShell",
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": null

--- a/container-templates/image/.devcontainer/devcontainer.json
+++ b/container-templates/image/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
 	// Update the 'image' property with your Docker image name.
 	"image": "mcr.microsoft.com/vscode/devcontainers/base:debian-10",
 
+	// Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+	"userEnvProbe": "interactiveShell",
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		// If you are using an Alpine-based image, change this to /bin/ash

--- a/containers/alpine/.devcontainer/devcontainer.json
+++ b/containers/alpine/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
 		// Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12, 3.13
 		"args": { "VARIANT": "3.13" }
 	},
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create. 
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"

--- a/containers/azure-ansible/.devcontainer/devcontainer.json
+++ b/containers/azure-ansible/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"INSTALL_NODE": "true"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"mounts": [
 		// [Optional] Anisble Collections: Uncomment if you want to mount your local .ansible/collections folder.
 		// "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ansible/collections,target=/root/.ansible/collections,type=bind,consistency=cached",

--- a/containers/azure-bicep/.devcontainer/devcontainer.json
+++ b/containers/azure-bicep/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
 	"name": "Azure Bicep (Community)",		
 	"dockerFile": "Dockerfile",
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"

--- a/containers/azure-blockchain/.devcontainer/devcontainer.json
+++ b/containers/azure-blockchain/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Azure Blockchain (Community)",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-cli/.devcontainer/devcontainer.json
+++ b/containers/azure-cli/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
 	"name": "Azure CLI",
 	"dockerFile": "Dockerfile",
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash"

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & C# - .NET Core 2.1",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & C# - .NET Core 3.1",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/azure-functions-java-11/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-11/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & Java 11",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-functions-java-8/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-8/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & Java 8",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-functions-node/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-node/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 		"args": { "VARIANT": "12" }
 	},
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-functions-pwsh/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-pwsh/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
 		}
 	},
 	"forwardPorts": [ 7071 ],
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/usr/bin/pwsh"

--- a/containers/azure-functions-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-python-3/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & Python 3",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings":  {

--- a/containers/azure-machine-learning-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-machine-learning-python-3/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 { 
 	"name": "Azure Machine Learning", 
 	"dockerFile": "Dockerfile", 
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// This line allows you to use Docker runconfigs if you set "sharedVolumes": false
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],

--- a/containers/azure-static-web-apps/.devcontainer/devcontainer.json
+++ b/containers/azure-static-web-apps/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Static Web Apps",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071, 5500 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-terraform/.devcontainer/devcontainer.json
+++ b/containers/azure-terraform/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 			"INSTALL_NODE": "true"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
 	"overrideCommand": false,
 	"runArgs": ["--env-file",".devcontainer/devcontainer.env"],

--- a/containers/bash/.devcontainer/devcontainer.json
+++ b/containers/bash/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
 		"args": { "VARIANT": "debian-10" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/bazel/.devcontainer/devcontainer.json
+++ b/containers/bazel/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 			"BAZEL_DOWNLOAD_SHA": "9808adad931ac652e8ff5022a74507c532250c2091d21d6aebc7064573669cc5"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/codespaces-linux-stretch/.devcontainer/devcontainer.json
+++ b/containers/codespaces-linux-stretch/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 	},
 	"remoteUser": "codespace",
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"workspaceMount": "source=${localWorkspaceFolder},target=/home/codespace/workspace,type=bind,consistency=cached",
 	"workspaceFolder": "/home/codespace/workspace",
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],

--- a/containers/codespaces-linux/.devcontainer/devcontainer.json
+++ b/containers/codespaces-linux/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 	},
 	"remoteUser": "codespace",
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"mounts": ["source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"],
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",

--- a/containers/cpp/.devcontainer/devcontainer.json
+++ b/containers/cpp/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 		"args": { "VARIANT": "debian-10" }
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/dapr-dotnet/.devcontainer/devcontainer.json
+++ b/containers/dapr-dotnet/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {

--- a/containers/dapr-javascript-node/.devcontainer/devcontainer.json
+++ b/containers/dapr-javascript-node/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {

--- a/containers/dart/.devcontainer/devcontainer.json
+++ b/containers/dart/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update VARIANT to pick a Dart version
 		"args": { "VARIANT": "2" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/debian/.devcontainer/devcontainer.json
+++ b/containers/debian/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'VARIANT' to pick an Debian version: buster, stretch
 		"args": { "VARIANT": "buster" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/deno/.devcontainer/devcontainer.json
+++ b/containers/deno/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
     "name": "Deno",
     "dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
     // Set *default* container specific settings.json values on container create.
     "settings": { 

--- a/containers/docker-existing-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-existing-docker-compose/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
 	"name": "Existing Docker Compose (Extend)",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.

--- a/containers/docker-existing-dockerfile/.devcontainer/devcontainer.json
+++ b/containers/docker-existing-dockerfile/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
 	"name": "Existing Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Sets the run context to one level up instead of the .devcontainer folder.
 	"context": "..",

--- a/containers/docker-from-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-from-docker-compose/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {

--- a/containers/docker-from-docker/.devcontainer/devcontainer.json
+++ b/containers/docker-from-docker/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"runArgs": ["--init"],
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {

--- a/containers/docker-in-docker/.devcontainer/devcontainer.json
+++ b/containers/docker-in-docker/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"runArgs": ["--init", "--privileged"],
 	"mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],
 	"overrideCommand": false,
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/dotnet-fsharp/.devcontainer/devcontainer.json
+++ b/containers/dotnet-fsharp/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 			"UPGRADE_PACKAGES": "false"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"

--- a/containers/dotnet-mssql/.devcontainer/devcontainer.json
+++ b/containers/dotnet-mssql/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/dotnet/.devcontainer/devcontainer.json
+++ b/containers/dotnet/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 			"INSTALL_AZURE_CLI": "false"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/elixir-phoenix-postgres/.devcontainer/devcontainer.json
+++ b/containers/elixir-phoenix-postgres/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "elixir",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/elm/.devcontainer/devcontainer.json
+++ b/containers/elm/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Elm (Community)",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/hugo/.devcontainer/devcontainer.json
+++ b/containers/hugo/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
 			"NODE_VERSION": "14",
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/java-8/.devcontainer/devcontainer.json
+++ b/containers/java-8/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/javascript-node-azurite/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-azurite/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/javascript-node-mongo/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-mongo/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/javascript-node-postgres/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-postgres/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 16
 		"args": { "VARIANT": "14" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/jekyll/.devcontainer/devcontainer.json
+++ b/containers/jekyll/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 			"NODE_VERSION": "lts/*"
 		}	
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/julia/.devcontainer/devcontainer.json
+++ b/containers/julia/.devcontainer/devcontainer.json
@@ -4,5 +4,6 @@
 	"image": "ghcr.io/julia-vscode/julia-devcontainer",
 	"extensions": ["julialang.language-julia"],
 	"postCreateCommand": "/julia-devcontainer-scripts/postcreate.jl",
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 }

--- a/containers/jupyter-datascience-notebooks/.devcontainer/devcontainer.json
+++ b/containers/jupyter-datascience-notebooks/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/kubernetes-helm-minikube/.devcontainer/devcontainer.json
+++ b/containers/kubernetes-helm-minikube/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 		"source=minikube-config,target=/home/vscode/.minikube,type=volume",
 	],
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/kubernetes-helm/.devcontainer/devcontainer.json
+++ b/containers/kubernetes-helm/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Kubernetes - Local Configuration",
 	"dockerFile": "Dockerfile",
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	"remoteEnv": {
 		"SYNC_LOCALHOST_KUBECONFIG": "true"

--- a/containers/markdown/.devcontainer/devcontainer.json
+++ b/containers/markdown/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Markdown Editing",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/mit-scheme/.devcontainer/devcontainer.json
+++ b/containers/mit-scheme/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'TARGET_SCHEME_VERSION' to pick an MIT-Scheme version: 11.1
 		"args": { "TARGET_SCHEME_VERSION": "11.1" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/perl/.devcontainer/devcontainer.json
+++ b/containers/perl/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 		"args": { "VARIANT": "5" }
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/php-mariadb/.devcontainer/devcontainer.json
+++ b/containers/php-mariadb/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/containers/powershell/.devcontainer/devcontainer.json
+++ b/containers/powershell/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "PowerShell",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3-anaconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-anaconda/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
+++ b/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
@@ -8,6 +8,8 @@
 			"VARIANT": "3.8"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/containers/python-3-miniconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-miniconda/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3-postgres/.devcontainer/devcontainer.json
+++ b/containers/python-3-postgres/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update VARIANT to pick a specific R version: latest, ... ,4.0.1 , 4.0.0
 		"args": { "VARIANT": "latest" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/reasonml/.devcontainer/devcontainer.json
+++ b/containers/reasonml/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "ReasonML (Community)",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ruby-rails/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ruby-sinatra/.devcontainer/devcontainer.json
+++ b/containers/ruby-sinatra/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/rust/.devcontainer/devcontainer.json
+++ b/containers/rust/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 		"dockerfile": "Dockerfile"
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/swift/.devcontainer/devcontainer.json
+++ b/containers/swift/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
 		"--security-opt",

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 			"VARIANT": "14"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ubuntu/.devcontainer/devcontainer.json
+++ b/containers/ubuntu/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic
 		"args": { "VARIANT": "focal" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/vue/.devcontainer/devcontainer.json
+++ b/containers/vue/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 		// Update 'VARIANT' to pick a Node version: 10, 12, 14
 		"args": { "VARIANT": "14" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/repository-containers/images/github.com/microsoft/vscode/.devcontainer/devcontainer.json
+++ b/repository-containers/images/github.com/microsoft/vscode/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 	"workspaceFolder": "/home/node/workspace/vscode",
 	"overrideCommand": false,
 	"runArgs": [ "--init", "--security-opt", "seccomp=unconfined" ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	"settings": {
 		// zsh is also available


### PR DESCRIPTION
This PR is a proposal to switch to `interactiveShell` mode by default for definitions here.  We hear enough about confusion that `~/.bashrc` and `~/.zshrc` are not getting fired for processes in VS Code that I think this makes sense to recommend despite a minimal perf it on startup.

We didn't do this initially since Codespaces didn't support the property, but I believe that's been resolved.

I should also add that the problem with "login" is that most images reset the environment which wipes out any `ENV` set variables. `common-debian.sh` has a script to fix this for anything set up until that point, but it seems like a bad starting point for those that are creating custom Dockerfiles.

//cc: @chrmarti @bamurtaugh @2percentsilk @joshspicer 