### PR TITLE
Use new .env file for secret restoration in SSH script

### DIFF
--- a/script-library/sshd-debian.sh
+++ b/script-library/sshd-debian.sh
@@ -99,8 +99,10 @@ if [ "${CODESPACES}" != "true" ] || [ "${VSCDC_FIXED_SECRETS}" = "true" ] || [ !
     # Not codespaces, already run, or secrets already in environment, so return
     return
 fi
-if [ -f /workspaces/.codespaces/shared/.user-secrets.json ]; then
-   $(cat /workspaces/.codespaces/shared/.user-secrets.json | jq -r '.[] | select (.type=="EnvironmentVariable") | "export "+.name+"=\""+.value+"\""')
+if [ -f /workspaces/.codespaces/shared/.env ]; then
+    set -o allexport
+    . /workspaces/.codespaces/shared/.env
+    set +o allexport
 fi
 export VSCDC_FIXED_SECRETS=true
 EOF


### PR DESCRIPTION
This simplifies the code to restore secrets in Codespaces when using SSH to connect to a dev container.

Verified working using https://github.dev/Chuxel/ssh-env-fix-test

//cc: @chrmarti @jkeech as FYI