### PR TITLE
Update build system to use buildx, support multi-arch builds

### DIFF
--- a/build/assets/release-notes-variant-part.md
+++ b/build/assets/release-notes-variant-part.md
@@ -14,6 +14,8 @@
 
 **Linux distribution:** {{distro.prettyName}}{{#if distro.idLike}} ({{distro.idLike}}-like distro){{/if}}
 
+**Architectures:** {{architectures}}
+
 **Available (non-root) user:** {{image.user}}
 
 ### Contents

--- a/build/src/image-info.js
+++ b/build/src/image-info.js
@@ -189,8 +189,15 @@ async function generateReleaseNotesPart(contents, release, stubRegistry, stubReg
     const markdownFormatter = markdownFormatterFactory.getFormatter();
     const formattedContents = getFormattedContents(contents, markdownFormatter);
     formattedContents.hasPip = formattedContents.pip.length > 0 || formattedContents.pipx.length > 0;
-    formattedContents.tags = configUtils.getTagList(definitionId, release, 'full-only', stubRegistry,  stubRegistryPath, variant),
+    formattedContents.tags = configUtils.getTagList(definitionId, release, 'full-only', stubRegistry,  stubRegistryPath, variant);
     formattedContents.variant = variant;
+
+    // architecture property could be a single string, an array, or an object of arrays by variant
+    let architectures = configUtils.getBuildSettings(definitionId).architectures || ['linux/amd64'];
+    if (!Array.isArray(architectures)) {
+        architectures = architectures[variant];
+    }
+    formattedContents.architectures = architectures.reduce((prev, current, index) => index > 0 ? `${prev}, ${current}` : current, '');
     return releaseNotesVariantPartTemplate(formattedContents);
 }
 

--- a/build/src/push.js
+++ b/build/src/push.js
@@ -30,6 +30,16 @@ async function push(repo, release, updateLatest, registry, registryPath, stubReg
     const stagingFolder = await configUtils.getStagingFolder(release);
     await configUtils.loadConfig(stagingFolder);
 
+    // Use or create builder
+    console.log('(*) Setting up builder...');
+    const builders = await asyncUtils.exec('docker buildx ls');
+    if(builders.indexOf('vscode-dev-containers') < 0) {
+        await asyncUtils.spawn('docker', ['buildx', 'create', '--use', '--name', 'vscode-dev-containers']);
+    } else {
+        await asyncUtils.spawn('docker', ['buildx', 'use', 'vscode-dev-containers']);
+    }
+    await asyncUtils.spawn('docker', ['run', '--privileged', '--rm', 'tonistiigi/binfmt', '--install', 'all']);
+
     // Build and push subset of images
     const definitionsToPush = definitionId ? [definitionId] : configUtils.getSortedDefinitionBuildList(page, pageTotal, definitionsToSkip);
     await asyncUtils.forEach(definitionsToPush, async (currentDefinitionId) => {
@@ -52,7 +62,7 @@ async function pushImage(definitionId, repo, release, updateLatest,
     
     // Make sure there's a Dockerfile present
     if (!await asyncUtils.exists(dockerFilePath)) {
-        throw `Invalid path ${dockerFilePath}`;
+        throw `Definition ${definitionId} does not exist! Invalid path: ${definitionPath}`;
     }
 
     // Look for context in devcontainer.json and use it to build the Dockerfile
@@ -84,7 +94,26 @@ async function pushImage(definitionId, repo, release, updateLatest,
             // Determine tags to use
             const versionTags = configUtils.getTagList(definitionId, release, updateLatest, registry, registryPath, variant);
             console.log(`(*) Tags:${versionTags.reduce((prev, current) => prev += `\n     ${current}`, '')}`);
-
+            let architectures = configUtils.getBuildSettings(definitionId).architectures;
+            switch (typeof architectures) {
+                case 'string': architectures = [architectures]; break;
+                case 'object': if (!Array.isArray(architectures)) { architectures = architectures[variant]; } break;
+                case 'undefined': architectures = ['linux/amd64']; break;
+            }
+            console.log(`(*) Target image architectures: ${architectures.reduce((prev, current) => prev += `\n     ${current}`, '')}`);
+            let localArchitecture = process.arch;
+            switch(localArchitecture) {
+                case 'arm': localArchitecture = 'linux/arm/v7'; break;
+                case 'aarch32': localArchitecture = 'linux/arm/v7'; break;
+                case 'aarch64': localArchitecture = 'linux/arm64'; break;
+                case 'x64': localArchitecture = 'linux/amd64'; break;
+                case 'x32': localArchitecture = 'linux/386'; break;
+                default: localArchitecture = `linux/${localArchitecture}`; break;
+            }
+            console.log(`(*) Local architecture: ${localArchitecture}`);
+            if (!pushImages) {
+                console.log(`(*) Push disabled: Only building local architecture (${localArchitecture}).`);
+            }
             if (replaceImage || !await isDefinitionVersionAlreadyPublished(definitionId, release, registry, registryPath, variant)) {
                 const context = devContainerJson.build ? devContainerJson.build.context || '.' : devContainerJson.context || '.';
                 const workingDir = path.resolve(dotDevContainerPath, context);
@@ -93,7 +122,8 @@ async function pushImage(definitionId, repo, release, updateLatest,
                     .concat(versionTags.reduce((prev, current) => prev.concat(['-t', current]), []));
                 const spawnOpts = { stdio: 'inherit', cwd: workingDir, shell: true };
                 await asyncUtils.spawn('docker', [
-                        'build', 
+                        'buildx',
+                        'build',
                         workingDir,
                         '-f', dockerFilePath, 
                         '--label', `version=${prepResult.meta.version}`,
@@ -101,16 +131,14 @@ async function pushImage(definitionId, repo, release, updateLatest,
                         '--label', `${imageLabelPrefix}.variant=${prepResult.meta.variant}`,
                         '--label', `${imageLabelPrefix}.release=${prepResult.meta.gitRepositoryRelease}`,
                         '--label', `${imageLabelPrefix}.source=${prepResult.meta.gitRepository}`,
-                        '--label', `${imageLabelPrefix}.timestamp='${prepResult.meta.buildTimestamp}'`
-                    ].concat(buildParams), spawnOpts);
-
-                // Push
-                if (pushImages) {
-                    console.log(`(*) Pushing...`);
-                    await asyncUtils.forEach(versionTags, async (versionTag) => {
-                        await asyncUtils.spawn('docker', ['push', versionTag], spawnOpts);
-                    });
-                } else {
+                        '--label', `${imageLabelPrefix}.timestamp='${prepResult.meta.buildTimestamp}'`,
+                        '--builder', 'vscode-dev-containers',
+                        '--progress', 'plain',
+                        '--platform', pushImages ? architectures.reduce((prev, current) => prev + ',' + current, '').substring(1) : localArchitecture,
+                        pushImages ? '--push' : '--load',
+                        ...buildParams
+                    ], spawnOpts);
+                if (!pushImages) {
                     console.log(`(*) Skipping push to registry.`);
                 }
             } else {

--- a/build/src/utils/async.js
+++ b/build/src/utils/async.js
@@ -51,7 +51,7 @@ module.exports = {
                     const stringChunk = chunk.toString();
                     result += stringChunk;
                     if (echo) {
-                        console.log(stringChunk);
+                        process.stdout.write(stringChunk);
                     }
                 });
             }
@@ -60,7 +60,7 @@ module.exports = {
                     const stringChunk = chunk.toString();
                     result += stringChunk;
                     if (echo) {
-                        console.error(stringChunk);
+                        process.stderr.write(stringChunk);
                     }
                 });
             }


### PR DESCRIPTION
Implements https://github.com/microsoft/vscode-dev-containers/issues/914. 

This PR does not update config to start building linux/arm64, but rather sets up the build system to do so. See https://github.com/microsoft/vscode-dev-containers/issues/558#issuecomment-905117722 for issues preventing switch, current plan of action.