### PR TITLE
Add global ts-node to TypeScript image

### DIFF
--- a/containers/typescript-node/.devcontainer/base.Dockerfile
+++ b/containers/typescript-node/.devcontainer/base.Dockerfile
@@ -3,7 +3,7 @@ ARG VARIANT=16-buster
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # Install tslint, typescript. eslint is installed by javascript image
-ARG NODE_MODULES="tslint-to-eslint-config typescript"
+ARG NODE_MODULES="tslint-to-eslint-config typescript ts-node"
 COPY library-scripts/meta.env /usr/local/etc/vscode-dev-containers
 RUN su node -c "umask 0002 && npm install -g ${NODE_MODULES}" \
     && npm cache clean --force > /dev/null 2>&1


### PR DESCRIPTION
I think a Node/TypeScript image could include ts-node by default installed globally, it would be smoother for many projects.