### PR TITLE
Adjust the post build script

### DIFF
--- a/repository-containers/github.com/python/cpython/.devcontainer/devcontainer.json
+++ b/repository-containers/github.com/python/cpython/.devcontainer/devcontainer.json
@@ -20,6 +20,6 @@
 		"ms-vscode.cpptools",
 		"ms-python.python"
 	],
-	"postCreateCommand": "./configure --with-pydebug --enable-shared && make -j4 regen-all &&  make -j4 -s",
+	"postCreateCommand": "./configure --with-pydebug && make -j4 regen-all &&  make -j4 -s && make install",
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ]
 }


### PR DESCRIPTION
This will create and install a standard binary instead of a shared library (better for most use cases)