### PR TITLE
Deprecate Node 10, Ruby 2.5, misc cleanup

### DIFF
--- a/container-templates/docker-compose/.devcontainer/devcontainer.json
+++ b/container-templates/docker-compose/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	"dockerComposeFile": "docker-compose.yml",
 
+	// Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+	"userEnvProbe": "interactiveShell",
+
 	// The 'service' property is the name of the service for the container that VS Code should
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "app",

--- a/container-templates/dockerfile/.devcontainer/devcontainer.json
+++ b/container-templates/dockerfile/.devcontainer/devcontainer.json
@@ -8,6 +8,9 @@
 		"args": { "VARIANT": "buster" }
 	},
 
+	// Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+	"userEnvProbe": "interactiveShell",
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": null

--- a/container-templates/image/.devcontainer/devcontainer.json
+++ b/container-templates/image/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
 	// Update the 'image' property with your Docker image name.
 	"image": "mcr.microsoft.com/vscode/devcontainers/base:debian-10",
 
+	// Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+	"userEnvProbe": "interactiveShell",
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		// If you are using an Alpine-based image, change this to /bin/ash

--- a/containers/alpine/.devcontainer/devcontainer.json
+++ b/containers/alpine/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
 		// Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12, 3.13
 		"args": { "VARIANT": "3.13" }
 	},
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create. 
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"

--- a/containers/alpine/README.md
+++ b/containers/alpine/README.md
@@ -17,12 +17,14 @@
 | *Container OS* | Alpine Linux |
 | *Languages, platforms* | Any |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
  While the definition itself works unmodified, you can select the version of Alpine the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "3.10" }
+"args": { "VARIANT": "3.12" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
@@ -31,14 +33,15 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.10`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.11`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.12`
+- `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.13`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/base:0-alpine`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200-alpine`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200.0-alpine`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201-alpine`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201.5-alpine`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/azure-ansible/.devcontainer/devcontainer.json
+++ b/containers/azure-ansible/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"INSTALL_NODE": "true"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"mounts": [
 		// [Optional] Anisble Collections: Uncomment if you want to mount your local .ansible/collections folder.
 		// "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ansible/collections,target=/root/.ansible/collections,type=bind,consistency=cached",

--- a/containers/azure-bicep/.devcontainer/devcontainer.json
+++ b/containers/azure-bicep/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
 	"name": "Azure Bicep (Community)",		
 	"dockerFile": "Dockerfile",
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"

--- a/containers/azure-blockchain/.devcontainer/devcontainer.json
+++ b/containers/azure-blockchain/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Azure Blockchain (Community)",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-cli/.devcontainer/devcontainer.json
+++ b/containers/azure-cli/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
 	"name": "Azure CLI",
 	"dockerFile": "Dockerfile",
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash"

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & C# - .NET Core 2.1",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & C# - .NET Core 3.1",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/azure-functions-java-11/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-11/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & Java 11",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-functions-java-8/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-8/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & Java 8",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-functions-node/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-node/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 		"args": { "VARIANT": "12" }
 	},
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-functions-pwsh/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-pwsh/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
 		}
 	},
 	"forwardPorts": [ 7071 ],
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/usr/bin/pwsh"

--- a/containers/azure-functions-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-python-3/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Functions & Python 3",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings":  {

--- a/containers/azure-machine-learning-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-machine-learning-python-3/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 { 
 	"name": "Azure Machine Learning", 
 	"dockerFile": "Dockerfile", 
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// This line allows you to use Docker runconfigs if you set "sharedVolumes": false
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ],

--- a/containers/azure-static-web-apps/.devcontainer/devcontainer.json
+++ b/containers/azure-static-web-apps/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Azure Static Web Apps",
 	"dockerFile": "Dockerfile",
 	"forwardPorts": [ 7071, 5500 ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/azure-terraform/.devcontainer/devcontainer.json
+++ b/containers/azure-terraform/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 			"INSTALL_NODE": "true"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
 	"overrideCommand": false,
 	"runArgs": ["--env-file",".devcontainer/devcontainer.env"],

--- a/containers/bash/.devcontainer/devcontainer.json
+++ b/containers/bash/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
 		"args": { "VARIANT": "debian-10" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/bazel/.devcontainer/devcontainer.json
+++ b/containers/bazel/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 			"BAZEL_DOWNLOAD_SHA": "9808adad931ac652e8ff5022a74507c532250c2091d21d6aebc7064573669cc5"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/codespaces-linux-stretch/.devcontainer/devcontainer.json
+++ b/containers/codespaces-linux-stretch/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 	},
 	"remoteUser": "codespace",
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"workspaceMount": "source=${localWorkspaceFolder},target=/home/codespace/workspace,type=bind,consistency=cached",
 	"workspaceFolder": "/home/codespace/workspace",
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],

--- a/containers/codespaces-linux-stretch/README.md
+++ b/containers/codespaces-linux-stretch/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python, Node.js, JavaScript, TypeScript, C++, Java, C#, F#, .NET Core, PHP, PowerShell, Go, Ruby, Rust |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Description
 
 > **Note:** This is the deprecated Debian 9/Strech based image. See the [codespaces-linux definition](../codespaces-linux) for the current Ubuntu 20.04/Focal based image.
@@ -29,10 +31,10 @@ The container includes the `zsh` (and Oh My Zsh!) and `fish` shells that you can
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. However, **note that only the most recent image is pre-cached in Codespaces which is currently the [Ubuntu 20.04 based image](../codespaces-linux)**. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/universal:0-stretch`
-- `mcr.microsoft.com/vscode/devcontainers/universal:0.22-stretch`
-- `mcr.microsoft.com/vscode/devcontainers/universal:0.22.3-stretch`
+- `mcr.microsoft.com/vscode/devcontainers/universal:0.23-stretch`
+- `mcr.microsoft.com/vscode/devcontainers/universal:0.23.5-stretch`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/universal/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/universal/tags/list).
 
 ## Accessing the container using SSH, SCP, or SSHFS
 

--- a/containers/codespaces-linux/.devcontainer/devcontainer.json
+++ b/containers/codespaces-linux/.devcontainer/devcontainer.json
@@ -28,6 +28,7 @@
 	},
 	"remoteUser": "codespace",
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"mounts": ["source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"],
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",

--- a/containers/codespaces-linux/README.md
+++ b/containers/codespaces-linux/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | Python, Node.js, JavaScript, TypeScript, C++, Java, C#, F#, .NET Core, PHP, PowerShell, Go, Ruby, Rust |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Description
 
 While language specific development containers can be useful, in some cases you may want to use more than one in a project without having to set them all up. In other cases you may be looking to create a general "sandbox" container you intend to use with multiple projects or repositories. The large container image generated here (`mcr.microsoft.com/vscode/devcontainers/universal:linux`) includes a number of runtime versions for popular languages lke Python, Node, PHP, Java, Go, C++, Ruby, Go, Rust and .NET Core/C# - many of which are [inherited from the Oryx build image](https://github.com/microsoft/oryx#supported-platforms) it is based on.
@@ -29,10 +31,10 @@ The container includes the `zsh` (and Oh My Zsh!) and `fish` shells that you can
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. However, **note that only the most recent image is pre-cached in Codespaces**. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/universal:1-focal`
-- `mcr.microsoft.com/vscode/devcontainers/universal:1.1-focal`
-- `mcr.microsoft.com/vscode/devcontainers/universal:1.1.1-focal`
+- `mcr.microsoft.com/vscode/devcontainers/universal:1.3-focal`
+- `mcr.microsoft.com/vscode/devcontainers/universal:1.3.3-focal`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/universal/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/universal/tags/list).
 
 ## Accessing the container using SSH, SCP, or SSHFS
 

--- a/containers/cpp/.devcontainer/devcontainer.json
+++ b/containers/cpp/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 		"args": { "VARIANT": "debian-10" }
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/cpp/README.md
+++ b/containers/cpp/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian, Ubuntu |
 | *Languages, platforms* | C++ |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of Debian or Ubuntu the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -37,10 +39,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/cpp:0-focal`
-- `mcr.microsoft.com/vscode/devcontainers/cpp:0.200-focal`
-- `mcr.microsoft.com/vscode/devcontainers/cpp:0.200.0-focal`
+- `mcr.microsoft.com/vscode/devcontainers/cpp:0.201-focal`
+- `mcr.microsoft.com/vscode/devcontainers/cpp:0.201.5-focal`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/dapr-dotnet/.devcontainer/devcontainer.json
+++ b/containers/dapr-dotnet/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {

--- a/containers/dapr-javascript-node/.devcontainer/devcontainer.json
+++ b/containers/dapr-javascript-node/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {

--- a/containers/dart/.devcontainer/devcontainer.json
+++ b/containers/dart/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update VARIANT to pick a Dart version
 		"args": { "VARIANT": "2" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/debian/.devcontainer/devcontainer.json
+++ b/containers/debian/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'VARIANT' to pick an Debian version: buster, stretch
 		"args": { "VARIANT": "buster" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/debian/README.md
+++ b/containers/debian/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Any |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of Debian the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -34,10 +36,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/base:0-buster`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200-buster`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200.0-buster`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201-buster`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201.5-buster`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/deno/.devcontainer/devcontainer.json
+++ b/containers/deno/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
     "name": "Deno",
     "dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
     // Set *default* container specific settings.json values on container create.
     "settings": { 

--- a/containers/docker-existing-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-existing-docker-compose/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 // If you want to run as a non-root user in the container, see .devcontainer/docker-compose.yml.
 {
 	"name": "Existing Docker Compose (Extend)",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.

--- a/containers/docker-existing-dockerfile/.devcontainer/devcontainer.json
+++ b/containers/docker-existing-dockerfile/.devcontainer/devcontainer.json
@@ -1,5 +1,6 @@
 {
 	"name": "Existing Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Sets the run context to one level up instead of the .devcontainer folder.
 	"context": "..",

--- a/containers/docker-from-docker-compose/.devcontainer/devcontainer.json
+++ b/containers/docker-from-docker-compose/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {

--- a/containers/docker-from-docker/.devcontainer/devcontainer.json
+++ b/containers/docker-from-docker/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"runArgs": ["--init"],
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	"remoteEnv": {

--- a/containers/docker-in-docker/.devcontainer/devcontainer.json
+++ b/containers/docker-in-docker/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"runArgs": ["--init", "--privileged"],
 	"mounts": ["source=dind-var-lib-docker,target=/var/lib/docker,type=volume"],
 	"overrideCommand": false,
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Use this environment variable if you need to bind mount your local source code into a new container.
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/dotnet-fsharp/.devcontainer/devcontainer.json
+++ b/containers/dotnet-fsharp/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 			"UPGRADE_PACKAGES": "false"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash"

--- a/containers/dotnet-mssql/.devcontainer/devcontainer.json
+++ b/containers/dotnet-mssql/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/dotnet/.devcontainer/devcontainer.json
+++ b/containers/dotnet/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 			"INSTALL_AZURE_CLI": "false"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | .NET, .NET Core, C# |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While this definition should work unmodified, you can select the version of .NET / .NET Core the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -35,10 +37,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/dotnet:0-3.1`
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.200-3.1`
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.200.0-3.1`
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.201-3.1`
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.6-3.1`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/elixir-phoenix-postgres/.devcontainer/devcontainer.json
+++ b/containers/elixir-phoenix-postgres/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "elixir",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/elm/.devcontainer/devcontainer.json
+++ b/containers/elm/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Elm (Community)",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Go |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of Go the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -35,10 +37,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/go:0-1.15`
-- `mcr.microsoft.com/vscode/devcontainers/go:0.200-1.15`
-- `mcr.microsoft.com/vscode/devcontainers/go:0.200.0-1.15`
+- `mcr.microsoft.com/vscode/devcontainers/go:0.202-1.15`
+- `mcr.microsoft.com/vscode/devcontainers/go:0.202.5-1.15`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,12 +1,15 @@
 {
-	"variants": ["1", "1.16", "1.15"],
+	"variants": ["1.16", "1.15"],
 	"definitionVersion": "0.202.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
 			"go:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"1.16": [ "go:${VERSION}-1" ]
+		}
 	},
 	"dependencies": {
 		"image": "golang:${VARIANT}",

--- a/containers/hugo/.devcontainer/devcontainer.json
+++ b/containers/hugo/.devcontainer/devcontainer.json
@@ -15,6 +15,7 @@
 			"NODE_VERSION": "14",
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/java-8/.devcontainer/devcontainer.json
+++ b/containers/java-8/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/java-8/README.md
+++ b/containers/java-8/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Java |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 > **Note:** A version of this [definition for **newer JDKs**](../java) is also available!
@@ -29,10 +31,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/java:0-8`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.200-8`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.200.0-8`
+- `mcr.microsoft.com/vscode/devcontainers/java:0.201-8`
+- `mcr.microsoft.com/vscode/devcontainers/java:0.201.5-8`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/java/README.md
+++ b/containers/java/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Java |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 > **Note:** A version of this [definition for **JDK 8**](../java-8) is also available!
@@ -36,10 +38,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/java:0-11`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.200-11`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.200.0-11`
+- `mcr.microsoft.com/vscode/devcontainers/java:0.201-11`
+- `mcr.microsoft.com/vscode/devcontainers/java:0.201.5-11`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/javascript-node-azurite/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-azurite/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/javascript-node-mongo/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-mongo/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/javascript-node-postgres/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-postgres/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/javascript-node/.devcontainer/Dockerfile
+++ b/containers/javascript-node/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12, 10
-ARG VARIANT=14
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/javascript-node/.devcontainer/base.Dockerfile
+++ b/containers/javascript-node/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12, 10
-ARG VARIANT=14-buster
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16-buster
 FROM node:${VARIANT}
 
 # [Option] Install zsh

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -2,8 +2,8 @@
 	"name": "Node.js",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 16
-		"args": { "VARIANT": "14" }
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
+		"args": { "VARIANT": "16" }
 	},
 	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 16
 		"args": { "VARIANT": "14" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/javascript-node/README.md
+++ b/containers/javascript-node/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/javascript-node |
-| *Available image variants* | 10, 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
+| *Available image variants* | 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -33,13 +33,12 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:16`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:14`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:12`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:10`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:0-12`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202-12`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202.0-12`
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202.1-12`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
 

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["16-buster", "14-buster", "12-buster", "10-buster","14-stretch", "12-stretch", "10-stretch"],
+	"variants": ["16-buster", "14-buster", "12-buster", "14-stretch", "12-stretch"],
 	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
@@ -10,8 +10,7 @@
 		"variantTags": {
 			"16-buster": [ "javascript-node:${VERSION}-16" ],
 			"14-buster": [ "javascript-node:${VERSION}-14" ],
-			"12-buster": [ "javascript-node:${VERSION}-12" ],
-			"10-buster": [ "javascript-node:${VERSION}-10" ]
+			"12-buster": [ "javascript-node:${VERSION}-12" ]
 		}
 	}, 
 	"dependencies": {

--- a/containers/jekyll/.devcontainer/devcontainer.json
+++ b/containers/jekyll/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 			"NODE_VERSION": "lts/*"
 		}	
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/julia/.devcontainer/devcontainer.json
+++ b/containers/julia/.devcontainer/devcontainer.json
@@ -4,5 +4,6 @@
 	"image": "ghcr.io/julia-vscode/julia-devcontainer",
 	"extensions": ["julialang.language-julia"],
 	"postCreateCommand": "/julia-devcontainer-scripts/postcreate.jl",
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 }

--- a/containers/jupyter-datascience-notebooks/.devcontainer/devcontainer.json
+++ b/containers/jupyter-datascience-notebooks/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/kubernetes-helm-minikube/.devcontainer/devcontainer.json
+++ b/containers/kubernetes-helm-minikube/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 		"source=minikube-config,target=/home/vscode/.minikube,type=volume",
 	],
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/kubernetes-helm/.devcontainer/devcontainer.json
+++ b/containers/kubernetes-helm/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
 	"name": "Kubernetes - Local Configuration",
 	"dockerFile": "Dockerfile",
 	"overrideCommand": false,
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	"remoteEnv": {
 		"SYNC_LOCALHOST_KUBECONFIG": "true"

--- a/containers/markdown/.devcontainer/devcontainer.json
+++ b/containers/markdown/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "Markdown Editing",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/mit-scheme/.devcontainer/devcontainer.json
+++ b/containers/mit-scheme/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'TARGET_SCHEME_VERSION' to pick an MIT-Scheme version: 11.1
 		"args": { "TARGET_SCHEME_VERSION": "11.1" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/perl/.devcontainer/devcontainer.json
+++ b/containers/perl/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 		"args": { "VARIANT": "5" }
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/php-mariadb/.devcontainer/devcontainer.json
+++ b/containers/php-mariadb/.devcontainer/devcontainer.json
@@ -4,7 +4,8 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
-	
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/containers/php/README.md
+++ b/containers/php/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | PHP |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of PHP the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -37,10 +39,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/php:0-7`
-- `mcr.microsoft.com/vscode/devcontainers/php:0.200-7`
-- `mcr.microsoft.com/vscode/devcontainers/php:0.200.0-7`
+- `mcr.microsoft.com/vscode/devcontainers/php:0.201-7`
+- `mcr.microsoft.com/vscode/devcontainers/php:0.201.5-7`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,12 +1,16 @@
 {
-	"variants": ["8", "8.0", "7", "7.4", "7.3"],
+	"variants": ["8.0", "7.4", "7.3"],
 	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
 			"php:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"8.0": [ "php:${VERSION}-8" ],
+			"7.4": [ "php:${VERSION}-7" ]
+		}
 	},
 	"dependencies": {
 		"image": "php:${VARIANT}",

--- a/containers/powershell/.devcontainer/devcontainer.json
+++ b/containers/powershell/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "PowerShell",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3-anaconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-anaconda/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3-anaconda/README.md
+++ b/containers/python-3-anaconda/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python, Anaconda |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 ### Configuration
@@ -27,10 +29,10 @@ While the definition itself works unmodified, you can also directly reference pr
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/anaconda:0-3`
-- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.200-3`
-- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.200.0-3`
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.201-3`
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.201.4-3`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/anaconda/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/anaconda/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
+++ b/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
@@ -8,6 +8,8 @@
 			"VARIANT": "3.8"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
+
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"terminal.integrated.shell.linux": "/bin/bash",

--- a/containers/python-3-miniconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-miniconda/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3-miniconda/README.md
+++ b/containers/python-3-miniconda/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python, Anaconda, Miniconda |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 ### Configuration
@@ -27,10 +29,10 @@ While the definition itself works unmodified, you can also directly reference pr
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/miniconda:0-3`
-- `mcr.microsoft.com/vscode/devcontainers/miniconda:0.200-3`
-- `mcr.microsoft.com/vscode/devcontainers/miniconda:0.200.0-3`
+- `mcr.microsoft.com/vscode/devcontainers/miniconda:0.201-3`
+- `mcr.microsoft.com/vscode/devcontainers/miniconda:0.201.4-3`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/miniconda/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/miniconda/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/python-3-postgres/.devcontainer/devcontainer.json
+++ b/containers/python-3-postgres/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 ### Configuration
@@ -38,10 +40,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/python:0-3.9`
-- `mcr.microsoft.com/vscode/devcontainers/python:0.200-3.9`
-- `mcr.microsoft.com/vscode/devcontainers/python:0.200.0-3.9`
+- `mcr.microsoft.com/vscode/devcontainers/python:0.201-3.9`
+- `mcr.microsoft.com/vscode/devcontainers/python:0.201.5-3.9`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize the your container's contents or build for a container architecture the image does not support.
 

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,12 +1,15 @@
 {
-	"variants": ["3", "3.9", "3.8", "3.7", "3.6"],
+	"variants": ["3.9", "3.8", "3.7", "3.6"],
 	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
 			"python:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"3.9": [ "python:${VERSION}-3" ]
+		}
 	},
 	"dependencies": {
 		"image": "python:${VARIANT}",

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update VARIANT to pick a specific R version: latest, ... ,4.0.1 , 4.0.0
 		"args": { "VARIANT": "latest" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/containers/reasonml/.devcontainer/devcontainer.json
+++ b/containers/reasonml/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
 	"name": "ReasonML (Community)",
 	"dockerFile": "Dockerfile",
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ruby-rails/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ruby-sinatra/.devcontainer/devcontainer.json
+++ b/containers/ruby-sinatra/.devcontainer/devcontainer.json
@@ -8,6 +8,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
 ARG VARIANT=2
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
 ARG VARIANT=2
 FROM ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
 			"VARIANT": "3",
 			// Options
 			"INSTALL_NODE": "true",

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ruby/README.md
+++ b/containers/ruby/README.md
@@ -10,12 +10,14 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/ruby |
-| *Available image variants* | 3, 3.0, 2, 2.7, 2.6, 2.5 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
+| *Available image variants* | 3, 3.0, 2, 2.7, 2.6 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Ruby |
+
+See **[history](history)** for information on the contents of published images.
 
 ## Using this definition
 
@@ -33,15 +35,14 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2`
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2.7`
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2.6`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:2.5`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/ruby:0-3`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0.200-3`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0.200.0-3`
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.201-3`
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.201.5-3`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,12 +1,16 @@
 {
-	"variants": ["3", "3.0", "2", "2.7", "2.6", "2.5"],
+	"variants": ["3.0", "2.7", "2.6"],
 	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
 			"ruby:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"3.0": [ "ruby:${VERSION}-3" ],
+			"2.7": [ "ruby:${VERSION}-2" ]
+		}
 	},
 	"dependencies": {
 		"image": "ruby:${VARIANT}",

--- a/containers/rust/.devcontainer/devcontainer.json
+++ b/containers/rust/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 		"dockerfile": "Dockerfile"
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/rust/README.md
+++ b/containers/rust/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Rust |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 This definition does not require any special steps to use. Note that the `Cargo.toml` file in the root of this folder is for the test project and can be ignored.
@@ -28,9 +30,9 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/vscode/devcontainers/rust:0-1`
 - `mcr.microsoft.com/vscode/devcontainers/rust:0.200-1`
-- `mcr.microsoft.com/vscode/devcontainers/rust:0.200.0-1`
+- `mcr.microsoft.com/vscode/devcontainers/rust:0.200.4-1`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/rust/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/rust/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/swift/.devcontainer/devcontainer.json
+++ b/containers/swift/.devcontainer/devcontainer.json
@@ -10,6 +10,7 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
 		"--security-opt",

--- a/containers/typescript-node/.devcontainer/Dockerfile
+++ b/containers/typescript-node/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12, 10
-ARG VARIANT=14
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/typescript-node/.devcontainer/base.Dockerfile
+++ b/containers/typescript-node/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12, 10
-ARG VARIANT=14-buster
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16-buster
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # Install tslint, typescript. eslint is installed by javascript image

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -7,6 +7,7 @@
 			"VARIANT": "14"
 		}
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
 	"name": "Node.js & TypeScript",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 16
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
 		"args": { 
-			"VARIANT": "14"
+			"VARIANT": "16"
 		}
 	},
 	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes

--- a/containers/typescript-node/README.md
+++ b/containers/typescript-node/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/typescript-node |
-| *Available image variants* | 10, 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list)) |
+| *Available image variants* | 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -33,13 +33,12 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:16`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:14`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:12`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:10`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202-12`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202.0-12`
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202.1-12`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
 

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["16-buster", "14-buster", "12-buster", "10-buster", "14-stretch", "12-stretch", "10-stretch"],
+	"variants": ["16-buster", "14-buster", "12-buster", "14-stretch", "12-stretch"],
 	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
@@ -11,8 +11,7 @@
 		"variantTags": {
 			"16-buster": [ "typescript-node:${VERSION}-16" ],
 			"14-buster": [ "typescript-node:${VERSION}-14" ],
-			"12-buster": [ "typescript-node:${VERSION}-12" ],
-			"10-buster": [ "typescript-node:${VERSION}-10" ]
+			"12-buster": [ "typescript-node:${VERSION}-12" ]
 		}
 	},
 	"dependencies": {

--- a/containers/ubuntu/.devcontainer/devcontainer.json
+++ b/containers/ubuntu/.devcontainer/devcontainer.json
@@ -5,6 +5,7 @@
 		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic
 		"args": { "VARIANT": "focal" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 

--- a/containers/ubuntu/README.md
+++ b/containers/ubuntu/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | Any |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of Ubuntu the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -34,10 +36,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/base:0-focal`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200-focal`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200.0-focal`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201-focal`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201.4-focal`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
 
 Alternatively, you can use the contents of the `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/vue/.devcontainer/devcontainer.json
+++ b/containers/vue/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
 		// Update 'VARIANT' to pick a Node version: 10, 12, 14
 		"args": { "VARIANT": "14" }
 	},
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {

--- a/repository-containers/images/github.com/microsoft/vscode/.devcontainer/devcontainer.json
+++ b/repository-containers/images/github.com/microsoft/vscode/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
 	"workspaceFolder": "/home/node/workspace/vscode",
 	"overrideCommand": false,
 	"runArgs": [ "--init", "--security-opt", "seccomp=unconfined" ],
+	"userEnvProbe": "interactiveShell", // Fire ~/.bashrc, ~/.zshrc before starting VS Code processes
 
 	"settings": {
 		// zsh is also available


### PR DESCRIPTION
PR also adds references to the "history" folder and reduces the number of unique images that have to be built by using the `variantTags` option to tag single digit versions of Python (3), PHP (8, 7), Go (1), and Ruby (3, 2).