### PR TITLE
Update master to main

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -3,7 +3,7 @@ name: Run Patches
 on: 
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'build/patch/**'
 

--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -161,4 +161,4 @@ jobs:
           -H "Accept: application/vnd.github.v3+json" \
           -H "Content-Type: application/json" \
           https://api.github.com/repos/${{ github.repository }}/actions/workflows/version-history.yml/dispatches \
-          --data "{\"ref\": \"master\", \"inputs\": {\"release\": \"${{ steps.get_tag_name.outputs.tag }}\", \"cg\": \"false\", \"push\": \"true\", \"overwrite\": \"false\"}"
+          --data "{\"ref\": \"main\", \"inputs\": {\"release\": \"${{ steps.get_tag_name.outputs.tag }}\", \"cg\": \"false\", \"push\": \"true\", \"overwrite\": \"false\"}"

--- a/.github/workflows/push-codespaces-dev.yml
+++ b/.github/workflows/push-codespaces-dev.yml
@@ -3,7 +3,7 @@ name: Build and push "dev" for universal image
 on: 
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'containers/codespaces-linux/**'
 
@@ -45,7 +45,7 @@ jobs:
         yarn install
         GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
         if [ "$GIT_BRANCH" == "" ]; then 
-            GIT_BRANCH=master
+            GIT_BRANCH=main
         fi
         build/vscdc push  codespaces-linux \
                           --release $GIT_BRANCH \

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -3,7 +3,7 @@ name: Build and push "dev" images
 on: 
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'containers/alpine/**'
       - 'containers/debian/**'
@@ -66,7 +66,7 @@ jobs:
         yarn install
         GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
         if [ "$GIT_BRANCH" == "" ]; then 
-            GIT_BRANCH=master
+            GIT_BRANCH=main
         fi
         build/vscdc push  --page ${{ matrix.page }} \
                           --pageTotal ${{ matrix.page-total }} \
@@ -95,7 +95,7 @@ jobs:
         yarn install
         GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
         if [ "$GIT_BRANCH" == "" ]; then 
-            GIT_BRANCH=master
+            GIT_BRANCH=main
         fi
         build/vscdc pack  --prep-and-package-only \
                           --release $GIT_BRANCH \
@@ -130,7 +130,7 @@ jobs:
         echo '(*) Triggering CG manifest and image history generation using workflow_dispatch'
         GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
         if [ "$GIT_BRANCH" == "" ]; then 
-            GIT_BRANCH=master
+            GIT_BRANCH=main
         fi
         # Use alternate GitHub token due to https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676
         curl -X POST \

--- a/.github/workflows/script-library.yml
+++ b/.github/workflows/script-library.yml
@@ -3,7 +3,7 @@ name: Test script library and update definitions
 on: 
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - 'script-library/**'
 

--- a/.github/workflows/version-history.yml
+++ b/.github/workflows/version-history.yml
@@ -6,7 +6,7 @@ on:
       release:
         description: 'Release branch or tag'
         required: true
-        default: 'master'
+        default: 'main'
       cg:
         description: 'Generate cgmanifest.json'
         required: true
@@ -103,7 +103,7 @@ jobs:
 
         GIT_BRANCH=$(echo "${{ github.ref }}" | grep -oP 'refs/(heads|tags)/\K(.+)')
         if [ "$GIT_BRANCH" == "" ]; then 
-            GIT_BRANCH=master
+            GIT_BRANCH=main
         fi
 
         git config --global user.email "vscr-feedback@microsoft.com"

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Each `RUN` statement creates a Docker image "layer". If one `RUN` statement adds
 
 Have a question or feedback?
 
-- Contribute or provide feedback for the [VS Code Remote](https://github.com/Microsoft/vscode-remote-release/blob/master/CONTRIBUTING.md) extensions or [GitHub Codespaces](https://github.com/github/feedback/discussions/categories/codespaces-feedback).
+- Contribute or provide feedback for the [VS Code Remote](https://github.com/Microsoft/vscode-remote-release/blob/main/CONTRIBUTING.md) extensions or [GitHub Codespaces](https://github.com/github/feedback/discussions/categories/codespaces-feedback).
 - Search [existing issues](https://github.com/Microsoft/vscode-dev-containers/issues) with dev container definitions or [report a problem](https://github.com/Microsoft/vscode-dev-containers/issues/new).
 - Contribute a [development container definition](CONTRIBUTING.md#contributing-dev-container-definitions) to the repository.
 
@@ -81,4 +81,4 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 Copyright (c) Microsoft Corporation. All rights reserved. <br />
 Licensed under the MIT License. See [LICENSE](LICENSE).
 
-For images generated from this repository, see [LICENSE](https://github.com/microsoft/containerregistry/blob/master/legal/Container-Images-Legal-Notice.md) and [NOTICE.txt](NOTICE.txt).
+For images generated from this repository, see [LICENSE](https://github.com/microsoft/containerregistry/blob/main/legal/Container-Images-Legal-Notice.md) and [NOTICE.txt](NOTICE.txt).

--- a/build/.vscode/launch.json
+++ b/build/.vscode/launch.json
@@ -32,7 +32,7 @@
 				"pack",
 				"--no-clean",
 				"--prep-and-package-only",
-				"--release", "master",
+				"--release", "main",
 				"--github-repo", "microsoft/vscode-dev-containers",
 				"--registry", "clantz.azurecr.io",
 				"--registryPath", "vscode/devcontainers",
@@ -52,7 +52,7 @@
 				"--cg",
 				"--overwrite",
 				"--prune",
-				"--release", "master",
+				"--release", "main",
 				"--github-repo", "microsoft/vscode-dev-containers",
 				"--registry", "mcr.microsoft.com",
 				"--registryPath", "vscode/devcontainers"

--- a/build/README.md
+++ b/build/README.md
@@ -44,7 +44,7 @@ Once you have your build configuration setup, you can use the `vscdc` CLI to tes
 1. First, build the image(s) using the CLI as follows:
 
    ```bash
-   build/vscdc push --no-push --registry mcr.microsoft.com --registry-path vscode/devcontainers --release master <you-definition-id-here>
+   build/vscdc push --no-push --registry mcr.microsoft.com --registry-path vscode/devcontainers --release main <you-definition-id-here>
    ```
 
 2. Use the Docker CLI to verify all of the expected images and tags and have the right contents:
@@ -56,7 +56,7 @@ Once you have your build configuration setup, you can use the `vscdc` CLI to tes
 3. Finally, test cgmanifest generation by running:
 
    ```bash
-   build/vscdc cg --registry mcr.microsoft.com --registry-path vscode/devcontainers --release master <you-definition-id-here>
+   build/vscdc cg --registry mcr.microsoft.com --registry-path vscode/devcontainers --release main <you-definition-id-here>
    ```
 
 Once you're happy with the result, you can also verify that the `devcontainer.json` and the associated concent that will be generated for your definition is correct.
@@ -64,7 +64,7 @@ Once you're happy with the result, you can also verify that the `devcontainer.js
 1. Generate a `.tgz` with all of the definitions zipped inside of it.
 
     ```bash
-    build/vscdc pack --prep-and-package-only --release master
+    build/vscdc pack --prep-and-package-only --release main
     ```
 
     A new file called `vscode-dev-containers-<version>-dev.tgz` should be in the root of the repository once this is done.
@@ -155,7 +155,7 @@ In this case, Debian is also the one that is used for `latest` for the `base` re
 
 > **NOTE:** The version number used for this repository should be kept in sync with the VS Code Remote - Containers extension to make it easy for developers to find.
 
-There's a special "dev" version that can be used to build master on CI - I ended up needing this to test and others would if they base an image off of one of the MCR images.  e.g. `dev-debian-9`.
+There's a special "dev" version that can be used to build main on CI - I ended up needing this to test and others would if they base an image off of one of the MCR images.  e.g. `dev-debian-9`.
 
 Finally, there is a **`parent`** property that can be used to specify if the container depends an image created as a part of another container build. For example, `typescript-node` uses the image from `javascript-node` and therefore includes the following:
 
@@ -296,14 +296,14 @@ When necessary, a specific version can also be specified for an individual image
 
 ### Deprecation of container definitions
 
-The versioning scheme above allows us to version dev containers and reference them even when they are removed from `master`. To keep the number of containers in `master` reasonable, we would deprecate and remove containers under the following scenarios:
+The versioning scheme above allows us to version dev containers and reference them even when they are removed from `main`. To keep the number of containers in `main` reasonable, we would deprecate and remove containers under the following scenarios:
 
 1. It refers to a runtime that is no longer supported - e.g. Node.js 8 is out of support as of the end of 2019, so we would deprecate `javascript-node-8`. Until that point, we would have containers for node 8, 10, and 12 (which just went LTS).
 2. The container is not used enough to maintain and has broken.
 3. The container refers to a product that has been deprecated.
 4. The container was contributed by a 3rd party, has issues, and the 3rd party is not responsive.
 
-Since the images would continue to exist after this point and the source code is available under the version label, we can safely remove the containers from master without impacting customers.
+Since the images would continue to exist after this point and the source code is available under the version label, we can safely remove the containers from main without impacting customers.
 
 ### Release process and the contents of the npm package
 
@@ -339,7 +339,7 @@ The `definition-manifest.json` file dictates how the build process should behave
 
 Testing, then, is as simple as it is now - open the folder in `vscode-dev-containers` in a container and edit / test as required. Anyone simply copying the folder contents then gets a fully working version of the container even if in-flight and there is no image for it yet.
 
-In the vscode-dev-containers repo itself, the `FROM` statement in `Dockerfile` would always point to `latest` or `dev` since it what is in master may not have even been released yet. This would get dynamically updated as a part of the release process - which we will cover next.
+In the vscode-dev-containers repo itself, the `FROM` statement in `Dockerfile` would always point to `latest` or `dev` since it what is in main may not have even been released yet. This would get dynamically updated as a part of the release process - which we will cover next.
 
 ```Dockerfile
 FROM mcr.microsoft.com/vs/devcontainer/javascript-node:dev-10
@@ -351,7 +351,7 @@ The process also automatically swaps out referenced MCR images for MAJOR version
 
 ##### Common scripts
 
-Another problem the build solves is mass updates - there's a set of things we want in every image and right now it requires ~54 changes to add things. With this new process, images use a tagged version of scripts in `script-library`. The build generates a SHA for script so they can be safely used in Dockerfiles that are not built into images while still allowing people to just grab `.devcontainer` from master and use it if they prefer.
+Another problem the build solves is mass updates - there's a set of things we want in every image and right now it requires ~54 changes to add things. With this new process, images use a tagged version of scripts in `script-library`. The build generates a SHA for script so they can be safely used in Dockerfiles that are not built into images while still allowing people to just grab `.devcontainer` from main and use it if they prefer.
 
 When a release is cut, this SHA is generated and the source code for the related Git tag is updated to include source files with these values set. Consequently, you may need to run `git fetch --tags --force` to update a tag that already exists on your system.
 
@@ -399,7 +399,7 @@ After everything builds successfully, the packaging process kicks off and perfor
 2. Runs through all Dockerfiles and looks for [common script](#common-scripts) references and updates the URL to the tagged version and adds the expected SHA as another arg. The result is that sections of the Dockerfile that look like this:
 
     ```Dockerfile
-    ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+    ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh"
     ARG COMMON_SCRIPT_SHA="dev-mode"
     ```
 

--- a/build/assets/release-notes-header.md
+++ b/build/assets/release-notes-header.md
@@ -1,4 +1,4 @@
-# [{{definition}}](https://github.com/{{repository}}/tree/master/containers/{{definition}})
+# [{{definition}}](https://github.com/{{repository}}/tree/main/containers/{{definition}})
 {{#if annotation}}
 {{{annotation}}}
 {{/if}}

--- a/build/config.json
+++ b/build/config.json
@@ -10,7 +10,7 @@
 	"repoContainersToBuildPath": "repository-containers/images",
 	"scriptLibraryPathInRepo": "script-library",
 	"scriptLibraryFolderNameInDefinition": "library-scripts",
-	"historyUrlPrefix": "https://github.com/microsoft/vscode-dev-containers/tree/master/containers/",
+	"historyUrlPrefix": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/",
 	"repositoryUrl": "https://github.com/microsoft/vscode-dev-containers/",
 	"imageLabelPrefix": "com.visualstudio.code.devcontainers",
 	"definitionBuildConfigFile": "definition-manifest.json",

--- a/build/src/utils/config.js
+++ b/build/src/utils/config.js
@@ -146,7 +146,7 @@ function getAllDefinitionPaths() {
     return allDefinitionPaths;
 }
 
-// Convert a release string (v1.0.0) or branch (master) into a version. If a definitionId and 
+// Convert a release string (v1.0.0) or branch (main) into a version. If a definitionId and 
 // release string is passed in, use the version specified in defintion-build.json if one exists.
 function getVersionFromRelease(release, definitionId) {
     definitionId = definitionId || 'NOT SPECIFIED';

--- a/build/vscdc
+++ b/build/vscdc
@@ -168,7 +168,7 @@ require('yargs')
             .options({
                 'release': {
                     describe: 'vscode-dev-containers release tag or branch',
-                    default: 'master'
+                    default: 'main'
                 },
                 'registry': {
                     describe: 'container registry to push images to',
@@ -232,7 +232,7 @@ require('yargs')
             .options({
                 'release': {
                     describe: 'vscode-dev-containers release tag or branch',
-                    default: 'master'
+                    default: 'main'
                 },
                 'registry': {
                     describe: 'container registry to push images to',

--- a/container-templates/README.md
+++ b/container-templates/README.md
@@ -8,4 +8,4 @@ If you are looking for a list of dev container definitions that are included in 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/container-templates/docker-compose/.devcontainer/library-scripts/README.md
+++ b/container-templates/docker-compose/.devcontainer/library-scripts/README.md
@@ -1,7 +1,7 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.  To retain your edits, move the file to a different location. You may also delete the files if they are not needed.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.  To retain your edits, move the file to a different location. You may also delete the files if they are not needed.
 
 ## Adding a new script from the script-library folder
 
-When creating a dev container for the vscode-dev-containers repository, simply drop a copy of the script you want to use from the [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) into this folder and it will be automatically kept up to date as things change.
+When creating a dev container for the vscode-dev-containers repository, simply drop a copy of the script you want to use from the [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) into this folder and it will be automatically kept up to date as things change.

--- a/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/container-templates/docker-compose/README.md
+++ b/container-templates/docker-compose/README.md
@@ -70,4 +70,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/container-templates/dockerfile/.devcontainer/library-scripts/README.md
+++ b/container-templates/dockerfile/.devcontainer/library-scripts/README.md
@@ -1,7 +1,7 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.  To retain your edits, move the file to a different location. You may also delete the files if they are not needed.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.  To retain your edits, move the file to a different location. You may also delete the files if they are not needed.
 
 ## Adding a new script from the script-library folder
 
-When creating a dev container for the vscode-dev-containers repository, simply drop a copy of the script you want to use from the [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) into this folder and it will be automatically kept up to date as things change.
+When creating a dev container for the vscode-dev-containers repository, simply drop a copy of the script you want to use from the [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) into this folder and it will be automatically kept up to date as things change.

--- a/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/container-templates/dockerfile/README.md
+++ b/container-templates/dockerfile/README.md
@@ -60,4 +60,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/container-templates/image/README.md
+++ b/container-templates/image/README.md
@@ -11,7 +11,7 @@
 | *Definition type*           | Image                                                                        |
 | *Works in Codespaces*       | Yes / No                                                                     |
 | *Container host OS support* | Linux, macOS, Windows                                                        |
-| *Container OS*              | [OS used by container - e.g. Debian]                                          |
+| *Container OS*              | [OS used by container - e.g. Debian]                                         |
 | *Languages, platforms*      | [Languages and platforms the container supports]                             |
 
 ## [Optional] Description
@@ -52,4 +52,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/README.md
+++ b/containers/README.md
@@ -12,4 +12,4 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for details on contributing to this re
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/alpine/.devcontainer/library-scripts/README.md
+++ b/containers/alpine/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/alpine/.devcontainer/library-scripts/common-alpine.sh
+++ b/containers/alpine/.devcontainer/library-scripts/common-alpine.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-alpine.sh [install zsh flag] [username] [user UID] [user GID] [install Oh My Zsh! flag]

--- a/containers/alpine/README.md
+++ b/containers/alpine/README.md
@@ -76,4 +76,4 @@ See [Remote Development and Linux](https://aka.ms/vscode-remote/linux) for detai
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/alpine/history/0.201.4.md
+++ b/containers/alpine/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [alpine](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/alpine)
+# [alpine](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/alpine)
 
 **Image version:** 0.201.4
 

--- a/containers/alpine/history/0.201.5.md
+++ b/containers/alpine/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [alpine](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/alpine)
+# [alpine](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/alpine)
 
 **Image version:** 0.201.5
 

--- a/containers/alpine/history/dev.md
+++ b/containers/alpine/history/dev.md
@@ -1,8 +1,8 @@
-# [alpine](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/alpine)
+# [alpine](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/alpine)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/alpine)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/alpine)
 
 **Definition variations:**
 - [3.13](#variant-313)

--- a/containers/azure-ansible/.devcontainer/library-scripts/README.md
+++ b/containers/azure-ansible/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/azure-ansible/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/containers/azure-ansible/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/azure-ansible/README.md
+++ b/containers/azure-ansible/README.md
@@ -50,4 +50,4 @@ Beyond `git`, this `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/),
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-bicep/.devcontainer/library-scripts/README.md
+++ b/containers/azure-bicep/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/azure-bicep/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/azure-bicep/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/azure-bicep/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-bicep/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/azure-bicep/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/azure-bicep/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/azure-bicep/README.md
+++ b/containers/azure-bicep/README.md
@@ -44,4 +44,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-cli/.devcontainer/library-scripts/README.md
+++ b/containers/azure-cli/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/azure-cli/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/azure-cli/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/azure-cli/README.md
+++ b/containers/azure-cli/README.md
@@ -46,4 +46,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/README.md
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-functions-dotnetcore-2.1/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/azure-functions-dotnetcore-2.1/README.md
+++ b/containers/azure-functions-dotnetcore-2.1/README.md
@@ -56,4 +56,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/dotnet:3.0-dotnet3-core-tools at this URL
-# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile
+# https://github.com/Azure/azure-functions-docker/blob/main/host/3.0/buster/amd64/dotnet/dotnet-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/dotnet:3.0-dotnet3-core-tools
 
 # Uncomment following lines If you want to enable Development Container Script
-# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/main/script-library
 
 # Avoid warnings by switching to noninteractive
 # ENV DEBIAN_FRONTEND=noninteractive
@@ -15,6 +15,6 @@ FROM mcr.microsoft.com/azure-functions/dotnet:3.0-dotnet3-core-tools
 # ARG USER_UID=1000
 # ARG USER_GID=$USER_UID
 
-# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh -o /tmp/common-script.sh \
 #     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
 #     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-dotnetcore-3.1/README.md
+++ b/containers/azure-functions-dotnetcore-3.1/README.md
@@ -56,4 +56,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-functions-java-11/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-11/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/java:3.0-java11-core-tools at this URL
-# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/java/java11/java11-core-tools.Dockerfile
+# https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/java/java11/java11-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/java:3.0-java11-core-tools
 
 # Uncomment following lines If you want to enable Development Container Script
-# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/main/script-library
 
 # Avoid warnings by switching to noninteractive
 # ENV DEBIAN_FRONTEND=noninteractive
@@ -15,6 +15,6 @@ FROM mcr.microsoft.com/azure-functions/java:3.0-java11-core-tools
 # ARG USER_UID=1000
 # ARG USER_GID=$USER_UID
 
-# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh -o /tmp/common-script.sh \
 #     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
 #     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-java-11/README.md
+++ b/containers/azure-functions-java-11/README.md
@@ -56,4 +56,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-functions-java-8/.devcontainer/Dockerfile
+++ b/containers/azure-functions-java-8/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/java:3.0-java8-core-tools at this URL
-# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/java/java8/java8-core-tools.Dockerfile
+# https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/java/java8/java8-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/java:3.0-java11-core-tools
 
 RUN apt-get -qq update && \
@@ -12,7 +12,7 @@ RUN apt-get -qq update && \
     rm -rf /var/lib/apt/lists/*
 
 # Uncomment following lines If you want to enable Development Container Script
-# For more details https://github.com/microsoft/vscode-dev-containers/tree/master/script-library
+# For more details https://github.com/microsoft/vscode-dev-containers/tree/main/script-library
 
 # Avoid warnings by switching to noninteractive
 # ENV DEBIAN_FRONTEND=noninteractive
@@ -24,6 +24,6 @@ RUN apt-get -qq update && \
 # ARG USER_UID=1000
 # ARG USER_GID=$USER_UID
 
-# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh -o /tmp/common-script.sh \
+# RUN apt-get update && curl -ssL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh -o /tmp/common-script.sh \
 #     && /bin/bash /tmp/common-script.sh "$INSTALL_ZSH" "$USERNAME" "$USER_UID" "$USER_GID" \
 #     && rm /tmp/common-script.sh 

--- a/containers/azure-functions-java-8/README.md
+++ b/containers/azure-functions-java-8/README.md
@@ -58,4 +58,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-functions-node/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/node at the following URLs:
-# Node 10: https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile
-# Node 12: https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile
+# Node 10: https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/node/node10/node10-core-tools.Dockerfile
+# Node 12: https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/node/node12/node12-core-tools.Dockerfile
 ARG VARIANT=12
 FROM mcr.microsoft.com/azure-functions/node:3.0-node${VARIANT}-core-tools
 

--- a/containers/azure-functions-node/README.md
+++ b/containers/azure-functions-node/README.md
@@ -69,4 +69,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-functions-pwsh/.devcontainer/Dockerfile
+++ b/containers/azure-functions-pwsh/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/powershell:3.0-powershell${VARIANT}-core-tools at this URL
-# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/powershell
+# https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/powershell
 
 # Update the VARIANT arg in devcontainer.json to pick a supported PowerShell version: 7, 6
 ARG VARIANT=7

--- a/containers/azure-functions-pwsh/README.md
+++ b/containers/azure-functions-pwsh/README.md
@@ -71,4 +71,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-functions-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-functions-python-3/.devcontainer/Dockerfile
@@ -1,3 +1,3 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools at this URL
-# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
+# https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools

--- a/containers/azure-functions-python-3/README.md
+++ b/containers/azure-functions-python-3/README.md
@@ -56,4 +56,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-machine-learning-python-3/README.md
+++ b/containers/azure-machine-learning-python-3/README.md
@@ -42,4 +42,4 @@ Once you have an Azure account, follow these steps:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-static-web-apps/.devcontainer/Dockerfile
+++ b/containers/azure-static-web-apps/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Find the Dockerfile for mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools at this URL
-# https://github.com/Azure/azure-functions-docker/blob/master/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
+# https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
 FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools
 
 ENV NVM_DIR="/usr/local/share/nvm"

--- a/containers/azure-static-web-apps/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/azure-static-web-apps/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/azure-static-web-apps/README.md
+++ b/containers/azure-static-web-apps/README.md
@@ -60,4 +60,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/azure-terraform/.devcontainer/library-scripts/README.md
+++ b/containers/azure-terraform/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/azure-terraform/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/azure-terraform/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/containers/azure-terraform/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/terraform-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/terraform.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/terraform.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./terraform-debian.sh [terraform version] [tflint version] [terragrunt version]

--- a/containers/azure-terraform/README.md
+++ b/containers/azure-terraform/README.md
@@ -100,4 +100,4 @@ For a complete list of all the available commands as part of the Azure Terraform
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/bash/README.md
+++ b/containers/bash/README.md
@@ -34,4 +34,4 @@ Just follow these steps:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/bazel/.devcontainer/library-scripts/README.md
+++ b/containers/bazel/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/bazel/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/bazel/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/bazel/README.md
+++ b/containers/bazel/README.md
@@ -62,4 +62,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/codespaces-linux/.devcontainer/library-scripts/README.md
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/codespaces-linux/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-in-docker-debian.sh [enable non-root docker access flag] [non-root user] [use moby]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/git-from-src-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/git-from-src-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/git-from-src.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/git-from-src.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./git-from-src-debian.sh [version]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/git-lfs-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/git-lfs-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/git-lfs.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/git-lfs.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./git-lfs-debian.sh

--- a/containers/codespaces-linux/.devcontainer/library-scripts/github-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/github-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/github.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/github.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./github-debian.sh [version]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/go-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/go-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/go.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/go.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./go-debian.sh [Go version] [GOROOT] [GOPATH] [non-root user] [Add GOPATH, GOROOT to rc files flag] [Install tools flag]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/gradle-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/gradle-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/gradle.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/gradle.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./gradle-debian.sh [Gradle version] [SDKMAN_DIR] [non-root user] [Update rc files flag]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/java-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/java-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/java.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/java.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./java-debian.sh [JDK version] [SDKMAN_DIR] [non-root user] [Add to rc files flag]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/kubectl-helm-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/kubectl-helm-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/kubectl-helm.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/kubectl-helm.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./kubectl-helm-debian.sh [kubectl verison] [Helm version] [minikube version] [kubectl SHA256] [Helm SHA256] [minikube SHA256]
@@ -124,7 +124,7 @@ if [ "${MINIKUBE_VERSION}" != "none" ]; then
 fi
 
 if ! type docker > /dev/null 2>&1; then
-    echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md'
+    echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md'
 fi
 
 echo -e "\nDone!"

--- a/containers/codespaces-linux/.devcontainer/library-scripts/maven-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/maven-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/maven.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/maven.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./maven-debian.sh [maven version] [SDKMAN_DIR] [non-root user] [Update rc files flag]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/powershell-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/powershell-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/powershell.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/powershell.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./powershell-debian.sh

--- a/containers/codespaces-linux/.devcontainer/library-scripts/python-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/python-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/python.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/python.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./python-debian.sh [Python Version] [Python intall path] [PIPX_HOME] [non-root user] [Update rc files flag] [install tools]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/ruby-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/ruby-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/ruby.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/ruby.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./ruby-debian.sh [Ruby version] [non-root user] [Add to rc files flag] [Install tools flag]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/rust-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/rust-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/rust.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/rust.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./rust-debian.sh [CARGO_HOME] [RUSTUP_HOME] [non-root user] [add CARGO/RUSTUP_HOME to rc files flag] [whether to update rust]

--- a/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/sshd.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/sshd.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./sshd-debian.sh [SSH Port (don't use 22)] [non-root user] [start sshd now flag] [new password for user]

--- a/containers/codespaces-linux/README.md
+++ b/containers/codespaces-linux/README.md
@@ -97,4 +97,4 @@ Given its size, we do not recommend extending this image. However, you can add i
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/codespaces-linux/history/1.3.2.md
+++ b/containers/codespaces-linux/history/1.3.2.md
@@ -1,4 +1,4 @@
-# [codespaces-linux](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/codespaces-linux)
+# [codespaces-linux](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/codespaces-linux)
 This document describes the base contents of the default GitHub Codespaces dev container image. Note that this image also includes detection logic to dynamically install additional language / runtime versions based on your repository's contents. Dynamically installed content can be found in sub-folders under `/opt`.
 
 **Image version:** 1.3.2

--- a/containers/codespaces-linux/history/1.3.3.md
+++ b/containers/codespaces-linux/history/1.3.3.md
@@ -1,4 +1,4 @@
-# [codespaces-linux](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/codespaces-linux)
+# [codespaces-linux](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/codespaces-linux)
 This document describes the base contents of the default GitHub Codespaces dev container image. Note that this image also includes detection logic to dynamically install additional language / runtime versions based on your repository's contents. Dynamically installed content can be found in sub-folders under `/opt`.
 
 **Image version:** 1.3.3

--- a/containers/codespaces-linux/history/dev.md
+++ b/containers/codespaces-linux/history/dev.md
@@ -1,9 +1,9 @@
-# [codespaces-linux](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/codespaces-linux)
+# [codespaces-linux](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/codespaces-linux)
 This document describes the base contents of the default GitHub Codespaces dev container image. Note that this image also includes detection logic to dynamically install additional language / runtime versions based on your repository's contents. Dynamically installed content can be found in sub-folders under `/opt`.
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/codespaces-linux)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/codespaces-linux)
 
 **Digest:** sha256:22e88362976668e473aaa3f9159b12d91f0788ebd98b673b6dfdf7eaf9f4d22d
 

--- a/containers/cpp/.devcontainer/library-scripts/README.md
+++ b/containers/cpp/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/cpp/README.md
+++ b/containers/cpp/README.md
@@ -83,4 +83,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/cpp/history/0.201.4.md
+++ b/containers/cpp/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [cpp](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/cpp)
+# [cpp](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/cpp)
 
 **Image version:** 0.201.4
 

--- a/containers/cpp/history/0.201.5.md
+++ b/containers/cpp/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [cpp](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/cpp)
+# [cpp](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/cpp)
 
 **Image version:** 0.201.5
 

--- a/containers/cpp/history/dev.md
+++ b/containers/cpp/history/dev.md
@@ -1,8 +1,8 @@
-# [cpp](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/cpp)
+# [cpp](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/cpp)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/cpp)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/cpp)
 
 **Definition variations:**
 - [buster](#variant-buster)

--- a/containers/dapr-dotnet/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/dapr-dotnet/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/dapr-dotnet/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/dapr-dotnet/.devcontainer/library-scripts/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/containers/dapr-dotnet/README.md
+++ b/containers/dapr-dotnet/README.md
@@ -117,4 +117,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/dapr-javascript-node/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/dapr-javascript-node/.devcontainer/library-scripts/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/containers/dapr-javascript-node/README.md
+++ b/containers/dapr-javascript-node/README.md
@@ -66,4 +66,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/dart/.devcontainer/library-scripts/README.md
+++ b/containers/dart/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/dart/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dart/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/dart/README.md
+++ b/containers/dart/README.md
@@ -52,4 +52,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/debian/.devcontainer/library-scripts/README.md
+++ b/containers/debian/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/debian/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/debian/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/debian/README.md
+++ b/containers/debian/README.md
@@ -70,4 +70,4 @@ Just follow these steps:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/debian/history/0.201.4.md
+++ b/containers/debian/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [debian](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian)
+# [debian](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/debian)
 
 **Image version:** 0.201.4
 

--- a/containers/debian/history/0.201.5.md
+++ b/containers/debian/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [debian](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian)
+# [debian](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/debian)
 
 **Image version:** 0.201.5
 

--- a/containers/debian/history/dev.md
+++ b/containers/debian/history/dev.md
@@ -1,8 +1,8 @@
-# [debian](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian)
+# [debian](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/debian)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/debian)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/debian)
 
 **Definition variations:**
 - [buster](#variant-buster)

--- a/containers/deno/README.md
+++ b/containers/deno/README.md
@@ -47,4 +47,4 @@ To verify the definition is working as expected on your system. Follow these ste
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/docker-existing-docker-compose/README.md
+++ b/containers/docker-existing-docker-compose/README.md
@@ -43,4 +43,4 @@ Follow these steps to use it:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/docker-existing-dockerfile/README.md
+++ b/containers/docker-existing-dockerfile/README.md
@@ -40,4 +40,4 @@ Follow these steps to use it:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE). 
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE). 

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/README.md
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/containers/docker-from-docker-compose/README.md
+++ b/containers/docker-from-docker-compose/README.md
@@ -209,4 +209,4 @@ docker run -it --rm -v "${LOCAL_WORKSPACE_FOLDER//\\/\/}:/workspace" debian bash
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/docker-from-docker/.devcontainer/library-scripts/README.md
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/docker-from-docker/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/containers/docker-from-docker/README.md
+++ b/containers/docker-from-docker/README.md
@@ -224,4 +224,4 @@ Beyond that, just follow these steps to use the definition:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/docker-in-docker/.devcontainer/library-scripts/README.md
+++ b/containers/docker-in-docker/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/docker-in-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-in-docker/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/docker-in-docker/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/containers/docker-in-docker/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-in-docker-debian.sh [enable non-root docker access flag] [non-root user] [use moby]

--- a/containers/docker-in-docker/README.md
+++ b/containers/docker-in-docker/README.md
@@ -63,4 +63,4 @@ Beyond that, just follow these steps to use the definition:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/dotnet-fsharp/.devcontainer/library-scripts/README.md
+++ b/containers/dotnet-fsharp/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/dotnet-fsharp/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/dotnet-fsharp/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/dotnet-fsharp/README.md
+++ b/containers/dotnet-fsharp/README.md
@@ -163,4 +163,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/dotnet-mssql/.devcontainer/library-scripts/README.md
+++ b/containers/dotnet-mssql/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/dotnet-mssql/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/dotnet-mssql/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/dotnet-mssql/README.md
+++ b/containers/dotnet-mssql/README.md
@@ -153,6 +153,6 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).
 
 Licenses for [SqlPackage](https://docs.microsoft.com/sql/tools/sqlpackage-download), [SQLCMD](https://docs.microsoft.com/sql/linux/sql-server-linux-setup-tools), and [SQL Server Developer Edition](https://go.microsoft.com/fwlink/?linkid=857698).

--- a/containers/dotnet/.devcontainer/library-scripts/README.md
+++ b/containers/dotnet/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/dotnet/.devcontainer/library-scripts/azcli-debian.sh
+++ b/containers/dotnet/.devcontainer/library-scripts/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/containers/dotnet/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dotnet/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/dotnet/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/dotnet/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -174,4 +174,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/dotnet/history/0.201.5.md
+++ b/containers/dotnet/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [dotnet](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnet)
+# [dotnet](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet)
 
 **Image version:** 0.201.5
 

--- a/containers/dotnet/history/0.201.6.md
+++ b/containers/dotnet/history/0.201.6.md
@@ -1,4 +1,4 @@
-# [dotnet](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnet)
+# [dotnet](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet)
 
 **Image version:** 0.201.6
 

--- a/containers/dotnet/history/dev.md
+++ b/containers/dotnet/history/dev.md
@@ -1,8 +1,8 @@
-# [dotnet](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnet)
+# [dotnet](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/dotnet)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dotnet)
 
 **Definition variations:**
 - [5.0](#variant-50)

--- a/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
+++ b/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ ARG USER_GID=$USER_UID
 # Options for common package install script
 ARG INSTALL_ZSH="true"
 ARG UPGRADE_PACKAGES="true"
-ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
 # Optional Settings for Phoenix
@@ -19,7 +19,7 @@ ARG PHOENIX_VERSION="1.5.4"
 
 # [Optional] Settings for installing Node.js.
 ARG INSTALL_NODE="true"
-ARG NODE_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/node-debian.sh"
+ARG NODE_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/node-debian.sh"
 ARG NODE_SCRIPT_SHA="dev-mode"
 ARG NODE_VERSION="lts/*"
 ENV NVM_DIR=/usr/local/share/nvm

--- a/containers/elixir-phoenix-postgres/README.md
+++ b/containers/elixir-phoenix-postgres/README.md
@@ -75,4 +75,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/elm/README.md
+++ b/containers/elm/README.md
@@ -46,4 +46,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/go/.devcontainer/library-scripts/README.md
+++ b/containers/go/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/go/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/go/.devcontainer/library-scripts/go-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/go-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/go.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/go.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./go-debian.sh [Go version] [GOROOT] [GOPATH] [non-root user] [Add GOPATH, GOROOT to rc files flag] [Install tools flag]

--- a/containers/go/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -91,4 +91,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/go/history/0.202.4.md
+++ b/containers/go/history/0.202.4.md
@@ -1,4 +1,4 @@
-# [go](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/go)
+# [go](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/go)
 
 **Image version:** 0.202.4
 

--- a/containers/go/history/0.202.5.md
+++ b/containers/go/history/0.202.5.md
@@ -1,4 +1,4 @@
-# [go](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/go)
+# [go](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/go)
 
 **Image version:** 0.202.5
 

--- a/containers/go/history/dev.md
+++ b/containers/go/history/dev.md
@@ -1,8 +1,8 @@
-# [go](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/go)
+# [go](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/go)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/go)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/go)
 
 **Definition variations:**
 - [1.16](#variant-116)

--- a/containers/hugo/README.md
+++ b/containers/hugo/README.md
@@ -42,4 +42,4 @@ The `.vscode` folder additionally contains a sample `tasks.json` file that can b
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/java-8/.devcontainer/library-scripts/README.md
+++ b/containers/java-8/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/java-8/README.md
+++ b/containers/java-8/README.md
@@ -116,4 +116,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/java-8/history/0.201.4.md
+++ b/containers/java-8/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [java-8](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java-8)
+# [java-8](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/java-8)
 
 **Image version:** 0.201.4
 

--- a/containers/java-8/history/0.201.5.md
+++ b/containers/java-8/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [java-8](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java-8)
+# [java-8](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/java-8)
 
 **Image version:** 0.201.5
 

--- a/containers/java-8/history/dev.md
+++ b/containers/java-8/history/dev.md
@@ -1,8 +1,8 @@
-# [java-8](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java-8)
+# [java-8](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/java-8)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java-8)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/java-8)
 
 **Digest:** sha256:0fd3c11b8442f77a823526596c171494a93a22491cd0ad9cf1ac31cc2566de57
 

--- a/containers/java/.devcontainer/library-scripts/README.md
+++ b/containers/java/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/java/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/java/.devcontainer/library-scripts/gradle-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/gradle-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/gradle.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/gradle.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./gradle-debian.sh [Gradle version] [SDKMAN_DIR] [non-root user] [Update rc files flag]

--- a/containers/java/.devcontainer/library-scripts/java-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/java-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/java.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/java.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./java-debian.sh [JDK version] [SDKMAN_DIR] [non-root user] [Add to rc files flag]

--- a/containers/java/.devcontainer/library-scripts/maven-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/maven-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/maven.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/maven.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./maven-debian.sh [maven version] [SDKMAN_DIR] [non-root user] [Update rc files flag]

--- a/containers/java/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/java/README.md
+++ b/containers/java/README.md
@@ -126,4 +126,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/java/history/0.201.4.md
+++ b/containers/java/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [java](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java)
+# [java](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/java)
 
 **Image version:** 0.201.4
 

--- a/containers/java/history/0.201.5.md
+++ b/containers/java/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [java](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java)
+# [java](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/java)
 
 **Image version:** 0.201.5
 

--- a/containers/java/history/dev.md
+++ b/containers/java/history/dev.md
@@ -1,8 +1,8 @@
-# [java](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java)
+# [java](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/java)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/java)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/java)
 
 **Definition variations:**
 - [15](#variant-15)

--- a/containers/javascript-node-azurite/README.md
+++ b/containers/javascript-node-azurite/README.md
@@ -59,4 +59,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/javascript-node-mongo/README.md
+++ b/containers/javascript-node-mongo/README.md
@@ -75,4 +75,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/javascript-node-postgres/README.md
+++ b/containers/javascript-node-postgres/README.md
@@ -75,4 +75,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/javascript-node/.devcontainer/library-scripts/README.md
+++ b/containers/javascript-node/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/javascript-node/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/javascript-node/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/javascript-node/README.md
+++ b/containers/javascript-node/README.md
@@ -83,4 +83,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/javascript-node/history/0.201.4.md
+++ b/containers/javascript-node/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [javascript-node](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node)
+# [javascript-node](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node)
 
 **Image version:** 0.201.4
 

--- a/containers/javascript-node/history/0.202.0.md
+++ b/containers/javascript-node/history/0.202.0.md
@@ -1,4 +1,4 @@
-# [javascript-node](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node)
+# [javascript-node](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node)
 
 **Image version:** 0.202.0
 

--- a/containers/javascript-node/history/0.202.1.md
+++ b/containers/javascript-node/history/0.202.1.md
@@ -1,4 +1,4 @@
-# [javascript-node](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node)
+# [javascript-node](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node)
 
 **Image version:** 0.202.1
 

--- a/containers/javascript-node/history/dev.md
+++ b/containers/javascript-node/history/dev.md
@@ -1,8 +1,8 @@
-# [javascript-node](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node)
+# [javascript-node](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node)
 
 **Definition variations:**
 - [16-buster](#variant-16-buster)

--- a/containers/jekyll/README.md
+++ b/containers/jekyll/README.md
@@ -37,4 +37,4 @@ In addition to Ruby and Bundler, this development container installs Jekyll and 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/julia/README.md
+++ b/containers/julia/README.md
@@ -32,4 +32,4 @@
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/jupyter-datascience-notebooks/.devcontainer/Dockerfile
+++ b/containers/jupyter-datascience-notebooks/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 FROM jupyter/datascience-notebook
 
 # We want to run common-debian.sh from here:
-# https://github.com/microsoft/vscode-dev-containers/tree/master/script-library#development-container-scripts
+# https://github.com/microsoft/vscode-dev-containers/tree/main/script-library#development-container-scripts
 # But that script assumes that the main non-root user (in this case jovyan)
 # is in a group with the same name (in this case jovyan).  So we must first make that so.
 COPY library-scripts/common-debian.sh /tmp/library-scripts/

--- a/containers/jupyter-datascience-notebooks/.devcontainer/library-scripts/README.md
+++ b/containers/jupyter-datascience-notebooks/.devcontainer/library-scripts/README.md
@@ -1,7 +1,7 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.  To retain your edits, move the file to a different location. You may also delete the files if they are not needed.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.  To retain your edits, move the file to a different location. You may also delete the files if they are not needed.
 
 ## Adding a new script from the script-library folder
 
-When creating a dev container for the vscode-dev-containers repository, simply drop a copy of the script you want to use from the [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) into this folder and it will be automatically kept up to date as things change.
+When creating a dev container for the vscode-dev-containers repository, simply drop a copy of the script you want to use from the [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) into this folder and it will be automatically kept up to date as things change.

--- a/containers/jupyter-datascience-notebooks/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/jupyter-datascience-notebooks/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/jupyter-datascience-notebooks/README.md
+++ b/containers/jupyter-datascience-notebooks/README.md
@@ -28,4 +28,4 @@ If you prefer, you can also just look through the contents of the `.devcontainer
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/README.md
+++ b/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-in-docker-debian.sh [enable non-root docker access flag] [non-root user] [use moby]

--- a/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/kubectl-helm-debian.sh
+++ b/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/kubectl-helm-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/kubectl-helm.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/kubectl-helm.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./kubectl-helm-debian.sh [kubectl verison] [Helm version] [minikube version] [kubectl SHA256] [Helm SHA256] [minikube SHA256]
@@ -124,7 +124,7 @@ if [ "${MINIKUBE_VERSION}" != "none" ]; then
 fi
 
 if ! type docker > /dev/null 2>&1; then
-    echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md'
+    echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md'
 fi
 
 echo -e "\nDone!"

--- a/containers/kubernetes-helm-minikube/README.md
+++ b/containers/kubernetes-helm-minikube/README.md
@@ -58,4 +58,4 @@ Beyond that, just follow these steps to use the definition:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE). 
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE). 

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/README.md
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/kubectl-helm-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/kubectl-helm-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/kubectl-helm.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/kubectl-helm.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./kubectl-helm-debian.sh [kubectl verison] [Helm version] [minikube version] [kubectl SHA256] [Helm SHA256] [minikube SHA256]
@@ -124,7 +124,7 @@ if [ "${MINIKUBE_VERSION}" != "none" ]; then
 fi
 
 if ! type docker > /dev/null 2>&1; then
-    echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md'
+    echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md'
 fi
 
 echo -e "\nDone!"

--- a/containers/kubernetes-helm/README.md
+++ b/containers/kubernetes-helm/README.md
@@ -65,7 +65,7 @@ However, this section will outline the how you can selectively add this function
         && chmod +x /usr/local/bin/kubectl
 
     # Install Helm
-    RUN curl -s https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -
+    RUN curl -s https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -
     ```
 
 4. Finally, we need to automatically swap out `localhost` for `host.docker.internal` in the container's copy of the Kubernetes config and (optionally) Minikube certificates. Manually copy the [`copy-kube-config.sh` script](.devcontainer/copy-kube-config.sh) from the `.devcontainer` folder in this repo folder into the same folder as your `Dockerfile` and then update your `Dockerfile` to use it from your `/root/.bashrc` and/or `/root/.zshrc`.
@@ -167,4 +167,4 @@ While you cannot sync or connect to your local Kubernetes configuration with Cod
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE). 
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE). 

--- a/containers/markdown/README.md
+++ b/containers/markdown/README.md
@@ -24,4 +24,4 @@ If you prefer, you can also just look through the contents of the `.devcontainer
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/mit-scheme/.devcontainer/library-scripts/README.md
+++ b/containers/mit-scheme/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/mit-scheme/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/mit-scheme/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/mit-scheme/.devcontainer/mit-scheme-debian.sh
+++ b/containers/mit-scheme/.devcontainer/mit-scheme-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/go.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/go.md
 #
 # Syntax: ./mit-scheme-debian.sh [Scheme version] [TARGET SCHEME PATH] [non-root user]
 

--- a/containers/mit-scheme/README.md
+++ b/containers/mit-scheme/README.md
@@ -45,4 +45,4 @@ Just follow these steps:
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/perl/.devcontainer/library-scripts/README.md
+++ b/containers/perl/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/perl/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/perl/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/perl/README.md
+++ b/containers/perl/README.md
@@ -52,4 +52,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/php-mariadb/README.md
+++ b/containers/php-mariadb/README.md
@@ -110,4 +110,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/php/.devcontainer/library-scripts/README.md
+++ b/containers/php/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/php/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/php/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/php/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/php/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/php/README.md
+++ b/containers/php/README.md
@@ -115,4 +115,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/php/history/0.201.4.md
+++ b/containers/php/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [php](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/php)
+# [php](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/php)
 
 **Image version:** 0.201.4
 

--- a/containers/php/history/0.201.5.md
+++ b/containers/php/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [php](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/php)
+# [php](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/php)
 
 **Image version:** 0.201.5
 

--- a/containers/php/history/dev.md
+++ b/containers/php/history/dev.md
@@ -1,8 +1,8 @@
-# [php](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/php)
+# [php](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/php)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/php)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/php)
 
 **Definition variations:**
 - [8.0](#variant-80)

--- a/containers/powershell/.devcontainer/library-scripts/README.md
+++ b/containers/powershell/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/powershell/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/powershell/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/powershell/README.md
+++ b/containers/powershell/README.md
@@ -44,4 +44,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/puppet/README.md
+++ b/containers/puppet/README.md
@@ -36,4 +36,4 @@ Develop Puppet manifests, modules, and code using VS Code without installing any
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/README.md
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/python-3-anaconda/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3-anaconda/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/python-3-anaconda/README.md
+++ b/containers/python-3-anaconda/README.md
@@ -155,4 +155,4 @@ Use this container to run Jupyter notebooks.
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/python-3-anaconda/history/0.201.3.md
+++ b/containers/python-3-anaconda/history/0.201.3.md
@@ -1,4 +1,4 @@
-# [python-3-anaconda](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3-anaconda)
+# [python-3-anaconda](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-anaconda)
 
 **Image version:** 0.201.3
 

--- a/containers/python-3-anaconda/history/0.201.4.md
+++ b/containers/python-3-anaconda/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [python-3-anaconda](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3-anaconda)
+# [python-3-anaconda](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-anaconda)
 
 **Image version:** 0.201.4
 

--- a/containers/python-3-anaconda/history/dev.md
+++ b/containers/python-3-anaconda/history/dev.md
@@ -1,8 +1,8 @@
-# [python-3-anaconda](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3-anaconda)
+# [python-3-anaconda](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-anaconda)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3-anaconda)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-anaconda)
 
 **Digest:** sha256:d14ce6bd790572b492e491c6949c2aee9c2459746cd1ff0c3d8dd2c7074cc9ac
 

--- a/containers/python-3-device-simulator-express/README.md
+++ b/containers/python-3-device-simulator-express/README.md
@@ -135,4 +135,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/README.md
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/python-3-miniconda/.devcontainer/library-scripts/python-debian.sh
+++ b/containers/python-3-miniconda/.devcontainer/library-scripts/python-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/python.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/python.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./python-debian.sh [Python Version] [Python intall path] [PIPX_HOME] [non-root user] [Update rc files flag] [install tools]

--- a/containers/python-3-miniconda/README.md
+++ b/containers/python-3-miniconda/README.md
@@ -145,4 +145,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/python-3-miniconda/history/0.201.3.md
+++ b/containers/python-3-miniconda/history/0.201.3.md
@@ -1,4 +1,4 @@
-# [python-3-miniconda](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3-miniconda)
+# [python-3-miniconda](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-miniconda)
 
 **Image version:** 0.201.3
 

--- a/containers/python-3-miniconda/history/0.201.4.md
+++ b/containers/python-3-miniconda/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [python-3-miniconda](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3-miniconda)
+# [python-3-miniconda](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-miniconda)
 
 **Image version:** 0.201.4
 

--- a/containers/python-3-miniconda/history/dev.md
+++ b/containers/python-3-miniconda/history/dev.md
@@ -1,8 +1,8 @@
-# [python-3-miniconda](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3-miniconda)
+# [python-3-miniconda](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-miniconda)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3-miniconda)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-miniconda)
 
 **Digest:** sha256:6a53ef53e064412e35ab0083f40e52c02774f0b187da07dca07a89e5746eec4f
 

--- a/containers/python-3-postgres/README.md
+++ b/containers/python-3-postgres/README.md
@@ -162,4 +162,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/python-3/.devcontainer/library-scripts/README.md
+++ b/containers/python-3/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/python-3/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/python-3/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/python-3/.devcontainer/library-scripts/python-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/python-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/python.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/python.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./python-debian.sh [Python Version] [Python intall path] [PIPX_HOME] [non-root user] [Update rc files flag] [install tools]

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -178,5 +178,5 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)
 

--- a/containers/python-3/history/0.201.4.md
+++ b/containers/python-3/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [python-3](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3)
+# [python-3](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3)
 
 **Image version:** 0.201.4
 

--- a/containers/python-3/history/0.201.5.md
+++ b/containers/python-3/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [python-3](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3)
+# [python-3](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3)
 
 **Image version:** 0.201.5
 

--- a/containers/python-3/history/dev.md
+++ b/containers/python-3/history/dev.md
@@ -1,8 +1,8 @@
-# [python-3](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3)
+# [python-3](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/python-3)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3)
 
 **Definition variations:**
 - [3.9](#variant-39)

--- a/containers/r/.devcontainer/library-scripts/README.md
+++ b/containers/r/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/r/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/r/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/r/README.md
+++ b/containers/r/README.md
@@ -43,4 +43,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/reasonml/README.md
+++ b/containers/reasonml/README.md
@@ -54,4 +54,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/ruby-rails/README.md
+++ b/containers/ruby-rails/README.md
@@ -73,7 +73,7 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).
 
 <!-- links -->
 

--- a/containers/ruby-sinatra/README.md
+++ b/containers/ruby-sinatra/README.md
@@ -64,7 +64,7 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).
 
 <!-- links -->
 [la]: https://code.mzhao.page/

--- a/containers/ruby/.devcontainer/library-scripts/README.md
+++ b/containers/ruby/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/ruby/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/ruby/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/ruby/.devcontainer/library-scripts/ruby-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/ruby-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/ruby.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/ruby.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./ruby-debian.sh [Ruby version] [non-root user] [Add to rc files flag] [Install tools flag]

--- a/containers/ruby/README.md
+++ b/containers/ruby/README.md
@@ -93,4 +93,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/ruby/history/0.201.4.md
+++ b/containers/ruby/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [ruby](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ruby)
+# [ruby](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ruby)
 
 **Image version:** 0.201.4
 

--- a/containers/ruby/history/0.201.5.md
+++ b/containers/ruby/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [ruby](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ruby)
+# [ruby](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ruby)
 
 **Image version:** 0.201.5
 

--- a/containers/ruby/history/dev.md
+++ b/containers/ruby/history/dev.md
@@ -1,8 +1,8 @@
-# [ruby](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ruby)
+# [ruby](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ruby)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ruby)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ruby)
 
 **Definition variations:**
 - [3.0](#variant-30)

--- a/containers/rust/.devcontainer/library-scripts/README.md
+++ b/containers/rust/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/rust/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/rust/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/rust/.devcontainer/library-scripts/rust-debian.sh
+++ b/containers/rust/.devcontainer/library-scripts/rust-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/rust.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/rust.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./rust-debian.sh [CARGO_HOME] [RUSTUP_HOME] [non-root user] [add CARGO/RUSTUP_HOME to rc files flag] [whether to update rust]

--- a/containers/rust/README.md
+++ b/containers/rust/README.md
@@ -70,4 +70,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/rust/history/0.200.3.md
+++ b/containers/rust/history/0.200.3.md
@@ -1,4 +1,4 @@
-# [rust](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/rust)
+# [rust](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/rust)
 
 **Image version:** 0.200.3
 

--- a/containers/rust/history/0.200.4.md
+++ b/containers/rust/history/0.200.4.md
@@ -1,4 +1,4 @@
-# [rust](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/rust)
+# [rust](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/rust)
 
 **Image version:** 0.200.4
 

--- a/containers/rust/history/dev.md
+++ b/containers/rust/history/dev.md
@@ -1,8 +1,8 @@
-# [rust](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/rust)
+# [rust](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/rust)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/rust)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/rust)
 
 **Digest:** sha256:4acec35787f21527d12b05bb4eb7e9fce6e2a7cbffc92867103492ba31df5b9d
 

--- a/containers/sfdx-project/README.md
+++ b/containers/sfdx-project/README.md
@@ -38,4 +38,4 @@ You can learn more about remote development with Salesforce Extension [here](htt
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/swift/.devcontainer/library-scripts/README.md
+++ b/containers/swift/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/swift/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/swift/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/swift/.devcontainer/library-scripts/node-debian.sh
+++ b/containers/swift/.devcontainer/library-scripts/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/containers/swift/README.md
+++ b/containers/swift/README.md
@@ -62,4 +62,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/typescript-node/.devcontainer/library-scripts/README.md
+++ b/containers/typescript-node/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/typescript-node/README.md
+++ b/containers/typescript-node/README.md
@@ -85,4 +85,4 @@ This definition includes some test code that will help you verify it is working 
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/containers/typescript-node/history/0.201.4.md
+++ b/containers/typescript-node/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [typescript-node](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/typescript-node)
+# [typescript-node](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/typescript-node)
 
 **Image version:** 0.201.4
 

--- a/containers/typescript-node/history/0.202.0.md
+++ b/containers/typescript-node/history/0.202.0.md
@@ -1,4 +1,4 @@
-# [typescript-node](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/typescript-node)
+# [typescript-node](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/typescript-node)
 
 **Image version:** 0.202.0
 

--- a/containers/typescript-node/history/0.202.1.md
+++ b/containers/typescript-node/history/0.202.1.md
@@ -1,4 +1,4 @@
-# [typescript-node](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/typescript-node)
+# [typescript-node](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/typescript-node)
 
 **Image version:** 0.202.1
 

--- a/containers/typescript-node/history/dev.md
+++ b/containers/typescript-node/history/dev.md
@@ -1,8 +1,8 @@
-# [typescript-node](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/typescript-node)
+# [typescript-node](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/typescript-node)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/typescript-node)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/typescript-node)
 
 **Definition variations:**
 - [16-buster](#variant-16-buster)

--- a/containers/ubuntu/.devcontainer/library-scripts/README.md
+++ b/containers/ubuntu/.devcontainer/library-scripts/README.md
@@ -1,5 +1,5 @@
 # Warning: Folder contents may be replaced
 
-The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/master/script-library) whenever the repository is packaged.
+The contents of this folder will be automatically replaced with a file of the same name in the [vscode-dev-containers](https://github.com/microsoft/vscode-dev-containers) repository's [script-library folder](https://github.com/microsoft/vscode-dev-containers/tree/main/script-library) whenever the repository is packaged.
 
 To retain your edits, move the file to a different location. You may also delete the files if they are not needed.

--- a/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/containers/ubuntu/README.md
+++ b/containers/ubuntu/README.md
@@ -68,4 +68,4 @@ Beyond `git`, this image / `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohm
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/containers/ubuntu/history/0.201.4.md
+++ b/containers/ubuntu/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [ubuntu](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ubuntu)
+# [ubuntu](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ubuntu)
 
 **Image version:** 0.201.4
 

--- a/containers/ubuntu/history/0.201.5.md
+++ b/containers/ubuntu/history/0.201.5.md
@@ -1,4 +1,4 @@
-# [ubuntu](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ubuntu)
+# [ubuntu](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ubuntu)
 
 **Image version:** 0.201.5
 

--- a/containers/ubuntu/history/dev.md
+++ b/containers/ubuntu/history/dev.md
@@ -1,8 +1,8 @@
-# [ubuntu](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ubuntu)
+# [ubuntu](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ubuntu)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/ubuntu)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ubuntu)
 
 **Definition variations:**
 - [focal](#variant-focal)

--- a/containers/vue/README.md
+++ b/containers/vue/README.md
@@ -32,4 +32,4 @@
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE).

--- a/repository-containers/README.md
+++ b/repository-containers/README.md
@@ -10,4 +10,4 @@ If you are looking for a list of additional dev container definitions that are i
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/repository-containers/github.com/tensorflow/addons/.devcontainer/Dockerfile
+++ b/repository-containers/github.com/tensorflow/addons/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@ ARG USER_GID=$USER_UID
 # Options for common setup script - SHA updated on release
 ARG INSTALL_ZSH="false"
 ARG UPGRADE_PACKAGES="false"
-ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.

--- a/repository-containers/github.com/tensorflow/tensorflow/.devcontainer/Dockerfile
+++ b/repository-containers/github.com/tensorflow/tensorflow/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ ARG USER_GID=$USER_UID
 # Options for common setup script - SHA updated on release
 ARG INSTALL_ZSH="false"
 ARG UPGRADE_PACKAGES="false"
-ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh"
+ARG COMMON_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh"
 ARG COMMON_SCRIPT_SHA="dev-mode"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.

--- a/repository-containers/images/README.md
+++ b/repository-containers/images/README.md
@@ -6,4 +6,4 @@ This folder contains Dockerfiles for images that are pre-built and published and
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)

--- a/repository-containers/images/github.com/microsoft/vscode/.devcontainer/library-scripts/desktop-lite-debian.sh
+++ b/repository-containers/images/github.com/microsoft/vscode/.devcontainer/library-scripts/desktop-lite-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/desktop-lite.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/desktop-lite.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./desktop-lite-debian.sh [non-root user] [vnc password] [install no vnc flag]

--- a/repository-containers/images/github.com/microsoft/vscode/history/0.173.0.md
+++ b/repository-containers/images/github.com/microsoft/vscode/history/0.173.0.md
@@ -1,4 +1,4 @@
-# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/github.com/microsoft/vscode)
+# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/github.com/microsoft/vscode)
 
 **Image version:** 0.201.4
 

--- a/repository-containers/images/github.com/microsoft/vscode/history/0.174.0.md
+++ b/repository-containers/images/github.com/microsoft/vscode/history/0.174.0.md
@@ -1,4 +1,4 @@
-# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/github.com/microsoft/vscode)
+# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/github.com/microsoft/vscode)
 
 **Image version:** 0.201.4
 

--- a/repository-containers/images/github.com/microsoft/vscode/history/0.200.0.md
+++ b/repository-containers/images/github.com/microsoft/vscode/history/0.200.0.md
@@ -1,4 +1,4 @@
-# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/github.com/microsoft/vscode)
+# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/github.com/microsoft/vscode)
 
 **Image version:** 0.200.0
 

--- a/repository-containers/images/github.com/microsoft/vscode/history/0.201.4.md
+++ b/repository-containers/images/github.com/microsoft/vscode/history/0.201.4.md
@@ -1,4 +1,4 @@
-# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/github.com/microsoft/vscode)
+# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/github.com/microsoft/vscode)
 
 **Image version:** 0.201.4
 

--- a/repository-containers/images/github.com/microsoft/vscode/history/dev.md
+++ b/repository-containers/images/github.com/microsoft/vscode/history/dev.md
@@ -1,8 +1,8 @@
-# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/github.com/microsoft/vscode)
+# [github.com/microsoft/vscode](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/github.com/microsoft/vscode)
 
 **Image version:** dev
 
-**Source release/branch:** [master](https://github.com/microsoft/vscode-dev-containers/tree/master/containers/github.com/microsoft/vscode)
+**Source release/branch:** [main](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/github.com/microsoft/vscode)
 
 **Definition variations:**
 - [12](#variant-12)

--- a/script-library/README.md
+++ b/script-library/README.md
@@ -80,10 +80,10 @@ Note that the CI process for this repository will automatically keep scripts in 
 
 ### Downloading the script with curl / wget instead
 
-If you prefer, you can download the script using `curl` or `wget` and execute it instead. This can convenient to do with your own `Dockerfile`, but is generally avoided for definitions in this repository. To avoid unexpected issues, you should reference a release specific version of the script, rather than using master. For example:
+If you prefer, you can download the script using `curl` or `wget` and execute it instead. This can convenient to do with your own `Dockerfile`, but is generally avoided for definitions in this repository. To avoid unexpected issues, you should reference a release specific version of the script, rather than using main. For example:
 
 ```Dockerfile
-RUN bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh")" \
+RUN bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh")" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 ```
 
@@ -92,7 +92,7 @@ Or if you're not sure if `curl` is installed:
 ```Dockerfile
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive  \
     && apt-get -y install --no-install-recommends curl ca-certificates \
-    && bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/common-debian.sh")" \
+    && bash -c "$(curl -fsSL "https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/common-debian.sh")" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 ```
 
@@ -151,5 +151,5 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for details on contributing definition
 
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE)
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)
 

--- a/script-library/azcli-debian.sh
+++ b/script-library/azcli-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/azcli.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/azcli.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./azcli-debian.sh

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-alpine.sh [install zsh flag] [username] [user UID] [user GID] [install Oh My Zsh! flag]

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-debian.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag] [Add non-free packages]

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -5,7 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # ** This script is community supported **
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/common.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/common.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./common-redhat.sh [install zsh flag] [username] [user UID] [user GID] [upgrade packages flag] [install Oh My Zsh! flag]

--- a/script-library/desktop-lite-debian.sh
+++ b/script-library/desktop-lite-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/desktop-lite.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/desktop-lite.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./desktop-lite-debian.sh [non-root user] [vnc password] [install no vnc flag]

--- a/script-library/docker-debian.sh
+++ b/script-library/docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-debian.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user] [use moby]

--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./docker-in-docker-debian.sh [enable non-root docker access flag] [non-root user] [use moby]

--- a/script-library/docker-redhat.sh
+++ b/script-library/docker-redhat.sh
@@ -5,7 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # ** This script is community supported **
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md
 # Maintainer: @smankoo
 #
 # Syntax: ./docker-redhat.sh [enable non-root docker socket access flag] [source socket] [target socket] [non-root user]

--- a/script-library/docs/sshd.md
+++ b/script-library/docs/sshd.md
@@ -111,13 +111,13 @@ If you already have a running container, you can use the script to spin up SSH i
 2. Open a terminal in VS Code and run the following if you're connected as a non-root user and `sudo` is installed:
 
     ```bash
-    sudo bash -c "$(curl -sSL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/sshd-debian.sh)" -- 2222 $(whoami) true random
+    sudo bash -c "$(curl -sSL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/sshd-debian.sh)" -- 2222 $(whoami) true random
     ```
 
     Or if running as root:
 
     ```bash
-    bash -c "$(curl -sSL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/master/script-library/sshd-debian.sh)" -- 2222 $(whoami) true random
+    bash -c "$(curl -sSL https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/sshd-debian.sh)" -- 2222 $(whoami) true random
     ```
 
 3. Take note of the password that was generated and the SSH command.

--- a/script-library/fish-debian.sh
+++ b/script-library/fish-debian.sh
@@ -5,7 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # ** This script is community supported **
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/fish.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/fish.md
 # Maintainer: @andreiborisov
 #
 # Syntax: ./fish-debian.sh [whether to install Fisher] [non-root user]

--- a/script-library/git-from-src-debian.sh
+++ b/script-library/git-from-src-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/git-from-src.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/git-from-src.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./git-from-src-debian.sh [version]

--- a/script-library/git-lfs-debian.sh
+++ b/script-library/git-lfs-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/git-lfs.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/git-lfs.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./git-lfs-debian.sh

--- a/script-library/github-debian.sh
+++ b/script-library/github-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/github.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/github.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./github-debian.sh [version]

--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/go.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/go.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./go-debian.sh [Go version] [GOROOT] [GOPATH] [non-root user] [Add GOPATH, GOROOT to rc files flag] [Install tools flag]

--- a/script-library/gradle-debian.sh
+++ b/script-library/gradle-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/gradle.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/gradle.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./gradle-debian.sh [Gradle version] [SDKMAN_DIR] [non-root user] [Update rc files flag]

--- a/script-library/homebrew-debian.sh
+++ b/script-library/homebrew-debian.sh
@@ -5,7 +5,7 @@
 #-------------------------------------------------------------------------------------------------------------
 #
 # ** This script is community supported **
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/homebrew.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/homebrew.md
 # Maintainer: @andreiborisov
 #
 # Syntax: ./homebrew-debian.sh [non-root user] [add Homebrew binaries to PATH] [whether to use shallow clone] [where to install Homebrew]

--- a/script-library/java-debian.sh
+++ b/script-library/java-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/java.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/java.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./java-debian.sh [JDK version] [SDKMAN_DIR] [non-root user] [Add to rc files flag]

--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/kubectl-helm.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/kubectl-helm.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./kubectl-helm-debian.sh [kubectl verison] [Helm version] [minikube version] [kubectl SHA256] [Helm SHA256] [minikube SHA256]
@@ -124,7 +124,7 @@ if [ "${MINIKUBE_VERSION}" != "none" ]; then
 fi
 
 if ! type docker > /dev/null 2>&1; then
-    echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/docker.md'
+    echo -e '\n(*) Warning: The docker command was not found.\n\nYou can use one of the following scripts to install it:\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker-in-docker.md\n\nor\n\nhttps://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/docker.md'
 fi
 
 echo -e "\nDone!"

--- a/script-library/maven-debian.sh
+++ b/script-library/maven-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/maven.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/maven.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./maven-debian.sh [maven version] [SDKMAN_DIR] [non-root user] [Update rc files flag]

--- a/script-library/node-debian.sh
+++ b/script-library/node-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/node.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]

--- a/script-library/powershell-debian.sh
+++ b/script-library/powershell-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/powershell.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/powershell.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./powershell-debian.sh

--- a/script-library/python-debian.sh
+++ b/script-library/python-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/python.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/python.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./python-debian.sh [Python Version] [Python intall path] [PIPX_HOME] [non-root user] [Update rc files flag] [install tools]

--- a/script-library/ruby-debian.sh
+++ b/script-library/ruby-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/ruby.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/ruby.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./ruby-debian.sh [Ruby version] [non-root user] [Add to rc files flag] [Install tools flag]

--- a/script-library/rust-debian.sh
+++ b/script-library/rust-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/rust.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/rust.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./rust-debian.sh [CARGO_HOME] [RUSTUP_HOME] [non-root user] [add CARGO/RUSTUP_HOME to rc files flag] [whether to update rust]

--- a/script-library/sshd-debian.sh
+++ b/script-library/sshd-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/sshd.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/sshd.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./sshd-debian.sh [SSH Port (don't use 22)] [non-root user] [start sshd now flag] [new password for user]

--- a/script-library/terraform-debian.sh
+++ b/script-library/terraform-debian.sh
@@ -4,7 +4,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 #
-# Docs: https://github.com/microsoft/vscode-dev-containers/blob/master/script-library/docs/terraform.md
+# Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/terraform.md
 # Maintainer: The VS Code and Codespaces Teams
 #
 # Syntax: ./terraform-debian.sh [terraform version] [tflint version] [terragrunt version]


### PR DESCRIPTION
Implements https://github.com/microsoft/vscode-dev-containers/issues/863. All other VS Code repositories have already switched.

//cc: @jkeech @joshspicer @chrmarti to see if there are any other impacts we need to consider before switching.

@bamurtaugh @2percentsilk We can update docs / links as it makes sense since master will auto redirect to main.