### PR TITLE
Update vue .devcontainer template

### DIFF
--- a/containers/vue/.devcontainer/Dockerfile
+++ b/containers/vue/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 14, 12, 10
-ARG VARIANT=14
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT=16
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 RUN su node -c "umask 0002 && npm install -g http-server @vue/cli @vue/cli-service-global"

--- a/containers/vue/.devcontainer/devcontainer.json
+++ b/containers/vue/.devcontainer/devcontainer.json
@@ -3,8 +3,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
-		// Update 'VARIANT' to pick a Node version: 10, 12, 14
-		"args": { "VARIANT": "14" }
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
+		"args": { "VARIANT": "16" }
 	},
 
 	// Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
Since the recommended node version choices for [`javascript-node`](https://github.com/microsoft/vscode-dev-containers/blob/main/containers/javascript-node/.devcontainer/base.Dockerfile) has been changed, I updated the template for Vue, which relies on `javascript-node`.
- Remove choice for node version 10.
- Add choice for node version 16.
- Change default node version choice from 14 to 16.