### PR TITLE
Build arm64 image variations for the debian and ubuntu definitions for M1 macs

### DIFF
--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -11,8 +11,8 @@ jobs:
     name: Build and push images
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5]
-        page-total: [5]
+        page: [1, 2, 3, 4, 5, 6]
+        page-total: [6]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -30,8 +30,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     strategy:
       matrix:
-        page: [1, 2, 3, 4]
-        page-total: [4]
+        page: [1, 2, 3, 4, 5]
+        page-total: [5]
       fail-fast: true
     runs-on: ubuntu-latest
     steps:

--- a/containers/debian/README.md
+++ b/containers/debian/README.md
@@ -11,7 +11,7 @@
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/base:debian |
 | *Available image variants* | stretch, buster, bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `bullseye` and `stretch` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/debian/definition-manifest.json
+++ b/containers/debian/definition-manifest.json
@@ -1,22 +1,27 @@
 {
 	"variants": ["buster", "bullseye",  "stretch"],
-	"definitionVersion": "0.202.1",
+	"definitionVersion": "0.202.2",
 	"build": {
-		"latest": true,
+		"latest": "bullseye",
 		"rootDistro": "debian",
+		"architectures": {
+			"bullseye": ["linux/amd64", "linux/arm64"],
+			"buster": ["linux/amd64"],
+			"stretch": ["linux/amd64", "linux/arm64"]
+		},
 		"tags": [
 			"base:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
 			"bullseye": [
 				"base:${VERSION}-debian-11",
-				"base:${VERSION}-debian11"
+				"base:${VERSION}-debian11",
+				"base:${VERSION}-debian",
+				"base:${VERSION}"
 			],
 			"buster": [
 				"base:${VERSION}-debian-10",
-				"base:${VERSION}-debian10",
-				"base:${VERSION}-debian",
-				"base:${VERSION}"
+				"base:${VERSION}-debian10"
 			],
 			"stretch": [
 				"base:${VERSION}-debian-9",

--- a/containers/ubuntu/.devcontainer/Dockerfile
+++ b/containers/ubuntu/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ubuntu version: bionic, focal
+# [Choice] Ubuntu version: hirsute, bionic, focal
 ARG VARIANT=focal
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 

--- a/containers/ubuntu/.devcontainer/base.Dockerfile
+++ b/containers/ubuntu/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# Update the VARIANT arg in devcontainer.json to pick an Ubuntu version: focal, bionic
+# Update the VARIANT arg in devcontainer.json to pick an Ubuntu version: hirsute, focal, bionic
 ARG VARIANT="focal"
 FROM buildpack-deps:${VARIANT}-curl
 

--- a/containers/ubuntu/.devcontainer/devcontainer.json
+++ b/containers/ubuntu/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "Ubuntu",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Ubuntu version: focal, bionic
+		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
 		"args": { "VARIANT": "focal" }
 	},
 

--- a/containers/ubuntu/README.md
+++ b/containers/ubuntu/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Other |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/base:ubuntu |
-| *Available image variants* | bionic, focal ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | hirsute, focal, bionic ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `hirsute` (21.04) and `bionic` (18.04) variants  |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu |
@@ -29,15 +29,16 @@ While the definition itself works unmodified, you can select the version of Ubun
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
-- `mcr.microsoft.com/vscode/devcontainers/base:ubuntu` (latest)
+- `mcr.microsoft.com/vscode/devcontainers/base:ubuntu` (latest LTS release)
+- `mcr.microsoft.com/vscode/devcontainers/base:hirsute` (or `ubuntu-21.04`)
 - `mcr.microsoft.com/vscode/devcontainers/base:focal` (or `ubuntu-20.04`)
 - `mcr.microsoft.com/vscode/devcontainers/base:bionic` (or `ubuntu-18.04`)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/base:0-focal`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.201-focal`
-- `mcr.microsoft.com/vscode/devcontainers/base:0.201.4-focal`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.202-focal`
+- `mcr.microsoft.com/vscode/devcontainers/base:0.202.0-focal`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list).
 

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -2,7 +2,7 @@
 	"variants": ["hirsute", "focal", "bionic"],
 	"definitionVersion": "0.202.0",
 	"build": {
-		"latest": "focal",
+		"latest": false,
 		"rootDistro": "debian",
 		"architectures": {
 			"hirsute": ["linux/amd64", "linux/arm64"],

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -1,13 +1,22 @@
 {
-	"variants": ["focal", "bionic"],
-	"definitionVersion": "0.201.9",
+	"variants": ["hirsute", "focal", "bionic"],
+	"definitionVersion": "0.202.0",
 	"build": {
-		"latest": false,
+		"latest": "focal",
 		"rootDistro": "debian",
+		"architectures": {
+			"hirsute": ["linux/amd64", "linux/arm64"],
+			"focal": ["linux/amd64"],
+			"bionic": ["linux/amd64", "linux/arm64"]
+		},
 		"tags": [
 			"base:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
+			"hirsute": [
+				"base:${VERSION}-ubuntu-21.04",
+				"base:${VERSION}-ubuntu21.04"
+			],
 			"focal": [
 				"base:${VERSION}-ubuntu-20.04",
 				"base:${VERSION}-ubuntu20.04",


### PR DESCRIPTION
As described in https://github.com/microsoft/vscode-dev-containers/issues/558#issuecomment-905117722, the situation for Docker on M1 macs is not ideal since both `debian:buster` nor `ubuntu:focal` experience segmentation faults due to an issue in `libss1.1`. It seems unlikely that `buster` will be patched now that `bullseye` is out (and buster therefore gets security fixes only). Unclear about Ubuntu 20.04/Focal.

Therefore this PR:
1. Adds arm64 builds for Debian `bullseye` and `stretch`, but leaves `buster` as x86 only.
2. Adds arm64 builds for Ubuntu `bionic`, but leaves `focal` as x86 only.
3. Breaks our typical policy of focusing on LTS releases considering the situation and adds an Ubuntu 21.04 / `hirsute` variant with arm64 support.

//cc: @joshspicer @2percentsilk @bamurtaugh @chrmarti 

We can then move on to other images from here given many already have `bullseye` image variants we can use.