### PR TITLE
Codespaces - Oryx version bump to 20210728.1

### DIFF
--- a/containers/codespaces-linux/.devcontainer/base.Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/base.Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-FROM mcr.microsoft.com/oryx/build:vso-focal-exp-20210721.2 as kitchensink
+FROM mcr.microsoft.com/oryx/build:vso-focal-20210728.1 as kitchensink
 
 ARG USERNAME=codespace
 ARG USER_UID=1000

--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "1.5.0",
+	"definitionVersion": "1.6.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
@@ -11,7 +11,7 @@
 	},
 	"dependencies": {
 		"annotation": "This document describes the base contents of the default GitHub Codespaces dev container image. Note that this image also includes detection logic to dynamically install additional language / runtime versions based on your repository's contents. Dynamically installed content can be found in sub-folders under `/opt`.",
-		"image": "mcr.microsoft.com/oryx/build:vso-focal-exp-20210721.2",
+		"image": "mcr.microsoft.com/oryx/build:vso-focal-20210728.1",
 		"imageLink": "https://github.com/microsoft/oryx",
 		"apt": [{
 				"cgIgnore": false,


### PR DESCRIPTION
The image `exp-20210721.2` was creating `oryx-build-commands.txt` file in the user directory which we want to avoid. Hence, the old image was not pushed to prod. This image is built upon  `exp-20210721.2` with a fix to the bug.

https://github.com/microsoft/Oryx/releases/tag/20210728.1 