### PR TITLE
Fix incorrect "lts" version

### DIFF
--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ RUN pip3 install ansible[azure]
 ARG INSTALL_AZURE_CLI="true"
 # [Option] Install Docker CLI
 ARG INSTALL_DOCKER="true"
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 ARG INSTALL_AZURE_CLI="true"
 # [Option] Install Docker CLI
 ARG INSTALL_DOCKER="true"
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/dapr-dotnet/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnet/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT=3.1
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnet-fsharp/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-5.0
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-mssql/.devcontainer/Dockerfile
+++ b/containers/dotnet-mssql/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT=3.1
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-mssql/.devcontainer/docker-compose.yml
+++ b/containers/dotnet-mssql/.devcontainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         # [Choice] Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
         VARIANT: 3.1
-        # [Choice] Node.js version: none, lts, 16, 14, 12, 10
+        # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # [Option] Install Azure CLI
         INSTALL_AZURE_CLI: "false"

--- a/containers/dotnet/.devcontainer/Dockerfile
+++ b/containers/dotnet/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT=3.1
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet/.devcontainer/base.Dockerfile
+++ b/containers/dotnet/.devcontainer/base.Dockerfile
@@ -16,7 +16,7 @@ ARG USER_GID=$USER_UID
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
+++ b/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
@@ -24,7 +24,7 @@ ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true
 ENV PATH=${NVM_DIR}/current/bin:${PATH}
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT=1
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" = "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -21,7 +21,7 @@ ENV GO111MODULE=auto
 RUN bash /tmp/library-scripts/go-debian.sh "none" "/usr/local/go" "${GOPATH}" "${USERNAME}" "false" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ARG GRADLE_VERSION=""
 RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
     && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/java-8/.devcontainer/base.Dockerfile
+++ b/containers/java-8/.devcontainer/base.Dockerfile
@@ -13,7 +13,7 @@ RUN su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && if [ "
     && if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
     && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 &&  . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -11,7 +11,7 @@ ARG GRADLE_VERSION=""
 RUN if [ "${INSTALL_MAVEN}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install maven \"${MAVEN_VERSION}\""; fi \
     && if [ "${INSTALL_GRADLE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/sdkman/bin/sdkman-init.sh && sdk install gradle \"${GRADLE_VERSION}\""; fi
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" = "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -30,7 +30,7 @@ RUN bash /tmp/library-scripts/java-debian.sh "none" "${SDKMAN_DIR}" "${USERNAME}
     && if [ "${INSTALL_GRADLE}" = "true" ]; then bash /tmp/library-scripts/gradle-debian.sh "${GRADLE_VERSION:-latest}" "${SDKMAN_DIR}" ${USERNAME} "true"; fi \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Node.js version: 14, 12, 10
+        # [Choice] Node.js version: 16, 14, 12
         VARIANT: 14
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Node.js version: 14, 12, 10
+        # [Choice] Node.js version: 16, 14, 12
         VARIANT: 14
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/jekyll/.devcontainer/Dockerfile
+++ b/containers/jekyll/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/vscode/devcontainers/jekyll:0
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/jekyll/.devcontainer/base.Dockerfile
+++ b/containers/jekyll/.devcontainer/base.Dockerfile
@@ -12,7 +12,7 @@ ENV LANG=en_US.UTF-8 \
 # Install bundler, latest jekyll, and github-pages for older jekyll
 RUN gem install bundler jekyll github-pages
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/php-mariadb/.devcontainer/Dockerfile
+++ b/containers/php-mariadb/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --g
 # Install php-mysql driver
 RUN docker-php-ext-install mysqli pdo pdo_mysql
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/php-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/php-mariadb/.devcontainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         # [Choice] PHP version: 7, 7.4, 7.3
         VARIANT: "7"
-        # [Choice] Node.js version: none, lts, 16, 14, 12, 10
+        # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/php/.devcontainer/Dockerfile
+++ b/containers/php/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT=7
 FROM mcr.microsoft.com/vscode/devcontainers/php:${VARIANT}
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/php/.devcontainer/base.Dockerfile
+++ b/containers/php/.devcontainer/base.Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sSL https://getcomposer.org/installer | php \
     && chmod +x composer.phar \
     && mv composer.phar /usr/local/bin/composer
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/python-3-anaconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-anaconda/.devcontainer/base.Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/python-3-miniconda/.devcontainer/Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/vscode/devcontainers/miniconda:0-3
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/python-3-miniconda/.devcontainer/base.Dockerfile
+++ b/containers/python-3-miniconda/.devcontainer/base.Dockerfile
@@ -25,7 +25,7 @@ ENV PATH=${PATH}:${PIPX_BIN_DIR}
 RUN bash /tmp/library-scripts/python-debian.sh "none" "/opt/conda" "${PIPX_HOME}" "${USERNAME}" "false" \ 
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" = "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/python-3-postgres/.devcontainer/docker-compose.yml
+++ b/containers/python-3-postgres/.devcontainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         # [Choice] Python version: 3, 3.8, 3.7, 3.6
         VARIANT: 3
-        # [Choice] Node.js version: none, lts, 16, 14, 12, 10
+        # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT=3
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -27,7 +27,7 @@ ENV PATH=${PATH}:${PIPX_BIN_DIR}
 RUN bash /tmp/library-scripts/python-debian.sh "none" "/usr/local" "${PIPX_HOME}" "${USERNAME}" \ 
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/ruby-rails-postgres/.devcontainer/Dockerfile
+++ b/containers/ruby-rails-postgres/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ RUN gem install rails webdrivers
 # The value is a comma-separated list of allowed domains 
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev"
 
-# [Choice] Node.js version: lts, 16, 14, 12
+# [Choice] Node.js version: lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 

--- a/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         # [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
         VARIANT: 2
-        # [Choice] Node.js version: lts, 16, 14, 12
+        # [Choice] Node.js version: lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
 
     volumes:

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ RUN gem install rails webdrivers
 # The value is a comma-separated list of allowed domains 
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev"
 
-# [Choice] Node.js version: lts, 16, 14, 12
+# [Choice] Node.js version: lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 # Install Sinatra
 RUN gem install sinatra sinatra-reloader thin data_mapper dm-sqlite-adapter 
 
-# [Choice] Node.js version: lts, 16, 14, 12
+# [Choice] Node.js version: lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="lts/*"
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT=2
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && bash /tmp/library-scripts/ruby-debian.sh "none" "${USERNAME}" "true" "true" \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/swift/.devcontainer/Dockerfile
+++ b/containers/swift/.devcontainer/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone https://github.com/vknabel/sourcekite \
     && ln -s /usr/lib/libsourcekitdInProc.so /usr/lib/sourcekitdInProc \
     && cd sourcekite && make install PREFIX=/usr/local -j2
 
-# [Choice] Node.js version: none, lts, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \


### PR DESCRIPTION
`nvm` requires a `/*` after `lts` to install the latest LTS version.  While `node-debian.sh` handles this, there are a number of places where `nvm` is used directly since it's already present.  This PR moves to `lts/*` anywhere nvm is involved.

Resolves #987 and is broader than #988

We may want to consider a point release for this given how many people are likely to select `lts`. 

/cc: @2percentsilk @chrmarti @joshspicer @jkeech 