### PR TITLE
update golang to in-support versions (1.16 and 1.17)

### DIFF
--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version: 1, 1.16, 1.15
+# [Choice] Go version: 1, 1.16, 1.17
 ARG VARIANT=1
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 

--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version: 1, 1.16, 1.15
+# [Choice] Go version: 1, 1.16, 1.17
 ARG VARIANT=1
 FROM golang:${VARIANT}
 

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.15
+			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
 			"VARIANT": "1",
 			// Options
 			"NODE_VERSION": "lts/*"

--- a/containers/go/.devcontainer/library-scripts/go-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/go-debian.sh
@@ -169,7 +169,7 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
 
     # Use go get for versions of go under 1.16
     go_install_command=install
-    if [[ "1.16" > "$(go version | grep -oP 'go\K[0-9]+\.[0-9]+\.[0-9]+')" ]]; then
+    if [[ "1.16" > "$(go version | grep -oP 'go\K[0-9]+\.[0-9]+(\.[0-9]+)?')" ]]; then
         export GO111MODULE=on
         go_install_command=get
         echo "Go version < 1.16, using go get."

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/go |
-| *Available image variants* | 1, 1.15, 1.14 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list)) |
+| *Available image variants* | 1, 1.16, 1.17 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -24,21 +24,21 @@ See **[history](history)** for information on the contents of published images.
 While the definition itself works unmodified, you can select the version of Go the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "1.14" }
+"args": { "VARIANT": "1.17" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/vscode/devcontainers/go` (latest)
 - `mcr.microsoft.com/vscode/devcontainers/go:1`
-- `mcr.microsoft.com/vscode/devcontainers/go:1.15`
-- `mcr.microsoft.com/vscode/devcontainers/go:1.14`
+- `mcr.microsoft.com/vscode/devcontainers/go:1.16`
+- `mcr.microsoft.com/vscode/devcontainers/go:1.17`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/go:0-1.15`
-- `mcr.microsoft.com/vscode/devcontainers/go:0.202-1.15`
-- `mcr.microsoft.com/vscode/devcontainers/go:0.202.5-1.15`
+- `mcr.microsoft.com/vscode/devcontainers/go:0-1.16`
+- `mcr.microsoft.com/vscode/devcontainers/go:0.204-1.16`
+- `mcr.microsoft.com/vscode/devcontainers/go:0.204.5-1.16`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list).
 

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,6 +1,6 @@
 {
-	"variants": ["1.16", "1.15"],
-	"definitionVersion": "0.203.0",
+	"variants": ["1.16", "1.17"],
+	"definitionVersion": "0.204.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
@@ -8,7 +8,7 @@
 			"go:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"1.16": [ "go:${VERSION}-1" ]
+			"1.17": [ "go:${VERSION}-1" ]
 		}
 	},
 	"dependencies": {

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["1.16", "1.17"],
+	"variants": ["1.17", "1.16"],
 	"definitionVersion": "0.204.0",
 	"build": {
 		"latest": true,

--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -169,7 +169,7 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
 
     # Use go get for versions of go under 1.16
     go_install_command=install
-    if [[ "1.16" > "$(go version | grep -oP 'go\K[0-9]+\.[0-9]+\.[0-9]+')" ]]; then
+    if [[ "1.16" > "$(go version | grep -oP 'go\K[0-9]+\.[0-9]+(\.[0-9]+)?')" ]]; then
         export GO111MODULE=on
         go_install_command=get
         echo "Go version < 1.16, using go get."


### PR DESCRIPTION
closes https://github.com/microsoft/vscode-dev-containers/issues/1000

Updates our versions of `go` to track latest supported

### TODO
- [ ] Test with `dev` tag
- [ ] Bump repo version to do full release
- [ ] Update [tracking issue](https://github.com/microsoft/vscode-dev-containers/issues/532)
- [ ] Pull into Codespaces