### PR TITLE
remove R-LSP extension

### DIFF
--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -19,7 +19,6 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ikuyadeu.r",
-		"reditorsupport.r-lsp"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
Removed "R Language Server Pack" from `devcontainer.json` extensions. Enabling the extension in newer versions of VS Code results in the following error:
```
The R language server extension has been integrated into vscode-R. You need to disable or uninstall REditorSupport.r-lsp and reload window to use the new version.The R language server extension has been integrated into vscode-R. You need to disable or uninstall REditorSupport.r-lsp and reload window to use the new version.
``` 
![R](https://user-images.githubusercontent.com/16673615/127595100-baf0b2cf-4cfe-430d-af3d-cb68cfa63380.png)
