### PR TITLE
Codespaces/git editor

### DIFF
--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -298,10 +298,16 @@ __bash_prompt() {
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
     unset -f __bash_prompt
 }
-__bash_prompt
 
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    $GIT_EDITOR="vscode"
+fi
+
+__bash_prompt
 EOF
 )"
+
 CODESPACES_ZSH="$(cat \
 <<'EOF'
 # Codespaces zsh prompt theme
@@ -321,6 +327,12 @@ ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
+
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    $GIT_EDITOR="vscode"
+fi
+
 __zsh_prompt
 EOF
 )"

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -301,7 +301,7 @@ __bash_prompt() {
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    $GIT_EDITOR="vscode"
+    export GIT_EDITOR="vscode"
 fi
 
 __bash_prompt
@@ -330,7 +330,7 @@ ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    $GIT_EDITOR="vscode"
+    export GIT_EDITOR="vscode"
 fi
 
 __zsh_prompt

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -327,12 +327,11 @@ __zsh_prompt() {
     PROMPT+='$(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}' # Git status
     unset -f __zsh_prompt
 }
-__zsh_prompt
-
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
+__zsh_prompt
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -302,9 +302,9 @@ __bash_prompt() {
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders"
+        export GIT_EDITOR="code-insiders --wait"
     else
-        export GIT_EDITOR="code"
+        export GIT_EDITOR="code --wait"
     fi
 fi
 
@@ -335,9 +335,9 @@ ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders"
+        export GIT_EDITOR="code-insiders --wait"
     else
-        export GIT_EDITOR="code"
+        export GIT_EDITOR="code --wait"
     fi
 fi
 

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -236,6 +236,15 @@ if [ -t 1 ] && [[ "${TERM_PROGRAM}" = "vscode" || "${TERM_PROGRAM}" = "codespace
     ((sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") &)
 fi
 
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders --wait"
+    else
+        export GIT_EDITOR="code --wait"
+    fi
+fi
+
 EOF
 )"
 
@@ -300,15 +309,6 @@ __bash_prompt() {
 }
 __bash_prompt
 
-# Set the default git editor
-if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders --wait"
-    else
-        export GIT_EDITOR="code --wait"
-    fi
-fi
-
 EOF
 )"
 
@@ -332,15 +332,6 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 __zsh_prompt
-
-# Set the default git editor
-if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders --wait"
-    else
-        export GIT_EDITOR="code --wait"
-    fi
-fi
 
 EOF
 )"

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -238,9 +238,9 @@ fi
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
+    if [[ -n $(command -v code-insiders) &&  -z $(command -v code) ]]; then 
         export GIT_EDITOR="code-insiders --wait"
-    else
+    else 
         export GIT_EDITOR="code --wait"
     fi
 fi

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -301,7 +301,11 @@ __bash_prompt() {
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    export GIT_EDITOR="vscode"
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders"
+    else
+        export GIT_EDITOR="code"
+    fi
 fi
 
 __bash_prompt
@@ -330,7 +334,11 @@ ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    export GIT_EDITOR="vscode"
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders"
+    else
+        export GIT_EDITOR="code"
+    fi
 fi
 
 __zsh_prompt

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -298,6 +298,7 @@ __bash_prompt() {
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
     unset -f __bash_prompt
 }
+__bash_prompt
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
@@ -308,7 +309,6 @@ if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     fi
 fi
 
-__bash_prompt
 EOF
 )"
 
@@ -327,6 +327,8 @@ __zsh_prompt() {
     PROMPT+='$(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}' # Git status
     unset -f __zsh_prompt
 }
+__zsh_prompt
+
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
@@ -341,7 +343,6 @@ if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     fi
 fi
 
-__zsh_prompt
 EOF
 )"
 

--- a/containers/codespaces-linux/.devcontainer/setup-user.sh
+++ b/containers/codespaces-linux/.devcontainer/setup-user.sh
@@ -16,20 +16,5 @@ sudo -u ${USERNAME} mkdir /home/${USERNAME}/.vsonline
 groupadd -g 800 docker
 usermod -a -G docker ${USERNAME}
 
-# Set VS Code as user's git edtior
-tee /tmp/scripts/git-ed.sh > /dev/null << EOF
-#!/usr/bin/env bash
-
-if [[ \$(which code-insiders) && ! \$(which code) ]]; then
-  GIT_ED="code-insiders"
-else
-  GIT_ED="code"
-fi
-
-\$GIT_ED --wait \$@
-EOF
-
+# Create user's .local/bin
 sudo -u ${USERNAME} mkdir -p /home/${USERNAME}/.local/bin
-install -o ${USERNAME} -g ${USERNAME} -m 755 /tmp/scripts/git-ed.sh /home/${USERNAME}/.local/bin/git-ed.sh
-sudo -u ${USERNAME} git config --global core.editor "/home/${USERNAME}/.local/bin/git-ed.sh"
-rm -f /tmp/scripts/git-ed.sh

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -171,9 +171,9 @@ fi
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
+    if [[ -n $(command -v code-insiders) &&  -z $(command -v code) ]]; then 
         export GIT_EDITOR="code-insiders --wait"
-    else
+    else 
         export GIT_EDITOR="code --wait"
     fi
 fi

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -224,9 +224,9 @@ __bash_prompt
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders"
+        export GIT_EDITOR="code-insiders --wait"
     else
-        export GIT_EDITOR="code"
+        export GIT_EDITOR="code --wait"
     fi
 fi
 
@@ -254,9 +254,9 @@ __zsh_prompt
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders"
+        export GIT_EDITOR="code-insiders --wait"
     else
-        export GIT_EDITOR="code"
+        export GIT_EDITOR="code --wait"
     fi
 fi
 

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -223,7 +223,11 @@ __bash_prompt
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    export GIT_EDITOR="vscode"
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders"
+    else
+        export GIT_EDITOR="code"
+    fi
 fi
 
 EOF
@@ -249,7 +253,11 @@ __zsh_prompt
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    export GIT_EDITOR="vscode"
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders"
+    else
+        export GIT_EDITOR="code"
+    fi
 fi
 
 EOF

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -221,6 +221,11 @@ __bash_prompt() {
 }
 __bash_prompt
 
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    export GIT_EDITOR="vscode"
+fi
+
 EOF
 )"
 CODESPACES_ZSH="$(cat \
@@ -241,6 +246,12 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 __zsh_prompt
+
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    export GIT_EDITOR="vscode"
+fi
+
 EOF
 )"
 

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -169,6 +169,15 @@ if [ -t 1 ] && [[ "${TERM_PROGRAM}" = "vscode" || "${TERM_PROGRAM}" = "codespace
     ((sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") &)
 fi
 
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders --wait"
+    else
+        export GIT_EDITOR="code --wait"
+    fi
+fi
+
 EOF
 )"
 
@@ -221,15 +230,6 @@ __bash_prompt() {
 }
 __bash_prompt
 
-# Set the default git editor
-if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders --wait"
-    else
-        export GIT_EDITOR="code --wait"
-    fi
-fi
-
 EOF
 )"
 CODESPACES_ZSH="$(cat \
@@ -250,15 +250,6 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 __zsh_prompt
-
-# Set the default git editor
-if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders --wait"
-    else
-        export GIT_EDITOR="code --wait"
-    fi
-fi
 
 EOF
 )"

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -298,10 +298,16 @@ __bash_prompt() {
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
     unset -f __bash_prompt
 }
-__bash_prompt
 
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    $GIT_EDITOR="vscode"
+fi
+
+__bash_prompt
 EOF
 )"
+
 CODESPACES_ZSH="$(cat \
 <<'EOF'
 # Codespaces zsh prompt theme
@@ -321,6 +327,12 @@ ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
+
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    $GIT_EDITOR="vscode"
+fi
+
 __zsh_prompt
 EOF
 )"

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -301,7 +301,7 @@ __bash_prompt() {
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    $GIT_EDITOR="vscode"
+    export GIT_EDITOR="vscode"
 fi
 
 __bash_prompt
@@ -330,7 +330,7 @@ ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    $GIT_EDITOR="vscode"
+    export GIT_EDITOR="vscode"
 fi
 
 __zsh_prompt

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -327,12 +327,11 @@ __zsh_prompt() {
     PROMPT+='$(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}' # Git status
     unset -f __zsh_prompt
 }
-__zsh_prompt
-
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
+__zsh_prompt
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -302,9 +302,9 @@ __bash_prompt() {
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders"
+        export GIT_EDITOR="code-insiders --wait"
     else
-        export GIT_EDITOR="code"
+        export GIT_EDITOR="code --wait"
     fi
 fi
 
@@ -335,9 +335,9 @@ ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders"
+        export GIT_EDITOR="code-insiders --wait"
     else
-        export GIT_EDITOR="code"
+        export GIT_EDITOR="code --wait"
     fi
 fi
 

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -236,6 +236,15 @@ if [ -t 1 ] && [[ "${TERM_PROGRAM}" = "vscode" || "${TERM_PROGRAM}" = "codespace
     ((sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") &)
 fi
 
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders --wait"
+    else
+        export GIT_EDITOR="code --wait"
+    fi
+fi
+
 EOF
 )"
 
@@ -300,15 +309,6 @@ __bash_prompt() {
 }
 __bash_prompt
 
-# Set the default git editor
-if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders --wait"
-    else
-        export GIT_EDITOR="code --wait"
-    fi
-fi
-
 EOF
 )"
 
@@ -332,15 +332,6 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 __zsh_prompt
-
-# Set the default git editor
-if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders --wait"
-    else
-        export GIT_EDITOR="code --wait"
-    fi
-fi
 
 EOF
 )"

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -238,9 +238,9 @@ fi
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
+    if [[ -n $(command -v code-insiders) &&  -z $(command -v code) ]]; then 
         export GIT_EDITOR="code-insiders --wait"
-    else
+    else 
         export GIT_EDITOR="code --wait"
     fi
 fi

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -301,7 +301,11 @@ __bash_prompt() {
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    export GIT_EDITOR="vscode"
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders"
+    else
+        export GIT_EDITOR="code"
+    fi
 fi
 
 __bash_prompt
@@ -330,7 +334,11 @@ ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    export GIT_EDITOR="vscode"
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders"
+    else
+        export GIT_EDITOR="code"
+    fi
 fi
 
 __zsh_prompt

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -298,6 +298,7 @@ __bash_prompt() {
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "
     unset -f __bash_prompt
 }
+__bash_prompt
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
@@ -308,7 +309,6 @@ if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     fi
 fi
 
-__bash_prompt
 EOF
 )"
 
@@ -327,6 +327,8 @@ __zsh_prompt() {
     PROMPT+='$(git_prompt_info)%{$fg[white]%}$ %{$reset_color%}' # Git status
     unset -f __zsh_prompt
 }
+__zsh_prompt
+
 ZSH_THEME_GIT_PROMPT_PREFIX="%{$fg_bold[cyan]%}(%{$fg_bold[red]%}"
 ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
@@ -341,7 +343,6 @@ if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     fi
 fi
 
-__zsh_prompt
 EOF
 )"
 

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -216,7 +216,11 @@ __bash_prompt
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    export GIT_EDITOR="vscode"
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders"
+    else
+        export GIT_EDITOR="code"
+    fi
 fi
 
 EOF
@@ -242,7 +246,11 @@ __zsh_prompt
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    export GIT_EDITOR="vscode"
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders"
+    else
+        export GIT_EDITOR="code"
+    fi
 fi
 
 EOF

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -217,9 +217,9 @@ __bash_prompt
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders"
+        export GIT_EDITOR="code-insiders --wait"
     else
-        export GIT_EDITOR="code"
+        export GIT_EDITOR="code --wait"
     fi
 fi
 
@@ -247,9 +247,9 @@ __zsh_prompt
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
     if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders"
+        export GIT_EDITOR="code-insiders --wait"
     else
-        export GIT_EDITOR="code"
+        export GIT_EDITOR="code --wait"
     fi
 fi
 

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -162,6 +162,15 @@ if [ -t 1 ] && [[ "${TERM_PROGRAM}" = "vscode" || "${TERM_PROGRAM}" = "codespace
     ((sleep 10s; touch "$HOME/.config/vscode-dev-containers/first-run-notice-already-displayed") &)
 fi
 
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    if [[ $(which code-insiders) && ! $(which code) ]]; then
+        export GIT_EDITOR="code-insiders --wait"
+    else
+        export GIT_EDITOR="code --wait"
+    fi
+fi
+
 EOF
 )"
 
@@ -214,15 +223,6 @@ __bash_prompt() {
 }
 __bash_prompt
 
-# Set the default git editor
-if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders --wait"
-    else
-        export GIT_EDITOR="code --wait"
-    fi
-fi
-
 EOF
 )"
 CODESPACES_ZSH="$(cat \
@@ -243,15 +243,6 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 __zsh_prompt
-
-# Set the default git editor
-if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
-        export GIT_EDITOR="code-insiders --wait"
-    else
-        export GIT_EDITOR="code --wait"
-    fi
-fi
 
 EOF
 )"

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -214,6 +214,11 @@ __bash_prompt() {
 }
 __bash_prompt
 
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    export GIT_EDITOR="vscode"
+fi
+
 EOF
 )"
 CODESPACES_ZSH="$(cat \
@@ -234,6 +239,12 @@ ZSH_THEME_GIT_PROMPT_SUFFIX="%{$reset_color%} "
 ZSH_THEME_GIT_PROMPT_DIRTY=" %{$fg_bold[yellow]%}✗%{$fg_bold[cyan]%})"
 ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg_bold[cyan]%})"
 __zsh_prompt
+
+# Set the default git editor
+if  [ "${TERM_PROGRAM}" = "vscode" ]; then
+    export GIT_EDITOR="vscode"
+fi
+
 EOF
 )"
 

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -164,9 +164,9 @@ fi
 
 # Set the default git editor
 if  [ "${TERM_PROGRAM}" = "vscode" ]; then
-    if [[ $(which code-insiders) && ! $(which code) ]]; then
+    if [[ -n $(command -v code-insiders) &&  -z $(command -v code) ]]; then 
         export GIT_EDITOR="code-insiders --wait"
-    else
+    else 
         export GIT_EDITOR="code --wait"
     fi
 fi


### PR DESCRIPTION
fixes https://github.com/microsoft/vssaas-planning/issues/4165

Sets the `$GIT_EDITOR` environment variable in the common-*.sh scripts when the vscode integrated terminal is detected, causing git operations (commit msgs, etc) to open up in the editor by default.  

This is an improvement on the previous method for several reasons:
- It previous config only applied to the kitchensink, not other VS Code devcontainer images/samples- 
- It caused issues for non-VS Code clients, like SSH connections
- It was set in the global git config, which will be overwritten by a lot of user's dotfiles in codespaces.