### PR TITLE
jekyll: update post-create.sh to install the Bundler version that was used to generate the Gemfile.lock

### DIFF
--- a/containers/jekyll/.devcontainer/post-create.sh
+++ b/containers/jekyll/.devcontainer/post-create.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Install the version of Bundler.
+if [ -f Gemfile.lock ] && grep "BUNDLED WITH" Gemfile.lock > /dev/null; then
+    cat Gemfile.lock | tail -n 2 | grep -C2 "BUNDLED WITH" | tail -n 1 | xargs gem install bundler -v
+fi
+
 # If there's a Gemfile, then run `bundle install`
 # It's assumed that the Gemfile will install Jekyll too
 if [ -f Gemfile ]; then


### PR DESCRIPTION
In setting up a Codespace for a site of mine, `post-create.sh` failed. This was because my Gemfile.lock contained these lines:

    BUNDLED WITH
      1.17.3

These lines indicate that the Bundler version that should be used with my Gemfile is 1.17.3. 
However, when the Dockerfile is run and the image created, it will get the latest bundler version of, today, 2.x.
When Bundler 2.x attempts to install gems for a Gemfile.lock BUNDLED WITH 1.x, it will fail.
In order to fix this, update the post-create.sh file to read the BUNDLED WITH declaration and install that version of Bundler.
When invoking the `bundle` command, it will read the Gemfile.lock and load the correct version automatically once it's installed.