### PR TITLE
fix: update indentation in Dind-debian script

### DIFF
--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -128,7 +128,7 @@ else
         export PIP_CACHE_DIR=/tmp/pip-tmp/cache
         pipx install --system-site-packages --pip-args '--no-cache-dir --force-reinstall' docker-compose
         rm -rf /tmp/pip-tmp
-    else 
+    else
         LATEST_COMPOSE_VERSION=$(basename "$(curl -fsSL -o /dev/null -w "%{url_effective}" https://github.com/docker/compose/releases/latest)")
         curl -fsSL "https://github.com/docker/compose/releases/download/${LATEST_COMPOSE_VERSION}/docker-compose-$(uname -s)-${TARGET_COMPOSE_ARCH}" -o /usr/local/bin/docker-compose
         chmod +x /usr/local/bin/docker-compose
@@ -147,11 +147,12 @@ if [ "${ENABLE_NONROOT_DOCKER}" = "true" ]; then
     if ! getent group docker > /dev/null 2>&1; then
         groupadd docker
     fi
-        usermod -aG docker ${USERNAME}
+
+    usermod -aG docker ${USERNAME}
 fi
 
 tee /usr/local/share/docker-init.sh > /dev/null \
-<< 'EOF' 
+<< 'EOF'
 #!/usr/bin/env bash
 #-------------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -221,7 +222,7 @@ set -e
 
 set +e
 
-# Execute whatever commands were passed in (if any). This allows us 
+# Execute whatever commands were passed in (if any). This allows us
 # to set this script to ENTRYPOINT while still executing the default CMD.
 exec "$@"
 EOF


### PR DESCRIPTION
I found the indentation of `usermod -aG docker ${USERNAME}` to be incorrect. 

Signed-off-by: Aaqa Ishtyaq <aaqaishtyaq@gmail.com>