### PR TITLE
Deprecate Node 10, Ruby 2.5, misc cleanup

### DIFF
--- a/containers/alpine/README.md
+++ b/containers/alpine/README.md
@@ -17,12 +17,14 @@
 | *Container OS* | Alpine Linux |
 | *Languages, platforms* | Any |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
  While the definition itself works unmodified, you can select the version of Alpine the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "3.10" }
+"args": { "VARIANT": "3.12" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
@@ -31,14 +33,15 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.10`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.11`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.12`
+- `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.13`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/base:0-alpine`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200-alpine`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200.0-alpine`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201-alpine`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201.5-alpine`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/codespaces-linux-stretch/README.md
+++ b/containers/codespaces-linux-stretch/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python, Node.js, JavaScript, TypeScript, C++, Java, C#, F#, .NET Core, PHP, PowerShell, Go, Ruby, Rust |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Description
 
 > **Note:** This is the deprecated Debian 9/Strech based image. See the [codespaces-linux definition](../codespaces-linux) for the current Ubuntu 20.04/Focal based image.
@@ -29,10 +31,10 @@ The container includes the `zsh` (and Oh My Zsh!) and `fish` shells that you can
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. However, **note that only the most recent image is pre-cached in Codespaces which is currently the [Ubuntu 20.04 based image](../codespaces-linux)**. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/universal:0-stretch`
-- `mcr.microsoft.com/vscode/devcontainers/universal:0.22-stretch`
-- `mcr.microsoft.com/vscode/devcontainers/universal:0.22.3-stretch`
+- `mcr.microsoft.com/vscode/devcontainers/universal:0.23-stretch`
+- `mcr.microsoft.com/vscode/devcontainers/universal:0.23.5-stretch`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/universal/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/universal/tags/list).
 
 ## Accessing the container using SSH, SCP, or SSHFS
 

--- a/containers/codespaces-linux/README.md
+++ b/containers/codespaces-linux/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | Python, Node.js, JavaScript, TypeScript, C++, Java, C#, F#, .NET Core, PHP, PowerShell, Go, Ruby, Rust |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Description
 
 While language specific development containers can be useful, in some cases you may want to use more than one in a project without having to set them all up. In other cases you may be looking to create a general "sandbox" container you intend to use with multiple projects or repositories. The large container image generated here (`mcr.microsoft.com/vscode/devcontainers/universal:linux`) includes a number of runtime versions for popular languages lke Python, Node, PHP, Java, Go, C++, Ruby, Go, Rust and .NET Core/C# - many of which are [inherited from the Oryx build image](https://github.com/microsoft/oryx#supported-platforms) it is based on.
@@ -29,10 +31,10 @@ The container includes the `zsh` (and Oh My Zsh!) and `fish` shells that you can
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. However, **note that only the most recent image is pre-cached in Codespaces**. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/universal:1-focal`
-- `mcr.microsoft.com/vscode/devcontainers/universal:1.1-focal`
-- `mcr.microsoft.com/vscode/devcontainers/universal:1.1.1-focal`
+- `mcr.microsoft.com/vscode/devcontainers/universal:1.3-focal`
+- `mcr.microsoft.com/vscode/devcontainers/universal:1.3.3-focal`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/universal/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/universal/tags/list).
 
 ## Accessing the container using SSH, SCP, or SSHFS
 

--- a/containers/cpp/README.md
+++ b/containers/cpp/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian, Ubuntu |
 | *Languages, platforms* | C++ |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of Debian or Ubuntu the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -37,10 +39,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/cpp:0-focal`
-- `mcr.microsoft.com/vscode/devcontainers/cpp:0.200-focal`
-- `mcr.microsoft.com/vscode/devcontainers/cpp:0.200.0-focal`
+- `mcr.microsoft.com/vscode/devcontainers/cpp:0.201-focal`
+- `mcr.microsoft.com/vscode/devcontainers/cpp:0.201.5-focal`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/debian/README.md
+++ b/containers/debian/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Any |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of Debian the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -34,10 +36,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/base:0-buster`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200-buster`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200.0-buster`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201-buster`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201.5-buster`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | .NET, .NET Core, C# |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While this definition should work unmodified, you can select the version of .NET / .NET Core the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -35,10 +37,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/dotnet:0-3.1`
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.200-3.1`
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.200.0-3.1`
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.201-3.1`
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.6-3.1`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Go |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of Go the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -35,10 +37,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/go:0-1.15`
-- `mcr.microsoft.com/vscode/devcontainers/go:0.200-1.15`
-- `mcr.microsoft.com/vscode/devcontainers/go:0.200.0-1.15`
+- `mcr.microsoft.com/vscode/devcontainers/go:0.202-1.15`
+- `mcr.microsoft.com/vscode/devcontainers/go:0.202.5-1.15`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,12 +1,15 @@
 {
-	"variants": ["1", "1.16", "1.15"],
+	"variants": ["1.16", "1.15"],
 	"definitionVersion": "0.202.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
 			"go:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"1.16": [ "go:${VERSION}-1" ]
+		}
 	},
 	"dependencies": {
 		"image": "golang:${VARIANT}",

--- a/containers/java-8/README.md
+++ b/containers/java-8/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Java |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 > **Note:** A version of this [definition for **newer JDKs**](../java) is also available!
@@ -29,10 +31,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/java:0-8`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.200-8`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.200.0-8`
+- `mcr.microsoft.com/vscode/devcontainers/java:0.201-8`
+- `mcr.microsoft.com/vscode/devcontainers/java:0.201.5-8`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/java/README.md
+++ b/containers/java/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Java |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 > **Note:** A version of this [definition for **JDK 8**](../java-8) is also available!
@@ -36,10 +38,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/java:0-11`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.200-11`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.200.0-11`
+- `mcr.microsoft.com/vscode/devcontainers/java:0.201-11`
+- `mcr.microsoft.com/vscode/devcontainers/java:0.201.5-11`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/javascript-node/.devcontainer/Dockerfile
+++ b/containers/javascript-node/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12, 10
-ARG VARIANT=14
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/javascript-node/.devcontainer/base.Dockerfile
+++ b/containers/javascript-node/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12, 10
-ARG VARIANT=14-buster
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16-buster
 FROM node:${VARIANT}
 
 # [Option] Install zsh

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -2,8 +2,8 @@
 	"name": "Node.js",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 16
-		"args": { "VARIANT": "14" }
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
+		"args": { "VARIANT": "16" }
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/containers/javascript-node/README.md
+++ b/containers/javascript-node/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/javascript-node |
-| *Available image variants* | 10, 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
+| *Available image variants* | 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -33,13 +33,12 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:16`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:14`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:12`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:10`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:0-12`
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202-12`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202.0-12`
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202.1-12`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
 

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["16-buster", "14-buster", "12-buster", "10-buster","14-stretch", "12-stretch", "10-stretch"],
+	"variants": ["16-buster", "14-buster", "12-buster", "14-stretch", "12-stretch"],
 	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
@@ -10,8 +10,7 @@
 		"variantTags": {
 			"16-buster": [ "javascript-node:${VERSION}-16" ],
 			"14-buster": [ "javascript-node:${VERSION}-14" ],
-			"12-buster": [ "javascript-node:${VERSION}-12" ],
-			"10-buster": [ "javascript-node:${VERSION}-10" ]
+			"12-buster": [ "javascript-node:${VERSION}-12" ]
 		}
 	}, 
 	"dependencies": {

--- a/containers/php/README.md
+++ b/containers/php/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | PHP |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of PHP the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -37,10 +39,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/php:0-7`
-- `mcr.microsoft.com/vscode/devcontainers/php:0.200-7`
-- `mcr.microsoft.com/vscode/devcontainers/php:0.200.0-7`
+- `mcr.microsoft.com/vscode/devcontainers/php:0.201-7`
+- `mcr.microsoft.com/vscode/devcontainers/php:0.201.5-7`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,12 +1,16 @@
 {
-	"variants": ["8", "8.0", "7", "7.4", "7.3"],
+	"variants": ["8.0", "7.4", "7.3"],
 	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
 			"php:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"8.0": [ "php:${VERSION}-8" ],
+			"7.4": [ "php:${VERSION}-7" ]
+		}
 	},
 	"dependencies": {
 		"image": "php:${VARIANT}",

--- a/containers/python-3-anaconda/README.md
+++ b/containers/python-3-anaconda/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python, Anaconda |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 ### Configuration
@@ -27,10 +29,10 @@ While the definition itself works unmodified, you can also directly reference pr
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/anaconda:0-3`
-- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.200-3`
-- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.200.0-3`
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.201-3`
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.201.4-3`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/anaconda/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/anaconda/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/python-3-miniconda/README.md
+++ b/containers/python-3-miniconda/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python, Anaconda, Miniconda |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 ### Configuration
@@ -27,10 +29,10 @@ While the definition itself works unmodified, you can also directly reference pr
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/miniconda:0-3`
-- `mcr.microsoft.com/vscode/devcontainers/miniconda:0.200-3`
-- `mcr.microsoft.com/vscode/devcontainers/miniconda:0.200.0-3`
+- `mcr.microsoft.com/vscode/devcontainers/miniconda:0.201-3`
+- `mcr.microsoft.com/vscode/devcontainers/miniconda:0.201.4-3`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/miniconda/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/miniconda/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Python |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 ### Configuration
@@ -38,10 +40,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/python:0-3.9`
-- `mcr.microsoft.com/vscode/devcontainers/python:0.200-3.9`
-- `mcr.microsoft.com/vscode/devcontainers/python:0.200.0-3.9`
+- `mcr.microsoft.com/vscode/devcontainers/python:0.201-3.9`
+- `mcr.microsoft.com/vscode/devcontainers/python:0.201.5-3.9`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize the your container's contents or build for a container architecture the image does not support.
 

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,12 +1,15 @@
 {
-	"variants": ["3", "3.9", "3.8", "3.7", "3.6"],
+	"variants": ["3.9", "3.8", "3.7", "3.6"],
 	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
 			"python:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"3.9": [ "python:${VERSION}-3" ]
+		}
 	},
 	"dependencies": {
 		"image": "python:${VARIANT}",

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
 ARG VARIANT=2
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
 ARG VARIANT=2
 FROM ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
 			"VARIANT": "3",
 			// Options
 			"INSTALL_NODE": "true",

--- a/containers/ruby/README.md
+++ b/containers/ruby/README.md
@@ -10,12 +10,14 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/ruby |
-| *Available image variants* | 3, 3.0, 2, 2.7, 2.6, 2.5 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
+| *Available image variants* | 3, 3.0, 2, 2.7, 2.6 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Ruby |
+
+See **[history](history)** for information on the contents of published images.
 
 ## Using this definition
 
@@ -33,15 +35,14 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2`
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2.7`
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2.6`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:2.5`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/ruby:0-3`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0.200-3`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0.200.0-3`
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.201-3`
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.201.5-3`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,12 +1,16 @@
 {
-	"variants": ["3", "3.0", "2", "2.7", "2.6", "2.5"],
+	"variants": ["3.0", "2.7", "2.6"],
 	"definitionVersion": "0.201.5",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"tags": [
 			"ruby:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"3.0": [ "ruby:${VERSION}-3" ],
+			"2.7": [ "ruby:${VERSION}-2" ]
+		}
 	},
 	"dependencies": {
 		"image": "ruby:${VARIANT}",

--- a/containers/rust/README.md
+++ b/containers/rust/README.md
@@ -16,6 +16,8 @@
 | *Container OS* | Debian |
 | *Languages, platforms* | Rust |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 This definition does not require any special steps to use. Note that the `Cargo.toml` file in the root of this folder is for the test project and can be ignored.
@@ -28,9 +30,9 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/vscode/devcontainers/rust:0-1`
 - `mcr.microsoft.com/vscode/devcontainers/rust:0.200-1`
-- `mcr.microsoft.com/vscode/devcontainers/rust:0.200.0-1`
+- `mcr.microsoft.com/vscode/devcontainers/rust:0.200.4-1`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/rust/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/rust/tags/list).
 
 Alternatively, you can use the contents of `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 

--- a/containers/typescript-node/.devcontainer/Dockerfile
+++ b/containers/typescript-node/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12, 10
-ARG VARIANT=14
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/typescript-node/.devcontainer/base.Dockerfile
+++ b/containers/typescript-node/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12, 10
-ARG VARIANT=14-buster
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16-buster
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # Install tslint, typescript. eslint is installed by javascript image

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -2,9 +2,9 @@
 	"name": "Node.js & TypeScript",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14, 16
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
 		"args": { 
-			"VARIANT": "14"
+			"VARIANT": "16"
 		}
 	},
 

--- a/containers/typescript-node/README.md
+++ b/containers/typescript-node/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/typescript-node |
-| *Available image variants* | 10, 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list)) |
+| *Available image variants* | 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -33,13 +33,12 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:16`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:14`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:12`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:10`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12`
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202-12`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202.0-12`
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202.1-12`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
 

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["16-buster", "14-buster", "12-buster", "10-buster", "14-stretch", "12-stretch", "10-stretch"],
+	"variants": ["16-buster", "14-buster", "12-buster", "14-stretch", "12-stretch"],
 	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
@@ -11,8 +11,7 @@
 		"variantTags": {
 			"16-buster": [ "typescript-node:${VERSION}-16" ],
 			"14-buster": [ "typescript-node:${VERSION}-14" ],
-			"12-buster": [ "typescript-node:${VERSION}-12" ],
-			"10-buster": [ "typescript-node:${VERSION}-10" ]
+			"12-buster": [ "typescript-node:${VERSION}-12" ]
 		}
 	},
 	"dependencies": {

--- a/containers/ubuntu/README.md
+++ b/containers/ubuntu/README.md
@@ -17,6 +17,8 @@
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | Any |
 
+See **[history](history)** for information on the contents of published images.
+
 ## Using this definition
 
 While the definition itself works unmodified, you can select the version of Ubuntu the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -34,10 +36,10 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/base:0-focal`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200-focal`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.200.0-focal`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201-focal`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.201.4-focal`
 
-See [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
+See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
 
 Alternatively, you can use the contents of the `base.Dockerfile` to fully customize your container's contents or to build it for a container host architecture not supported by the image.
 


### PR DESCRIPTION
PR also adds references to the "history" folder and reduces the number of unique images that have to be built by using the `variantTags` option to tag single digit versions of Python (3), PHP (8, 7), Go (1), and Ruby (3, 2).