### PR TITLE
enable html format templating

### DIFF
--- a/containers/hugo/.devcontainer/devcontainer.json
+++ b/containers/hugo/.devcontainer/devcontainer.json
@@ -17,7 +17,9 @@
 	},
 
 	// Set *default* container specific settings.json values on container create.
-	"settings": {},
+	"settings": {
+		"html.format.templating": true,
+	},
 	
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [


### PR DESCRIPTION
Add the template format option to prevent vscode from messing with the hugo template format in html files.