### PR TITLE
Change bash git ref prompt to more closely match zsh

### DIFF
--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -215,17 +215,12 @@ __bash_prompt() {
         && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
         && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
     local gitbranch='`\
-        export BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); \
-        if [ "${BRANCH}" = "HEAD" ]; then \
-            export BRANCH=$(git describe --contains --all HEAD 2>/dev/null); \
-        fi; \
-        if [ "${BRANCH}" != "" ]; then \
+        export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
             echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
             fi \
-            && echo -n "\[\033[0;36m\]) "; \
-        fi`'
+            && echo -n "\[\033[0;36m\]) "; `'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -216,11 +216,13 @@ __bash_prompt() {
         && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
     local gitbranch='`\
         export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
+        if [ "${BRANCH}" != "" ]; then \
             echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
-            fi \
+               fi \
             && echo -n "\[\033[0;36m\]) "; `'
+        fi`'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "

--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -221,7 +221,7 @@ __bash_prompt() {
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
                fi \
-            && echo -n "\[\033[0;36m\]) "; `'
+            && echo -n "\[\033[0;36m\]) "; \
         fi`'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -292,11 +292,13 @@ __bash_prompt() {
         && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
     local gitbranch='`\
         export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
+        if [ "${BRANCH}" != "" ]; then \
             echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
-            fi \
+               fi \
             && echo -n "\[\033[0;36m\]) "; `'
+        fi`'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -292,16 +292,11 @@ __bash_prompt() {
         && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
     local gitbranch='`\
         export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
-        if [ "${BRANCH}" = "HEAD" ]; then \
-            export BRANCH=$(git describe --contains --all HEAD 2>/dev/null); \
-        fi; \
-        if [ "${BRANCH}" != "" ]; then \
             echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
             fi \
-            && echo -n "\[\033[0;36m\]) "; \
-        fi`'
+            && echo -n "\[\033[0;36m\]) "; `'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -291,7 +291,7 @@ __bash_prompt() {
         && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
         && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
     local gitbranch='`\
-        export BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); \
+        export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
         if [ "${BRANCH}" = "HEAD" ]; then \
             export BRANCH=$(git describe --contains --all HEAD 2>/dev/null); \
         fi; \

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -297,7 +297,7 @@ __bash_prompt() {
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
                fi \
-            && echo -n "\[\033[0;36m\]) "; `'
+            && echo -n "\[\033[0;36m\]) "; \
         fi`'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -205,17 +205,12 @@ __bash_prompt() {
         && [ ! -z "${GITHUB_USER}" ] && echo -n "\[\033[0;32m\]@${GITHUB_USER} " || echo -n "\[\033[0;32m\]\u " \
         && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
     local gitbranch='`\
-        export BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); \
-        if [ "${BRANCH}" = "HEAD" ]; then \
-            export BRANCH=$(git describe --contains --all HEAD 2>/dev/null); \
-        fi; \
-        if [ "${BRANCH}" != "" ]; then \
+        export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
             echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
             fi \
-            && echo -n "\[\033[0;36m\]) "; \
-        fi`'
+            && echo -n "\[\033[0;36m\]) "; `'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -206,11 +206,13 @@ __bash_prompt() {
         && [ "$XIT" -ne "0" ] && echo -n "\[\033[1;31m\]➜" || echo -n "\[\033[0m\]➜"`'
     local gitbranch='`\
         export BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || git rev-parse --short HEAD 2>/dev/null); \
+        if [ "${BRANCH}" != "" ]; then \
             echo -n "\[\033[0;36m\](\[\033[1;31m\]${BRANCH}" \
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
-            fi \
+               fi \
             && echo -n "\[\033[0;36m\]) "; `'
+        fi`'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'
     PS1="${userpart} ${lightblue}\w ${gitbranch}${removecolor}\$ "

--- a/script-library/common-redhat.sh
+++ b/script-library/common-redhat.sh
@@ -211,7 +211,7 @@ __bash_prompt() {
             && if git ls-files --error-unmatch -m --directory --no-empty-directory -o --exclude-standard ":/*" > /dev/null 2>&1; then \
                     echo -n " \[\033[1;33m\]✗"; \
                fi \
-            && echo -n "\[\033[0;36m\]) "; `'
+            && echo -n "\[\033[0;36m\]) "; \
         fi`'
     local lightblue='\[\033[1;34m\]'
     local removecolor='\[\033[0m\]'


### PR DESCRIPTION
fixes https://github.com/github/codespaces/issues/3012

More closely matches [how ohmyzsh displays git ref information on a detached HEAD](https://github.com/ohmyzsh/ohmyzsh/blob/d646884add277d134235a9b18ab755388d6e0d8d/lib/git.zsh#L20-L23).  

The behavior in a standard common-debian bash shell, when browsing a detached HEAD, changes from: 

![image](https://user-images.githubusercontent.com/23246594/124681551-c2d2fd00-de96-11eb-86b5-e4c0a8429255.png)


to

![image](https://user-images.githubusercontent.com/23246594/124681393-6c65be80-de96-11eb-91f4-99118f236794.png)
