### PR TITLE
Increment breakfix number for images for 1.59 release

### DIFF
--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.14", "3.13", "3.12", "3.11"],
-	"definitionVersion": "0.202.0",
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",

--- a/containers/cpp/definition-manifest.json
+++ b/containers/cpp/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "focal", "bionic", "stretch"],
-	"definitionVersion": "0.201.7",
+	"definitionVersion": "0.201.8",
 	"build": {
 		"latest": true,
 		"parent": {

--- a/containers/debian/definition-manifest.json
+++ b/containers/debian/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "stretch"],
-	"definitionVersion": "0.201.7",
+	"definitionVersion": "0.201.8",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["5.0", "3.1", "2.1"],
-	"definitionVersion": "0.201.8",
+	"definitionVersion": "0.201.9",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["1.16", "1.15"],
-	"definitionVersion": "0.202.7",
+	"definitionVersion": "0.202.8",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/java-8/definition-manifest.json
+++ b/containers/java-8/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.202.2",
+	"definitionVersion": "0.202.3",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "16", "11" ],
-	"definitionVersion": "0.202.2",
+	"definitionVersion": "0.202.3",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["16-buster", "14-buster", "12-buster", "14-stretch", "12-stretch"],
-	"definitionVersion": "0.202.3",
+	"definitionVersion": "0.202.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/jekyll/definition-manifest.json
+++ b/containers/jekyll/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.0.1",
+	"definitionVersion": "0.0.2",
 	"build": {
 		"latest": true,
 		"parent": "ruby",

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["8.0", "7.4", "7.3"],
-	"definitionVersion": "0.201.7",
+	"definitionVersion": "0.201.8",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3-anaconda/definition-manifest.json
+++ b/containers/python-3-anaconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.201.6",
+	"definitionVersion": "0.201.7",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3-miniconda/definition-manifest.json
+++ b/containers/python-3-miniconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.201.6",
+	"definitionVersion": "0.201.7",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.9", "3.8", "3.7", "3.6"],
-	"definitionVersion": "0.201.7",
+	"definitionVersion": "0.201.8",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.0", "2.7", "2.6"],
-	"definitionVersion": "0.201.7",
+	"definitionVersion": "0.201.8",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/rust/definition-manifest.json
+++ b/containers/rust/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.200.6",
+	"definitionVersion": "0.200.7",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["16-buster", "14-buster", "12-buster", "14-stretch", "12-stretch"],
-	"definitionVersion": "0.202.3",
+	"definitionVersion": "0.202.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["focal", "bionic"],
-	"definitionVersion": "0.201.7",
+	"definitionVersion": "0.201.8",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",

--- a/repository-containers/images/github.com/microsoft/vscode/definition-manifest.json
+++ b/repository-containers/images/github.com/microsoft/vscode/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.202.3",
+	"definitionVersion": "0.202.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",


### PR DESCRIPTION
This PR is part of our roughly monthly release cycle for picking up library updates as a part of the VS Code release cycle. 

The "unversial" image is covered under #974

//cc @alexr00 with @chrmarti being OOF