### PR TITLE
Fix bullseye regressions, keep buster as default for node

### DIFF
--- a/containers/javascript-node/.devcontainer/base.Dockerfile
+++ b/containers/javascript-node/.devcontainer/base.Dockerfile
@@ -37,6 +37,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Install eslint
     && su ${USERNAME} -c "umask 0002 && npm install -g eslint" \
     && npm cache clean --force > /dev/null 2>&1 \
+    # Install python-is-python3 on bullseye to prevent node-gyp regressions
+    && . /etc/os-release \
+    && if [ "${VERSION_CODENAME}" = "bullseye" ]; then apt-get -y install --no-install-recommends python-is-python3; fi \
     # Clean up
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /root/.gnupg /tmp/library-scripts
 

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
+		// Use the -bullseye variants if you are on a M1 mac.
 		"args": { "VARIANT": "16-bullseye" }
 	},
 

--- a/containers/javascript-node/README.md
+++ b/containers/javascript-node/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/javascript-node |
-| *Available image variants* | 12 / 12-bullseye, 14 / 14-bullseye, 16 / 16-bullseye, 12-buster, 14-buster, 16-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
+| *Available image variants* | 12 / 12-buster, 14 / 14-buster, 16 / 16-buster, 12-bullseye, 14-bullseye, 16-bullseye,  ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -2,7 +2,7 @@
 	"variants": ["16-bullseye", "14-bullseye", "12-bullseye", "16-buster", "14-buster", "12-buster"],
 	"definitionVersion": "0.203.0",
 	"build": {
-		"latest": "16-bullseye",
+		"latest": "16-buster",
 		"rootDistro": "debian",
 		"architectures": {
 			"16-bullseye": ["linux/amd64", "linux/arm64"],
@@ -16,9 +16,9 @@
 			"javascript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"16-bullseye": [ "javascript-node:${VERSION}-16" ],
-			"14-bullseye": [ "javascript-node:${VERSION}-14" ],
-			"12-bullseye": [ "javascript-node:${VERSION}-12" ]
+			"16-buster": [ "javascript-node:${VERSION}-16" ],
+			"14-buster": [ "javascript-node:${VERSION}-14" ],
+			"12-buster": [ "javascript-node:${VERSION}-12" ]
 		}
 	}, 
 	"dependencies": {

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
+		// Use the -bullseye variants if you are on a M1 mac.		
 		"args": { 
 			"VARIANT": "16-bullseye"
 		}

--- a/containers/typescript-node/README.md
+++ b/containers/typescript-node/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/typescript-node |
-| *Available image variants* | 12 / 12-bullseye, 14 / 14-bullseye, 16 / 16-bullseye, 12-buster, 14-buster, 16-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
+| *Available image variants* | 12 / 12-buster, 14 / 14-buster, 16 / 16-buster, 12-bullseye, 14-bullseye, 16-bullseye,  ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/javascript-node/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -2,7 +2,7 @@
 	"variants": ["16-bullseye", "14-bullseye", "12-bullseye", "16-buster", "14-buster", "12-buster"],
 	"definitionVersion": "0.203.0",
 	"build": {
-		"latest": true,
+		"latest": "16-buster",
 		"rootDistro": "debian",
 		"parent": "javascript-node",
 		"architectures": {

--- a/repository-containers/images/github.com/microsoft/vscode/.devcontainer/base.Dockerfile
+++ b/repository-containers/images/github.com/microsoft/vscode/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:14-buster
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:14-bullseye
 
 ARG NODE_VERSION="14"
 COPY library-scripts/desktop-lite-debian.sh /tmp/library-scripts/

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -126,6 +126,9 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         sed -i "s/deb-src http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}\/updates main contrib non-free/" /etc/apt/sources.list
         sed -i "s/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main contrib non-free/" /etc/apt/sources.list 
         sed -i "s/deb-src http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main/deb http:\/\/deb\.debian\.org\/debian ${VERSION_CODENAME}-backports main contrib non-free/" /etc/apt/sources.list
+        # Handle bullseye location for security https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html
+        sed -i "s/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main contrib non-free/" /etc/apt/sources.list
+        sed -i "s/deb-src http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main/deb http:\/\/security\.debian\.org\/debian-security ${VERSION_CODENAME}-security main contrib non-free/" /etc/apt/sources.list
         echo "Running apt-get update..."
         apt-get update
         package_list="${package_list} manpages-posix manpages-posix-dev"


### PR DESCRIPTION
After spending some time with the bullseye variants of node, there are still some clear regressions. Given the default for "node" has not updated, we can instead keep things at buster by default but mention the use of bullseye for M1 macs in devcontainer.json comments