### PR TITLE
Add Javascript / Typescript arm64 images

### DIFF
--- a/containers/javascript-node/.devcontainer/Dockerfile
+++ b/containers/javascript-node/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12
-ARG VARIANT=16
+# [Choice] Node.js version: 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/javascript-node/.devcontainer/base.Dockerfile
+++ b/containers/javascript-node/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12
-ARG VARIANT=16-buster
+# [Choice] Node.js version: 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=16-bullseye
 FROM node:${VARIANT}
 
 # [Option] Install zsh

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -2,8 +2,9 @@
 	"name": "Node.js",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 12, 14, 16
-		"args": { "VARIANT": "16" }
+		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Append -bullseye or -buster to pin to an OS version.
+		"args": { "VARIANT": "16-bullseye" }
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/containers/javascript-node/README.md
+++ b/containers/javascript-node/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/javascript-node |
-| *Available image variants* | 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 12 / 12-bullseye, 14 / 14-bullseye, 16 / 16-bullseye, 12-buster, 14-buster, 16-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -23,22 +23,25 @@ See **[history](history)** for information on the contents of published images.
 
 While the definition itself works unmodified, you can select the version of Node.js the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
-```json
-"args": { "VARIANT": "12" }
+```jsonc
+// Or you can use 14-bullseye if you want to pin to an OS version
+"args": { "VARIANT": "14" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:16`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:14`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:12`
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:16` (or `16-bullseye` to stay on this OS version)
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:14` (or `14-bullseye` to stay on this OS version)
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:12` (or `12-bullseye` to stay on this OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0-12`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202-12`
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.202.1-12`
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-14` (or `0-14-bullseye`)
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.204-14` (or `0.203-14-bullseye`)
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.204.0-14` (or `0.203.0-14-bullseye`)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-14`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
 

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,16 +1,24 @@
 {
-	"variants": ["16-buster", "14-buster", "12-buster", "14-stretch", "12-stretch"],
-	"definitionVersion": "0.202.7",
+	"variants": ["16-bullseye", "14-bullseye", "12-bullseye", "16-buster", "14-buster", "12-buster"],
+	"definitionVersion": "0.203.0",
 	"build": {
-		"latest": true,
+		"latest": "16-bullseye",
 		"rootDistro": "debian",
+		"architectures": {
+			"16-bullseye": ["linux/amd64", "linux/arm64"],
+			"14-bullseye": ["linux/amd64", "linux/arm64"],
+			"12-bullseye": ["linux/amd64", "linux/arm64"],
+			"16-buster": ["linux/amd64"],
+			"14-buster": ["linux/amd64"],
+			"12-buster": ["linux/amd64"]
+		},
 		"tags": [
 			"javascript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"16-buster": [ "javascript-node:${VERSION}-16" ],
-			"14-buster": [ "javascript-node:${VERSION}-14" ],
-			"12-buster": [ "javascript-node:${VERSION}-12" ]
+			"16-bullseye": [ "javascript-node:${VERSION}-16" ],
+			"14-bullseye": [ "javascript-node:${VERSION}-14" ],
+			"12-bullseye": [ "javascript-node:${VERSION}-12" ]
 		}
 	}, 
 	"dependencies": {

--- a/containers/typescript-node/.devcontainer/Dockerfile
+++ b/containers/typescript-node/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12
-ARG VARIANT=16
+# [Choice] Node.js version: 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/typescript-node/.devcontainer/base.Dockerfile
+++ b/containers/typescript-node/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Node.js version: 16, 14, 12
-ARG VARIANT=16-buster
+# [Choice] Node.js version: 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # Install tslint, typescript. eslint is installed by javascript image

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -2,9 +2,10 @@
 	"name": "Node.js & TypeScript",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node version: 12, 14, 16
+		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
+		// Append -bullseye or -buster to pin to an OS version.
 		"args": { 
-			"VARIANT": "16"
+			"VARIANT": "16-bullseye"
 		}
 	},
 

--- a/containers/typescript-node/README.md
+++ b/containers/typescript-node/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/typescript-node |
-| *Available image variants* | 12, 14, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 12 / 12-bullseye, 14 / 14-bullseye, 16 / 16-bullseye, 12-buster, 14-buster, 16-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -23,22 +23,25 @@ See **[history](history)** for information on the contents of published images.
 
 While the definition itself works unmodified, you can select the version of Node.js the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
-```json
-"args": { "VARIANT": "12" }
+```jsonc
+// Or you can use 14-bullseye if you want to pin to an OS version
+"args": { "VARIANT": "14" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:16`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:14`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:12`
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:16` (or `16-bullseye` to stay on this OS version)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:14` (or `14-bullseye` to stay on this OS version)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:12` (or `12-bullseye` to stay on this OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-12`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202-12`
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.202.1-12`
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-14` (or `0-14-bullseye`)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.204-14` (or `0.203-14-bullseye`)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.204.0-14` (or `0.203.0-14-bullseye`)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-14`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/typescript-node/tags/list).
 

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,10 +1,18 @@
 {
-	"variants": ["16-buster", "14-buster", "12-buster", "14-stretch", "12-stretch"],
-	"definitionVersion": "0.202.7",
+	"variants": ["16-bullseye", "14-bullseye", "12-bullseye", "16-buster", "14-buster", "12-buster"],
+	"definitionVersion": "0.203.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"parent": "javascript-node",
+		"architectures": {
+			"16-bullseye": ["linux/amd64", "linux/arm64"],
+			"14-bullseye": ["linux/amd64", "linux/arm64"],
+			"12-bullseye": ["linux/amd64", "linux/arm64"],
+			"16-buster": ["linux/amd64"],
+			"14-buster": ["linux/amd64"],
+			"12-buster": ["linux/amd64"]
+		},
 		"tags": [
 			"typescript-node:${VERSION}-${VARIANT}"
 		],


### PR DESCRIPTION
This PR updates the javascript and typescript definitions to to include arm64 pre-built images. As described in #558, there are challenges with Debian 10/buster. Unfortunately, the default `node` image in DockerHub is still on `buster`.

To provide the needed flexibility, this PR:
1. Introduces `-bullseye` flavors of each Node version and makes this the default (e.g. `16` == `16-bullseye`)
2. Keeps the existing `-buster` favors of the image for those that prefer to use them, or hit an unexpected issue.
3. Updates the choice of versions to include all variations so developers can pick which one they want to pin to.
4. Drops the old `-stretch` variations for 14/12 that we were not advertising anyway.
5. Builds arm64 images for the `-bullseye` variants.

