### PR TITLE
Issue #884 - the two manpages packages can not be found.

### DIFF
--- a/containers/dart/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dart/.devcontainer/library-scripts/common-debian.sh
@@ -109,8 +109,6 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         ncdu \
         man-db \
         strace \
-        manpages \
-        manpages-dev \
         init-system-helpers"
         
     # Needed for adding manpages-posix and manpages-posix-dev which are non-free packages in Debian


### PR DESCRIPTION
remove dependencies that cant be found.
These packages can not be found when creating the container.
