### PR TITLE
Update R definition according to the extension update

### DIFF
--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# R version: latest, ... , 4.0.3
-ARG VARIANT="latest"
+# R version: 4, 4.1, 4.0
+ARG VARIANT="4"
 FROM rocker/r-ver:${VARIANT}
 
 # Use the [Option] comment to specify true/false arguments that should appear in VS Code UX
@@ -32,10 +32,12 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         httpgd \
     && rm -rf /tmp/downloaded_packages
 
+# VSCode R Debugger dependency, install the latest release version from GitHub.
+RUN Rscript -e 'remotes::install_github("ManuelHentschel/vscDebugger@*release", dependencies = FALSE)'
+
 # R Session watcher settings.
 # See more details: https://github.com/REditorSupport/vscode-R/wiki/R-Session-watcher
-RUN echo 'source(file.path(Sys.getenv("HOME"), ".vscode-R", "init.R"))' >> ${R_HOME}/etc/Rprofile.site \
-    && echo 'options(vsc.use_httpgd = TRUE)' >> ${R_HOME}/etc/Rprofile.site
+RUN echo 'source(file.path(Sys.getenv("HOME"), ".vscode-R", "init.R"))' >> ${R_HOME}/etc/Rprofile.site
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -2,14 +2,15 @@
 	"name": "R (Community)",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update VARIANT to pick a specific R version: latest, ... , 4.0.3
-		"args": { "VARIANT": "latest" }
+		// Update VARIANT to pick a specific R version: 4, 4.1, 4.0
+		"args": { "VARIANT": "4" }
 	},
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {
 		"r.rterm.linux": "/usr/local/bin/radian",
 		"r.bracketedPaste": true,
+		"r.plot.useHttpgd": true,
 		"[r]": {
 			"editor.wordSeparators": "`~!@#%$^&*()-=+[{]}\\|;:'\",<>/?"
 		},
@@ -23,7 +24,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ikuyadeu.r"
+		"ikuyadeu.r",
+		"rdebugger.r-debugger"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/containers/r/README.md
+++ b/containers/r/README.md
@@ -35,9 +35,9 @@ This definition includes some test code that will help you verify it is working 
 1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
 2. Clone this repository.
 3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
-4. Select the `containers/R` folder.
-5. After the folder has opened in the container, you should see the R version printed in the terminal.
-6. Now open the `test-project/sample.R` and press <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd> to run the script.
+4. Select the `containers/r` folder.
+5. Open the `test-project/hello.R` and press the "Run Source" icon displayed in the upper right (or <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>S</kbd> key) to run the code.
+6. You should see "Hello, remote world!" in a terminal window after the program executes.
 
 ## License
 

--- a/containers/r/test-project/hello.R
+++ b/containers/r/test-project/hello.R
@@ -1,0 +1,10 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+say_hello <- function(name) {
+  message(paste0("Hello, ", name, "!"))
+}
+
+say_hello("remote world")

--- a/containers/r/test-project/sample.R
+++ b/containers/r/test-project/sample.R
@@ -1,4 +1,0 @@
-# A sample R script
-
-myString <- "Hello, Remote World!"
-print ( myString)


### PR DESCRIPTION
Reflects extensions and base image updates, and makes improvements that weren't in time for the last PR #954.

1. Since the settings `vsc.use_httpgd = TRUE` made on `Rprofile` can now be done from `settings.json` too, delete it from the `Dockerfile` and move it to `devcontainer.json`. (https://github.com/REditorSupport/vscode-R/pull/743)
2. Change the VALIANT and comments to match other definitions as the base image now pushes minor and major version tags. (https://github.com/rocker-org/rocker-versioned2/pull/214)
3. Add a new extension `rdebugger.r-debugger` that enable debugging of R on VS Code and R package `vscDebugger` required by `rdebugger.r-debugger`. (Suggested by https://github.com/microsoft/vscode-dev-containers/pull/954#issuecomment-884057946)
4. Test project updates that resemble other definitions.  
However, I didn't add launch.json because I thought that execution using launch.json would be done on the debug terminal and confuse the user. (https://github.com/ManuelHentschel/VSCode-R-Debugger/issues/147)

cc @kmehant @renkun-ken @ManuelHentschel @ElianHugh