### PR TITLE
Updated some Debian scripts to support arm

### DIFF
--- a/script-library/azcli-debian.sh
+++ b/script-library/azcli-debian.sh
@@ -27,7 +27,7 @@ if ! dpkg -s apt-transport-https curl ca-certificates lsb-release > /dev/null 2>
 fi
 
 # Install the Azure CLI
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
+echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
 curl -sL https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
 apt-get update
 apt-get install -y azure-cli

--- a/script-library/docker-debian.sh
+++ b/script-library/docker-debian.sh
@@ -53,10 +53,10 @@ apt-get-update-if-needed()
 # Ensure apt is in non-interactive to avoid prompts
 export DEBIAN_FRONTEND=noninteractive
 
-# Install apt-transport-https, curl, lsb-release, gpg if missing
-if ! dpkg -s apt-transport-https curl ca-certificates lsb-release > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+# Install apt-transport-https, curl, lsb-release, gpg, python3-pip, libffi-dev if missing
+if ! dpkg -s apt-transport-https curl ca-certificates lsb-release python3-pip libffi-dev > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
     apt-get-update-if-needed
-    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release gnupg2 
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release gnupg2 python3-pip libffi-dev
 fi
 
 # Install Docker / Moby CLI if not already installed
@@ -67,12 +67,12 @@ else
         DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
         CODENAME=$(lsb_release -cs)
         curl -s https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
-        echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+        echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
         apt-get update
         apt-get -y install --no-install-recommends moby-cli moby-buildx
     else
         curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
-        echo "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
+        echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
         apt-get update
         apt-get -y install --no-install-recommends docker-ce-cli
     fi
@@ -82,9 +82,8 @@ fi
 if type docker-compose > /dev/null 2>&1; then
     echo "Docker Compose already installed."
 else
-    LATEST_COMPOSE_VERSION=$(basename "$(curl -fsSL -o /dev/null -w "%{url_effective}" https://github.com/docker/compose/releases/latest)")
-    curl -fsSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    chmod +x /usr/local/bin/docker-compose
+    # Install from pip because the pre-built binaries don't exist for ARM
+    pip3 install docker-compose
 fi
 
 # If init file already exists, exit

--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -52,9 +52,9 @@ apt-get-update-if-needed()
 export DEBIAN_FRONTEND=noninteractive
 
 # Install docker/dockerd dependencies if missing
-if ! dpkg -s apt-transport-https curl ca-certificates lsb-release lxc pigz iptables > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
+if ! dpkg -s apt-transport-https curl ca-certificates lsb-release lxc pigz iptables python3-pip libffi-dev > /dev/null 2>&1 || ! type gpg > /dev/null 2>&1; then
     apt-get-update-if-needed
-    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release lxc pigz iptables gnupg2 
+    apt-get -y install --no-install-recommends apt-transport-https curl ca-certificates lsb-release lxc pigz iptables gnupg2 python3-pip libffi-dev
 fi
 
 # Swap to legacy iptables for compatibility
@@ -71,12 +71,12 @@ else
         DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
         CODENAME=$(lsb_release -cs)
         curl -s https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
-        echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+        echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
         apt-get update
         apt-get -y install --no-install-recommends moby-cli moby-buildx moby-engine
     else
         curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | (OUT=$(apt-key add - 2>&1) || echo $OUT)
-        echo "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
+        echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
         apt-get update
         apt-get -y install --no-install-recommends docker-ce-cli docker-ce
     fi
@@ -88,9 +88,8 @@ echo "Finished installing docker / moby"
 if type docker-compose > /dev/null 2>&1; then
     echo "Docker Compose already installed."
 else
-    LATEST_COMPOSE_VERSION=$(basename "$(curl -fsSL -o /dev/null -w "%{url_effective}" https://github.com/docker/compose/releases/latest)")
-    curl -fsSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-    chmod +x /usr/local/bin/docker-compose
+   # Install from pip because the pre-built binaries don't exist for ARM
+    pip3 install docker-compose
 fi
 
 # If init file already exists, exit

--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -23,6 +23,17 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
+# Get arch
+GO_ARCH=
+dpkgArch="$(dpkg --print-architecture)"
+case "${dpkgArch##*-}" in
+    amd64) GO_ARCH='amd64';;
+    arm64) GO_ARCH='arm64';;
+    armhf) GO_ARCH='armv6l';;
+    i386) GO_ARCH='386';;
+    *) echo "unsupported architecture"; exit 1 ;;
+esac
+
 # Ensure that login shells get the correct path if the user updated the PATH using ENV.
 rm -f /etc/profile.d/00-restore-env.sh
 echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
@@ -74,7 +85,7 @@ fi
 GO_INSTALL_SCRIPT="$(cat <<EOF
     set -e
     echo "Downloading Go ${TARGET_GO_VERSION}..."
-    curl -sSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-amd64.tar.gz"
+    curl -sSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${GO_ARCH}.tar.gz"
     echo "Extracting Go ${TARGET_GO_VERSION}..."
     tar -xzf /tmp/go.tar.gz -C "${TARGET_GOROOT}" --strip-components=1
     rm -f /tmp/go.tar.gz

--- a/script-library/powershell-debian.sh
+++ b/script-library/powershell-debian.sh
@@ -30,7 +30,7 @@ fi
 DISTRO=$(lsb_release -is | tr '[:upper:]' '[:lower:]')
 CODENAME=$(lsb_release -cs)
 curl -s https://packages.microsoft.com/keys/microsoft.asc | (OUT=$(apt-key add - 2>&1) || echo $OUT)
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
+echo "deb [arch=$(dpkg --print-architecture)] https://packages.microsoft.com/repos/microsoft-${DISTRO}-${CODENAME}-prod ${CODENAME} main" > /etc/apt/sources.list.d/microsoft.list
 apt-get update -yq
 apt-get install -yq powershell
 echo "Done!"


### PR DESCRIPTION
This PR updates **some** (not all) scripts in script-library to add fixes so they can be used to build arm64 containers too. Note that the PR doesn't add full arm64 support for the repo (see #558), but it does offer some help in that direction.

How this came to be: I wanted to be able to use a devcontainer on a M1 Mac. The base images that we currently publish don't support ARM, so I resorted to creating my own containers but I used the scripts in the script-library folder to make things easier for me.