### PR TITLE
Restore bashrc and profile from skeleton file if file doesn't exist

### DIFF
--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -207,6 +207,16 @@ else
     USER_RC_PATH="/home/${USERNAME}"
 fi
 
+# Restore user .bashrc defaults from skeleton file if it doesn't exist or is empty
+if [ ! -f "${USER_RC_PATH}/.bashrc" ] || [ ! -s "${USER_RC_PATH}/.bashrc" ] ; then
+    cp  /etc/skel/.bashrc "${USER_RC_PATH}/.bashrc"
+fi
+
+# Restore user .profile defaults from skeleton file if it doesn't exist or is empty
+if  [ ! -f "${USER_RC_PATH}/.profile" ] || [ ! -s "${USER_RC_PATH}/.profile" ] ; then
+    cp  /etc/skel/.profile "${USER_RC_PATH}/.profile"
+fi
+
 # .bashrc/.zshrc snippet
 RC_SNIPPET="$(cat << 'EOF'
 
@@ -293,6 +303,7 @@ EOF
 )"
 CODESPACES_ZSH="$(cat \
 <<'EOF'
+# Codespaces zsh prompt theme
 __zsh_prompt() {
     local prompt_username
     if [ ! -z "${GITHUB_USER}" ]; then 

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -207,6 +207,16 @@ else
     USER_RC_PATH="/home/${USERNAME}"
 fi
 
+# Restore user .bashrc defaults from skeleton file if it doesn't exist or is empty
+if [ ! -f "${USER_RC_PATH}/.bashrc" ] || [ ! -s "${USER_RC_PATH}/.bashrc" ] ; then
+    cp  /etc/skel/.bashrc "${USER_RC_PATH}/.bashrc"
+fi
+
+# Restore user .profile defaults from skeleton file if it doesn't exist or is empty
+if  [ ! -f "${USER_RC_PATH}/.profile" ] || [ ! -s "${USER_RC_PATH}/.profile" ] ; then
+    cp  /etc/skel/.profile "${USER_RC_PATH}/.profile"
+fi
+
 # .bashrc/.zshrc snippet
 RC_SNIPPET="$(cat << 'EOF'
 

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -303,6 +303,7 @@ EOF
 )"
 CODESPACES_ZSH="$(cat \
 <<'EOF'
+# Codespaces zsh prompt theme
 __zsh_prompt() {
     local prompt_username
     if [ ! -z "${GITHUB_USER}" ]; then 


### PR DESCRIPTION
fixes: https://github.com/microsoft/vscode-dev-containers/issues/878

Pulls from the skeleton file in our `common-debian.sh` if the .bashrc and .profile do not exist (or are empty).