### PR TITLE
Update the R definition

### DIFF
--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# R version: latest, ... ,4.0.1 , 4.0.0
+# R version: latest, ... , 4.0.3
 ARG VARIANT="latest"
 FROM rocker/r-ver:${VARIANT}
 
@@ -29,7 +29,13 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && install2.r --error --skipinstalled --ncpus -1 \
         devtools \
         languageserver \
+        httpgd \
     && rm -rf /tmp/downloaded_packages
+
+# R Session watcher settings.
+# See more details: https://github.com/REditorSupport/vscode-R/wiki/R-Session-watcher
+RUN echo 'source(file.path(Sys.getenv("HOME"), ".vscode-R", "init.R"))' >> ${R_HOME}/etc/Rprofile.site \
+    && echo 'options(vsc.use_httpgd = TRUE)' >> ${R_HOME}/etc/Rprofile.site
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \

--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         libxt-dev \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts \
     && python3 -m pip --no-cache-dir install radian \
-    && install2.r --error --skipinstalled --repos ${CRAN} --ncpus -1 \
+    && install2.r --error --skipinstalled --ncpus -1 \
         devtools \
         languageserver \
     && rm -rf /tmp/downloaded_packages

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "R (Community)",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update VARIANT to pick a specific R version: latest, ... ,4.0.1 , 4.0.0
+		// Update VARIANT to pick a specific R version: latest, ... , 4.0.3
 		"args": { "VARIANT": "latest" }
 	},
 
@@ -12,6 +12,12 @@
 		"r.bracketedPaste": true,
 		"[r]": {
 			"editor.wordSeparators": "`~!@#%$^&*()-=+[{]}\\|;:'\",<>/?"
+		},
+		"terminal.integrated.profiles.linux": {
+			"radian": {
+				"path": "/usr/local/bin/radian",
+				"overrideName": true
+			}
 		}
 	},
 

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ikuyadeu.r",
+		"ikuyadeu.r"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
 	"settings": {
 		"r.rterm.linux": "/usr/local/bin/radian",
 		"r.bracketedPaste": true,
-		"r.sessionWatcher": true,
 		"[r]": {
 			"editor.wordSeparators": "`~!@#%$^&*()-=+[{]}\\|;:'\",<>/?"
 		}
@@ -19,7 +18,6 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ikuyadeu.r",
-		"reditorsupport.r-lsp"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
- Remove `reditorsupport.r-lsp` as its functionality has been merged into `ikuyadeu.r`. (https://github.com/REditorSupport/vscode-R/pull/695)
- `r.sessionWatcher` is now true by default, so remove it from settings. (https://github.com/REditorSupport/vscode-R/pull/670)
- Remove the `--repos` option from the `install2.r` command, which install the R packages in the container, as it is unnecessary. (Related to the base image improvement: https://github.com/rocker-org/rocker-versioned2/pull/195)
- Install the `httpgd` package for better plot viewer. (https://github.com/REditorSupport/vscode-R/pull/620)
- Edit the Rprofile to enable self-managed R sessions and use `httpgd` by default in VSCode.
- Add a setting to make it easier to use `radian` in the integrated terminal.

cc @kmehant @Ikuyadeu @randy3k @renkun-ken