### PR TITLE
Fix SDKMAN java version path issue

### DIFF
--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -24,7 +24,7 @@ ARG MAVEN_VERSION=""
 ARG INSTALL_GRADLE="false"
 ARG GRADLE_VERSION=""
 ENV SDKMAN_DIR="/usr/local/sdkman"
-ENV PATH="${PATH}:${SDKMAN_DIR}/java/current/bin:${SDKMAN_DIR}/maven/current/bin:${SDKMAN_DIR}/gradle/current/bin"
+ENV PATH="${SDKMAN_DIR}/java/current/bin:${PATH}:${SDKMAN_DIR}/maven/current/bin:${SDKMAN_DIR}/gradle/current/bin"
 RUN bash /tmp/library-scripts/java-debian.sh "none" "${SDKMAN_DIR}" "${USERNAME}" "true" \
     && if [ "${INSTALL_MAVEN}" = "true" ]; then bash /tmp/library-scripts/maven-debian.sh "${MAVEN_VERSION:-latest}" "${SDKMAN_DIR}" ${USERNAME} "true"; fi \
     && if [ "${INSTALL_GRADLE}" = "true" ]; then bash /tmp/library-scripts/gradle-debian.sh "${GRADLE_VERSION:-latest}" "${SDKMAN_DIR}" ${USERNAME} "true"; fi \

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "16", "11" ],
-	"definitionVersion": "0.202.0",
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
Resolves issue where the SDKMAN installed version of Java does not show up in the path if you are using a non-interactive terminal.  Related to #895.