### PR TITLE
install dlv-dap and use `go install` to install go tools

### DIFF
--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -148,8 +148,8 @@ else
 fi
 
 # Install Go tools that are isImportant && !replacedByGopls based on
-# https://github.com/golang/vscode-go/blob/0c6dce4a96978f61b022892c1376fe3a00c27677/src/goTools.ts#L188
-# exception: golangci-lint is installed using their install script below.
+# https://github.com/golang/vscode-go/blob/0ff533d408e4eb8ea54ce84d6efa8b2524d62873/src/goToolsInformation.ts
+# Exception `dlv-dap` is a copy of github.com/go-delve/delve/cmd/dlv built from the master.
 GO_TOOLS="\
     golang.org/x/tools/gopls \
     honnef.co/go/tools/... \
@@ -167,12 +167,15 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     export GOPATH=/tmp/gotools
     export GOCACHE=/tmp/gotools/cache
 
-    # Go tools w/module support
-    export GO111MODULE=on
-    (echo "${GO_TOOLS}" | xargs -n 1 go get -v )2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
+    (echo "${GO_TOOLS}" | xargs -n 1 go install -v )2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
 
     # Move Go tools into path and clean up
     mv /tmp/gotools/bin/* ${TARGET_GOPATH}/bin/
+
+    # install dlv-dap (dlv@master)
+    go install -v github.com/go-delve/delve/cmd/dlv@master 2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
+    mv /tmp/gotools/bin/dlv ${TARGET_GOPATH}/bin/dlv-dap
+
     rm -rf /tmp/gotools
     chown -R ${USERNAME} "${TARGET_GOPATH}"
 fi

--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -151,14 +151,14 @@ fi
 # https://github.com/golang/vscode-go/blob/0ff533d408e4eb8ea54ce84d6efa8b2524d62873/src/goToolsInformation.ts
 # Exception `dlv-dap` is a copy of github.com/go-delve/delve/cmd/dlv built from the master.
 GO_TOOLS="\
-    golang.org/x/tools/gopls \
-    honnef.co/go/tools/... \
-    golang.org/x/lint/golint \
-    github.com/mgechev/revive \
-    github.com/uudashr/gopkgs/v2/cmd/gopkgs \
-    github.com/ramya-rao-a/go-outline \
-    github.com/go-delve/delve/cmd/dlv \
-    github.com/golangci/golangci-lint/cmd/golangci-lint"
+    golang.org/x/tools/gopls@latest \
+    honnef.co/go/tools/cmd/staticcheck@latest \
+    golang.org/x/lint/golint@latest \
+    github.com/mgechev/revive@latest \
+    github.com/uudashr/gopkgs/v2/cmd/gopkgs@latest \
+    github.com/ramya-rao-a/go-outline@latest \
+    github.com/go-delve/delve/cmd/dlv@latest \
+    github.com/golangci/golangci-lint/cmd/golangci-lint@latest"
 if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     echo "Installing common Go tools..."
     export PATH=${TARGET_GOROOT}/bin:${PATH}


### PR DESCRIPTION
dlv-dap is a delve built from the head.

since go1.16 (latest), 
* GO111MODULE=on is the default.
* `go install` is the recommended way of installing tools and from go1.17 (to be released soon), `go get` will print out
deprecation warning message and encourage users to use `go install`.
(If you want to keep this script usable for go1.15, I can revert this part back).

Fixes #984