### PR TITLE
add bash and zsh completion for kubectl

### DIFF
--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -67,7 +67,6 @@ kubectl completion bash > /etc/bash_completion.d/kubectl
 # kubectl zsh completion
 mkdir -p /home/${USERNAME}/.oh-my-zsh/completions
 kubectl completion zsh > /home/${USERNAME}/.oh-my-zsh/completions/_kubectl
-echo 'source $HOME/.oh-my-zsh/completions/_kubectl' >> /home/${USERNAME}/.zshrc
 
 # Install Helm, verify signature and checksum
 echo "Downloading Helm..."

--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -25,7 +25,7 @@ fi
 
 export DEBIAN_FRONTEND=noninteractive
 
-# Install curl if missing
+# Install curl and bash-completion if missing
 if ! dpkg -s curl ca-certificates coreutils gnupg2 bash-completion > /dev/null 2>&1; then
     if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
         apt-get update
@@ -61,8 +61,13 @@ if ! type kubectl > /dev/null 2>&1; then
     exit 1
 fi
 
-# generate kubectl bash completion
+# kubectl bash completion
 kubectl completion bash > /etc/bash_completion.d/kubectl
+
+# kubectl zsh completion
+mkdir -p /home/${USERNAME}/.oh-my-zsh/completions
+kubectl completion zsh > /home/${USERNAME}/.oh-my-zsh/completions/_kubectl
+echo 'source $HOME/.oh-my-zsh/completions/_kubectl' >> /home/${USERNAME}/.zshrc
 
 # Install Helm, verify signature and checksum
 echo "Downloading Helm..."

--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -26,11 +26,11 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 
 # Install curl if missing
-if ! dpkg -s curl ca-certificates coreutils gnupg2 > /dev/null 2>&1; then
+if ! dpkg -s curl ca-certificates coreutils gnupg2 bash-completion > /dev/null 2>&1; then
     if [ ! -d "/var/lib/apt/lists" ] || [ "$(ls /var/lib/apt/lists/ | wc -l)" = "0" ]; then
         apt-get update
     fi
-    apt-get -y install --no-install-recommends curl ca-certificates coreutils gnupg2
+    apt-get -y install --no-install-recommends curl ca-certificates coreutils gnupg2 bash-completion
 fi
 
 ARCHITECTURE="$(uname -m)"
@@ -60,6 +60,9 @@ if ! type kubectl > /dev/null 2>&1; then
     echo '(!) kubectl installation failed!'
     exit 1
 fi
+
+# generate kubectl bash completion
+kubectl completion bash > /etc/bash_completion.d/kubectl
 
 # Install Helm, verify signature and checksum
 echo "Downloading Helm..."


### PR DESCRIPTION
This PR adds bash and zsh completion for kubectl which provides a better developer experience and prevents inherited containers from having to implement.