### PR TITLE
Simplify node version selection

### DIFF
--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -24,14 +24,13 @@ RUN pip3 install ansible[azure]
 ARG INSTALL_AZURE_CLI="true"
 # [Option] Install Docker CLI
 ARG INSTALL_DOCKER="true"
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
 RUN if [ "${INSTALL_AZURE_CLI}" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
-    && if [ "${INSTALL_AZURE_CLI}" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+    && if [ "${NODE_VERSION}" != "none" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
     && if [ "${INSTALL_DOCKER}" = "true" ]; then \
         bash /tmp/library-scripts/docker-debian.sh "true" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}"; \
     else \

--- a/containers/azure-ansible/.devcontainer/devcontainer.json
+++ b/containers/azure-ansible/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"args": {
 			"INSTALL_AZURE_CLI": "true",
 			"INSTALL_DOCKER": "true",
-			"INSTALL_NODE": "true"
+			"NODE_VERSION": "lts"
 		}
 	},
 	"mounts": [

--- a/containers/azure-ansible/README.md
+++ b/containers/azure-ansible/README.md
@@ -20,15 +20,15 @@ While technically optional, this definition includes the Ansible extension. You 
 
 There are a few options you can pick from  by updating the following line in `.devcontainer/devcontainer.json`:
 
-```Dockerfile
+```jsonc
 "arg": {
    "INSTALL_AZURE_CLI": "true",
    "INSTALL_DOCKER": "true",
-   "INSTALL_NODE": "true"
+   "NODE_VERSION": "lts"
 }
 ```
 
-If you plan to use the Azure Cloud Shell for all of your Ansible operations, you can set `"INSTALL_DOCKER": "false"`. Conversely, if you do not plan to use Cloud Shell, you can set `"INSTALL_DOCKER": "false"`. By default, both are installed so you can decide later.
+If you plan to use the Azure Cloud Shell for all of your Ansible operations, you can set `"INSTALL_DOCKER": "false"`. Conversely, if you do not plan to use Cloud Shell, you can set `"NODE_VERSION": "none"`. By default, both are installed so you can decide later.
 
 Beyond `git`, this `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -27,7 +27,7 @@ ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
 RUN if [ "${INSTALL_AZURE_CLI}" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
-    && if [ "${NODE_VERSION}}" != "none" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+    && if [ "${NODE_VERSION}" != "none" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
     && if [ "${INSTALL_DOCKER}" = "true" ]; then \
         bash /tmp/library-scripts/docker-debian.sh "true" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}"; \
     else \

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -21,14 +21,13 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 ARG INSTALL_AZURE_CLI="true"
 # [Option] Install Docker CLI
 ARG INSTALL_DOCKER="true"
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
 RUN if [ "${INSTALL_AZURE_CLI}" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
-    && if [ "${INSTALL_NODE}" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+    && if [ "${NODE_VERSION}}" != "none" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
     && if [ "${INSTALL_DOCKER}" = "true" ]; then \
         bash /tmp/library-scripts/docker-debian.sh "true" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}"; \
     else \

--- a/containers/azure-terraform/.devcontainer/devcontainer.json
+++ b/containers/azure-terraform/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 			"TERRAGRUNT_VERSION": "0.28.1",
 			"INSTALL_AZURE_CLI": "true",
 			"INSTALL_DOCKER": "true",
-			"INSTALL_NODE": "true"
+			"NODE_VERSION": "lts/*"
 		}
 	},
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],

--- a/containers/azure-terraform/README.md
+++ b/containers/azure-terraform/README.md
@@ -31,11 +31,11 @@ You can also choose the specific version of Terraform installed by updating the 
    "TERRAGRUNT_VERSION": "0.28.1"
    "INSTALL_AZURE_CLI": "true",
    "INSTALL_DOCKER": "true",
-   "INSTALL_NODE": "true"
+   "NODE_VERSION": "lts"
 }
 ```
 
-If you plan to use the Azure Cloud Shell for all of your Terraform operations, you can set `"INSTALL_DOCKER": "false"`. Conversely, if you do not plan to use Cloud Shell, you can set `"INSTALL_DOCKER": "false"`. By default, both are installed so you can decide later.
+If you plan to use the Azure Cloud Shell for all of your Terraform operations, you can set `"INSTALL_DOCKER": "false"`. Conversely, if you do not plan to use Cloud Shell, you can set `"NODE_VERSION": "none"`. By default, both are installed so you can decide later.
 
 Beyond `git`, this `Dockerfile` includes `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 

--- a/containers/dapr-dotnet/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnet/.devcontainer/Dockerfile
@@ -2,10 +2,9 @@
 ARG VARIANT=3.1
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Option] Install Azure CLI
 ARG INSTALL_AZURE_CLI="false"

--- a/containers/dapr-dotnet/README.md
+++ b/containers/dapr-dotnet/README.md
@@ -53,8 +53,7 @@ Given how frequently ASP.NET applications use Node.js for front end code, this c
 
 ```yaml
 arg:
-  INSTALL_NODE: "true"
-  ARG NODE_VERSION: "10"
+  ARG NODE_VERSION: "14" # Set to "none" to skip Node.js installation
 ```
 
 If you would like to install the Azure CLI update this line in `.devcontainer/docker-compose.yml`:
@@ -62,8 +61,7 @@ If you would like to install the Azure CLI update this line in `.devcontainer/do
 ```yaml
 arg:
   INSTALL_AZURE_CLI: "true"
-  INSTALL_NODE: "true"
-  ARG NODE_VERSION: "10"
+  NODE_VERSION: "lts"
 ```
 
 If you've already opened your folder in a container, rebuild the container using the **Remote-Containers: Rebuild Container** command from the Command Palette (<kbd>F1</kbd>) so the settings take effect.

--- a/containers/dapr-dotnet/README.md
+++ b/containers/dapr-dotnet/README.md
@@ -53,7 +53,7 @@ Given how frequently ASP.NET applications use Node.js for front end code, this c
 
 ```yaml
 arg:
-  ARG NODE_VERSION: "14" # Set to "none" to skip Node.js installation
+  NODE_VERSION: "14" # Set to "none" to skip Node.js installation
 ```
 
 If you would like to install the Azure CLI update this line in `.devcontainer/docker-compose.yml`:

--- a/containers/dotnet-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnet-fsharp/.devcontainer/Dockerfile
@@ -1,9 +1,8 @@
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-5.0
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Option] Install Azure CLI
 ARG INSTALL_AZURE_CLI="false"

--- a/containers/dotnet-fsharp/.devcontainer/devcontainer.json
+++ b/containers/dotnet-fsharp/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Options
-			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*",
 			"INSTALL_AZURE_CLI": "false",
 			"UPGRADE_PACKAGES": "false"

--- a/containers/dotnet-fsharp/README.md
+++ b/containers/dotnet-fsharp/README.md
@@ -111,21 +111,19 @@ If you've already opened your folder in a container, rebuild the container using
 
 Given JavaScript front-end web client code written for use in conjunction with an ASP.NET back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "3.1",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10",
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 
 If you would like to install the Azure CLI update you can set the `INSTALL_AZURE_CLI` argument line in `.devcontainer/devcontainer.json`:
 
-```Dockerfile
+```json
 "args": {
     "VARIANT": "3.1",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10",
+    "NODE_VERSION": "14",
     "INSTALL_AZURE_CLI": "true"
 }
 ```

--- a/containers/dotnet-mssql/.devcontainer/Dockerfile
+++ b/containers/dotnet-mssql/.devcontainer/Dockerfile
@@ -2,10 +2,9 @@
 ARG VARIANT=3.1
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+RUN if [ "${NODE_VERSION}}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Option] Install Azure CLI
 ARG INSTALL_AZURE_CLI="false"

--- a/containers/dotnet-mssql/.devcontainer/Dockerfile
+++ b/containers/dotnet-mssql/.devcontainer/Dockerfile
@@ -3,8 +3,8 @@ ARG VARIANT=3.1
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
 
 # [Choice] Node.js version: none, lts, 16, 14, 12, 10
-ARG NODE_VERSION="lts/*"
-RUN if [ "${NODE_VERSION}}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Option] Install Azure CLI
 ARG INSTALL_AZURE_CLI="false"

--- a/containers/dotnet-mssql/.devcontainer/docker-compose.yml
+++ b/containers/dotnet-mssql/.devcontainer/docker-compose.yml
@@ -8,9 +8,9 @@ services:
       args:
         # [Choice] Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
         VARIANT: 3.1
-        # Options
-        INSTALL_NODE: "false"
+        # [Choice] Node.js version: none, lts, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
+        # [Option] Install Azure CLI
         INSTALL_AZURE_CLI: "false"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/dotnet-mssql/README.md
+++ b/containers/dotnet-mssql/README.md
@@ -93,8 +93,7 @@ Given how frequently ASP.NET applications use Node.js for front end code, this c
 ```yaml
 args:
   VARIANT: "3.1"
-  INSTALL_NODE: "true"
-  NODE_VERSION: "10"
+  NODE_VERSION: "14" # Set to "none" to skip Node.js installation
 ```
 
 If you would like to install the Azure CLI update you can set the `INSTALL_AZURE_CLI` argument line in `.devcontainer/docker-compose.yml`:
@@ -102,8 +101,7 @@ If you would like to install the Azure CLI update you can set the `INSTALL_AZURE
 ```yaml
 args:
   VARIANT: "3.1"
-  INSTALL_NODE: "true"
-  NODE_VERSION: "10"
+  NODE_VERSION: "14"
   INSTALL_AZURE_CLI: "true"
 ```
 

--- a/containers/dotnet/.devcontainer/Dockerfile
+++ b/containers/dotnet/.devcontainer/Dockerfile
@@ -2,10 +2,9 @@
 ARG VARIANT=3.1
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Option] Install Azure CLI
 ARG INSTALL_AZURE_CLI="false"

--- a/containers/dotnet/.devcontainer/base.Dockerfile
+++ b/containers/dotnet/.devcontainer/base.Dockerfile
@@ -16,13 +16,12 @@ ARG USER_GID=$USER_UID
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Azure CLI

--- a/containers/dotnet/.devcontainer/devcontainer.json
+++ b/containers/dotnet/.devcontainer/devcontainer.json
@@ -6,7 +6,6 @@
 			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
 			"VARIANT": "5.0",
 			// Options
-			"INSTALL_NODE": "true",
 			"NODE_VERSION": "lts/*",
 			"INSTALL_AZURE_CLI": "false"
 		}

--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -116,21 +116,19 @@ If you've already opened your folder in a container, rebuild the container using
 
 Given JavaScript front-end web client code written for use in conjunction with an ASP.NET back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "3.1",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10",
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 
 If you would like to install the Azure CLI update you can set the `INSTALL_AZURE_CLI` argument line in `.devcontainer/devcontainer.json`:
 
-```Dockerfile
+```jsonc
 "args": {
     "VARIANT": "3.1",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10",
+    "NODE_VERSION": "14", 
     "INSTALL_AZURE_CLI": "true"
 }
 ```

--- a/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
+++ b/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
@@ -17,14 +17,15 @@ ARG COMMON_SCRIPT_SHA="dev-mode"
 # Optional Settings for Phoenix
 ARG PHOENIX_VERSION="1.5.4"
 
-# [Optional] Settings for installing Node.js.
-ARG INSTALL_NODE="true"
 ARG NODE_SCRIPT_SOURCE="https://raw.githubusercontent.com/microsoft/vscode-dev-containers/main/script-library/node-debian.sh"
 ARG NODE_SCRIPT_SHA="dev-mode"
-ARG NODE_VERSION="lts/*"
+ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true
 ENV PATH=${NVM_DIR}/current/bin:${PATH}
+
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="lts/*"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 RUN apt-get update \
@@ -35,7 +36,7 @@ RUN apt-get update \
   && /bin/bash /tmp/common-setup.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" \
   #
   # [Optional] Install Node.js for use with web applications
-  && if [ "$INSTALL_NODE" = "true" ]; then \
+  && if [ "$NODE_VERSION" != "none" ]; then \
   curl -sSL ${NODE_SCRIPT_SOURCE} -o /tmp/node-setup.sh \
   && ([ "${NODE_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/node-setup.sh" | sha256sum -c -)) \
   && /bin/bash /tmp/node-setup.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; \

--- a/containers/elixir-phoenix-postgres/.devcontainer/docker-compose.yml
+++ b/containers/elixir-phoenix-postgres/.devcontainer/docker-compose.yml
@@ -11,7 +11,6 @@ services:
         # Phoenix Version: 1.4.17, 1.5.4, ...
         PHOENIX_VERSION: "1.5.7"
         # Node Version: 10, 11, ...
-        INSTALL_NODE: "true"
         NODE_VERSION: "10"
 
     volumes:

--- a/containers/elixir-phoenix-postgres/README.md
+++ b/containers/elixir-phoenix-postgres/README.md
@@ -40,8 +40,7 @@ services:
     args:
       # ...
       # Node Version: 10, 11, ...
-      INSTALL_NODE: true
-      NODE_VERSION: 10
+      NODE_VERSION: 14
       # ...
 ```
 

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -2,10 +2,9 @@
 ARG VARIANT=1
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" = "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -21,13 +21,12 @@ ENV GO111MODULE=auto
 RUN bash /tmp/library-scripts/go-debian.sh "none" "/usr/local/go" "${GOPATH}" "${USERNAME}" "false" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Remove library scripts for final image

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -6,7 +6,6 @@
 			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.15
 			"VARIANT": "1",
 			// Options
-			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -48,11 +48,10 @@ Alternatively, you can use the contents of `base.Dockerfile` to fully customize 
 
 Given JavaScript front-end web client code written for use in conjunction with a Go back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "1",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10"
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -9,10 +9,9 @@ ARG GRADLE_VERSION=""
 RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
     && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/java-8/.devcontainer/base.Dockerfile
+++ b/containers/java-8/.devcontainer/base.Dockerfile
@@ -13,10 +13,9 @@ RUN su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && if [ "
     && if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
     && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 &&  . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
 
-# [Optional] Install a version of Node.js using nvm for front end dev
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/java-8/.devcontainer/devcontainer.json
+++ b/containers/java-8/.devcontainer/devcontainer.json
@@ -5,7 +5,6 @@
 		"args": {
 			"INSTALL_MAVEN": "false",
 			"INSTALL_GRADLE": "false",
-			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/java-8/README.md
+++ b/containers/java-8/README.md
@@ -74,10 +74,9 @@ You can also specify the version of Gradle or Maven if needed.
 
 Given JavaScript front-end web client code written for use in conjunction with a Java back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can enable installation and change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10"
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -11,10 +11,9 @@ ARG GRADLE_VERSION=""
 RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
     && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" = "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -30,13 +30,12 @@ RUN bash /tmp/library-scripts/java-debian.sh "none" "${SDKMAN_DIR}" "${USERNAME}
     && if [ "${INSTALL_GRADLE}" = "true" ]; then bash /tmp/library-scripts/gradle-debian.sh "${GRADLE_VERSION:-latest}" "${SDKMAN_DIR}" ${USERNAME} "true"; fi \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH="${NVM_DIR}/current/bin:${PATH}"
-RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Remove library scripts for final image

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -8,7 +8,6 @@
 			// Options
 			"INSTALL_MAVEN": "false",
 			"INSTALL_GRADLE": "false",
-			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/java/README.md
+++ b/containers/java/README.md
@@ -83,11 +83,10 @@ You can also specify the version of Gradle or Maven if needed.
 
 Given JavaScript front-end web client code written for use in conjunction with a Java back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can enable installation and change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
    "VARIANT": "11",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10",
+    "NODE_VERSION": "10" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/php-mariadb/.devcontainer/Dockerfile
+++ b/containers/php-mariadb/.devcontainer/Dockerfile
@@ -15,10 +15,9 @@ RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --g
 # Install php-mysql driver
 RUN docker-php-ext-install mysqli pdo pdo_mysql
 
-# [Optional] Install a version of Node.js using nvm for front end dev
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/php-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/php-mariadb/.devcontainer/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       args:
         # [Choice] PHP version: 7, 7.4, 7.3
         VARIANT: "7"
-        # [Option] Install Node.js
-        INSTALL_NODE: "true"
+        # [Choice] Node.js version: none, lts, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/php-mariadb/README.md
+++ b/containers/php-mariadb/README.md
@@ -41,8 +41,7 @@ Given how frequently web applications use Node.js for front end code, this conta
 ```yaml
 args:
   VARIANT: "7"
-  INSTALL_NODE: "true"
-  NODE_VERSION: "10"
+  NODE_VERSION: "10" # Set to "none" to skip Node.js installation
 ```
 
 You also can connect to MariaDB from an external tool when using VS Code by updating `.devcontainer/devcontainer.json` as follows:

--- a/containers/php/.devcontainer/Dockerfile
+++ b/containers/php/.devcontainer/Dockerfile
@@ -2,10 +2,9 @@
 ARG VARIANT=7
 FROM mcr.microsoft.com/vscode/devcontainers/php:${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/php/.devcontainer/base.Dockerfile
+++ b/containers/php/.devcontainer/base.Dockerfile
@@ -33,13 +33,12 @@ RUN curl -sSL https://getcomposer.org/installer | php \
     && chmod +x composer.phar \
     && mv composer.phar /usr/local/bin/composer
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-RUN if [ "$INSTALL_NODE" = "true" ]; then /bin/bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Remove library scripts for final image

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -5,7 +5,6 @@
 		"args": { 
 			// Update VARIANT to pick a PHP version: 8, 8.0, 7, 7.4, 7.3
 			"VARIANT": "8",
-			"INSTALL_NODE": "true",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/php/README.md
+++ b/containers/php/README.md
@@ -50,11 +50,10 @@ Alternatively, you can use the contents of `base.Dockerfile` to fully customize 
 
 Given JavaScript front-end web client code written for use in conjunction with a PHP back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "7",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10"
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/python-3-anaconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/base.Dockerfile
@@ -15,13 +15,12 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Remove library scripts for final image

--- a/containers/python-3-anaconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-anaconda/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 		"context": "..",
 		"dockerfile": "Dockerfile",
 		"args": {
-			"INSTALL_NODE": "true",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/python-3-anaconda/README.md
+++ b/containers/python-3-anaconda/README.md
@@ -60,10 +60,9 @@ If you've already opened your folder in a container, rebuild the container using
 
 Given JavaScript front-end web client code written for use in conjunction with a Python back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10"
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -1,9 +1,8 @@
 FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # Copy environment.yml (if found) to a temp location so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.

--- a/containers/python-3-miniconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/base.Dockerfile
@@ -25,13 +25,12 @@ ENV PATH=${PATH}:${PIPX_BIN_DIR}
 RUN bash /tmp/library-scripts/python-debian.sh "none" "/opt/conda" "${PIPX_HOME}" "${USERNAME}" "false" \ 
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
  # Remove library scripts for final image

--- a/containers/python-3-miniconda/.devcontainer/devcontainer.json
+++ b/containers/python-3-miniconda/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
 		"context": "..",
 		"dockerfile": "Dockerfile",
 		"args": {
-			"INSTALL_NODE": "true",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/python-3-miniconda/README.md
+++ b/containers/python-3-miniconda/README.md
@@ -60,10 +60,9 @@ If you've already opened your folder in a container, rebuild the container using
 
 Given JavaScript front-end web client code written for use in conjunction with a Python back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10"
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -9,10 +9,9 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" = "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] If your requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/containers/python-3-postgres/.devcontainer/docker-compose.yml
+++ b/containers/python-3-postgres/.devcontainer/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       args:
         # [Choice] Python version: 3, 3.8, 3.7, 3.6
         VARIANT: 3
-        # [Choice] Install Node.js
-        INSTALL_NODE: "true"
+        # [Choice] Node.js version: none, lts, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/python-3-postgres/README.md
+++ b/containers/python-3-postgres/README.md
@@ -47,11 +47,10 @@ network_mode: service:db
 
 Given JavaScript front-end web client code written for use in conjunction with a Python back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/docker-compose.yml`.
 
-```json
+```yaml
 args:
   VARIANT: 3.7
-  INSTALL_NODE: "true",
-  NODE_VERSION: "10"
+  NODE_VERSION: "14" # Set to "none" to skip Node.js installation
 ```
 
 ### Installing or updating Python utilities

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -2,10 +2,9 @@
 ARG VARIANT=3
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -27,13 +27,12 @@ ENV PATH=${PATH}:${PIPX_BIN_DIR}
 RUN bash /tmp/library-scripts/python-debian.sh "none" "/usr/local" "${PIPX_HOME}" "${USERNAME}" \ 
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Remove library scripts for final image

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -7,7 +7,6 @@
 			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
 			"VARIANT": "3",
 			// Options
-			"INSTALL_NODE": "true",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -53,11 +53,10 @@ Beyond Python and `git`, this image / `Dockerfile` includes a number of Python t
 
 Given JavaScript front-end web client code written for use in conjunction with a Python back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "3",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10"
+    "NODE_VERSION": "10" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/ruby-rails-postgres/.devcontainer/Dockerfile
+++ b/containers/ruby-rails-postgres/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN gem install rails webdrivers
 # The value is a comma-separated list of allowed domains 
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev"
 
+# [Choice] Node.js version: lts, 16, 14, 12
 ARG NODE_VERSION="lts/*"
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 

--- a/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         # [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
         VARIANT: 2
-        # [Choice] Install Node.js
+        # [Choice] Node.js version: lts, 16, 14, 12
         NODE_VERSION: "lts/*"
 
     volumes:

--- a/containers/ruby-rails-postgres/README.md
+++ b/containers/ruby-rails-postgres/README.md
@@ -79,7 +79,7 @@ This container also includes Node.js. You can change the version of Node.js by u
 ```yaml
 args:
   VARIANT: 2.6
-  NODE_VERSION: "12"
+  NODE_VERSION: "12" # Set to "none" to skip Node.js installation
 ```
 
 ### Adding the definition to your folder

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -9,6 +9,7 @@ RUN gem install rails webdrivers
 # The value is a comma-separated list of allowed domains 
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev"
 
+# [Choice] Node.js version: lts, 16, 14, 12
 ARG NODE_VERSION="lts/*"
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 

--- a/containers/ruby-rails/README.md
+++ b/containers/ruby-rails/README.md
@@ -24,10 +24,10 @@ While this definition should work unmodified, you can select the version of Ruby
 
 This container also includes Node.js. You can change the version of Node.js by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "2",
-    "NODE_VERSION": "10",
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -5,6 +5,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 # Install Sinatra
 RUN gem install sinatra sinatra-reloader thin data_mapper dm-sqlite-adapter 
 
+# [Choice] Node.js version: lts, 16, 14, 12
 ARG NODE_VERSION="lts/*"
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 

--- a/containers/ruby-sinatra/README.md
+++ b/containers/ruby-sinatra/README.md
@@ -26,11 +26,10 @@ While this definition should work unmodified, you can select the version of Ruby
 
 Given JavaScript front-end web client code written for use in conjunction with a Ruby back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "2",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10",
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -2,10 +2,9 @@
 ARG VARIANT=2
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
+RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -21,13 +21,12 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && bash /tmp/library-scripts/ruby-debian.sh "none" "${USERNAME}" "true" "true" \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Option] Install Node.js 
-ARG INSTALL_NODE="true"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
-RUN if [ "$INSTALL_NODE" = "true" ]; then bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
  # Remove library scripts for final image

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -6,7 +6,6 @@
 			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
 			"VARIANT": "3",
 			// Options
-			"INSTALL_NODE": "true",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/ruby/README.md
+++ b/containers/ruby/README.md
@@ -50,11 +50,10 @@ Alternatively, you can use the contents of `base.Dockerfile` to fully customize 
 
 Given JavaScript front-end web client code written for use in conjunction with a Ruby back-end often requires the use of Node.js-based utilities to build, this container also includes `nvm` so that you can easily install Node.js. You can change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "2",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10"
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 

--- a/containers/swift/.devcontainer/Dockerfile
+++ b/containers/swift/.devcontainer/Dockerfile
@@ -23,14 +23,13 @@ RUN git clone https://github.com/vknabel/sourcekite \
     && ln -s /usr/lib/libsourcekitdInProc.so /usr/lib/sourcekitdInProc \
     && cd sourcekite && make install PREFIX=/usr/local -j2
 
-# [Option] Install Node.js
-ARG INSTALL_NODE="false"
-ARG NODE_VERSION="lts/*"
+# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}
 COPY library-scripts/node-debian.sh /tmp/library-scripts/
-RUN if [ "$INSTALL_NODE" = "true" ]; then /bin/bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; fi \
+RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 # [Optional] Uncomment this section to install additional OS packages you may want.

--- a/containers/swift/.devcontainer/devcontainer.json
+++ b/containers/swift/.devcontainer/devcontainer.json
@@ -6,7 +6,6 @@
 			// Update the VARIANT arg to pick a Swift version 
 			"VARIANT": "5.3",
 			// Options
-			"INSTALL_NODE": "false",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/swift/README.md
+++ b/containers/swift/README.md
@@ -24,11 +24,10 @@ While the definition itself works unmodified, you can select the version of Swif
 
 Given how frequently web applications use Node.js for front end code, this container also includes an optional install of Node.js. You can enable installation and change the version of Node.js installed or disable its installation by updating the `args` property in `.devcontainer/devcontainer.json`.
 
-```json
+```jsonc
 "args": {
     "VARIANT": "4",
-    "INSTALL_NODE": "true",
-    "NODE_VERSION": "10",
+    "NODE_VERSION": "14" // Set to "none" to skip Node.js installation
 }
 ```
 


### PR DESCRIPTION
This PR reduces the optional selection of a node version in a number of containers from a true/false install argument plus a version number to a version number where "none" is also a valid input.

This then also simplifies the UI and allows for a version of node to be selected rather than just assuming "lts/*" and requiring the devcontainer.json file to be modified after the fact (though this is still allowed).

This PR is also related to #615.