### PR TITLE
Python arm64 support, buster variants for back compat

### DIFF
--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -11,8 +11,8 @@ jobs:
     name: Build and push images
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5, 6]
-        page-total: [6]
+        page: [1, 2, 3, 4, 5, 6, 7]
+        page-total: [7]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -30,8 +30,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5]
-        page-total: [5]
+        page: [1, 2, 3, 4, 5, 6]
+        page-total: [6]
       fail-fast: true
     runs-on: ubuntu-latest
     steps:

--- a/containers/javascript-node/README.md
+++ b/containers/javascript-node/README.md
@@ -24,22 +24,22 @@ See **[history](history)** for information on the contents of published images.
 While the definition itself works unmodified, you can select the version of Node.js the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```jsonc
-// Or you can use 14-bullseye if you want to pin to an OS version
+// Or you can use 14-bullseye or 14-buster if you want to pin to an OS version
 "args": { "VARIANT": "14" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/javascript-node` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:16` (or `16-bullseye` to stay on this OS version)
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:14` (or `14-bullseye` to stay on this OS version)
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:12` (or `12-bullseye` to stay on this OS version)
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:16` (or `16-bullseye`, `16-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:14` (or `14-bullseye`, `14-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/javascript-node:12` (or `12-bullseye`, `12-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-14` (or `0-14-bullseye`)
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.204-14` (or `0.203-14-bullseye`)
-- `mcr.microsoft.com/vscode/devcontainers/javascript-node:0.204.0-14` (or `0.203.0-14-bullseye`)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-14` (or `0-14-bullseye`, `0-14-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.204-14` (or `0.203-14-bullseye`, `0.203-14-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.204.0-14` (or `0.203.0-14-bullseye`, `0.203.0-14-buster`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-14`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
-ARG VARIANT=3
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT=3-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
-ARG VARIANT=3
+# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT=3-bullseye
 FROM python:${VARIANT}
 
 # Copy library scripts to execute

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -4,8 +4,10 @@
 		"dockerfile": "Dockerfile",
 		"context": "..",
 		"args": { 
-			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
-			"VARIANT": "3",
+			// Update 'VARIANT' to pick a Python version: 3, 3.9, 3.8, 3.7, 3.6.
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use the -bullseye variants if you are on a M1 mac.
+			"VARIANT": "3-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/python |
-| *Available image variants* | 3, 3.6, 3.7, 3.8, 3.9 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 3 / 3-bullseye, 3.6 / 3.6-bullseye, 3.7 / 3.7-bullseye, 3.8 / 3.8-bullseye, 3.9 / 3.9-bullseye, 3-buster, 3.6-buster, 3.7-buster, 3.8-buster, 3.9-buster,  ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container Host OS Support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -26,22 +26,25 @@ See **[history](history)** for information on the contents of published images.
 While the definition itself works unmodified, you can select the version of Python the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
+// Or you can use 3.7-bullseye or 3.7-buster if you want to pin to an OS version
 "args": { "VARIANT": "3.7" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/python:3` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/python:3.6`
-- `mcr.microsoft.com/vscode/devcontainers/python:3.7`
-- `mcr.microsoft.com/vscode/devcontainers/python:3.8`
-- `mcr.microsoft.com/vscode/devcontainers/python:3.9`
+- `mcr.microsoft.com/vscode/devcontainers/python:3.6` (or `3.6-bullseye`, `3.6-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/python:3.7` (or `3.7-bullseye`, `3.7-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/python:3.8` (or `3.8-bullseye`, `3.8-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/python:3.9` (or `3.9-bullseye`, `3.9-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/python:0-3.9`
-- `mcr.microsoft.com/vscode/devcontainers/python:0.201-3.9`
-- `mcr.microsoft.com/vscode/devcontainers/python:0.201.5-3.9`
+- `mcr.microsoft.com/vscode/devcontainers/python:0-3.9` (or `0-3.9-bullseye`, `0-3.9-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/python:0.202-3.9` (or `0.202-3.9-bullseye`, `0.202-3.9-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/python:0.202.0-3.9` (or `0.202.0-3.9-bullseye`, `0.202/0-3.9-buster`)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-14`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list).
 

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,14 +1,30 @@
 {
-	"variants": ["3.9", "3.8", "3.7", "3.6"],
-	"definitionVersion": "0.201.9",
+	"variants": ["3.9-bullseye", "3.8-bullseye", "3.7-bullseye", "3.6-buster", "3.9-buster", "3.8-buster", "3.7-buster", "3.6-buster"],
+	"definitionVersion": "0.202.0",
 	"build": {
-		"latest": true,
+		"latest": "3.9-bullseye",
 		"rootDistro": "debian",
+		"architectures": {
+			"3.9-bullseye": ["linux/amd64", "linux/arm64"],
+			"3.8-bullseye": ["linux/amd64", "linux/arm64"],
+			"3.7-bullseye": ["linux/amd64", "linux/arm64"],
+			"3.6-bullseye": ["linux/amd64", "linux/arm64"],
+			"3.9-buster": ["linux/amd64"],
+			"3.8-buster": ["linux/amd64"],
+			"3.7-buster": ["linux/amd64"],
+			"3.6-buster": ["linux/amd64"]
+		},
 		"tags": [
 			"python:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"3.9": [ "python:${VERSION}-3" ]
+			"3.9-bullseye": [ 
+				"python:${VERSION}-3.9",
+				"python:${VERSION}-3"
+			], 
+			"3.8-bullseye": [ "python:${VERSION}-3.8" ],
+			"3.7-bullseye": [ "python:${VERSION}-3.7" ],
+			"3.6-bullseye": [ "python:${VERSION}-3.6" ]
 		}
 	},
 	"dependencies": {

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
-		// Use the -bullseye variants if you are on a M1 mac.		
+		// Use the -bullseye variants if you are on a M1 mac.
 		"args": { 
 			"VARIANT": "16-bullseye"
 		}

--- a/containers/typescript-node/README.md
+++ b/containers/typescript-node/README.md
@@ -24,22 +24,22 @@ See **[history](history)** for information on the contents of published images.
 While the definition itself works unmodified, you can select the version of Node.js the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```jsonc
-// Or you can use 14-bullseye if you want to pin to an OS version
+// Or you can use 14-bullseye or 14-buster if you want to pin to an OS version
 "args": { "VARIANT": "14" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/typescript-node` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:16` (or `16-bullseye` to stay on this OS version)
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:14` (or `14-bullseye` to stay on this OS version)
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:12` (or `12-bullseye` to stay on this OS version)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:16` (or `16-bullseye`, `16-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:14` (or `14-bullseye`, `14-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:12` (or `12-bullseye`, `12-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-14` (or `0-14-bullseye`)
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.204-14` (or `0.203-14-bullseye`)
-- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.204.0-14` (or `0.203.0-14-bullseye`)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0-14` (or `0-14-bullseye`, `0-14-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.204-14` (or `0.203-14-bullseye`, `0.203-14-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/typescript-node:0.204.0-14` (or `0.203.0-14-bullseye`, `0.203.0-14-buster`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-14`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/repository-containers/images/github.com/microsoft/vscode/definition-manifest.json
+++ b/repository-containers/images/github.com/microsoft/vscode/definition-manifest.json
@@ -1,10 +1,10 @@
 {
-	"definitionVersion": "0.202.4",
+	"definitionVersion": "0.203.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
 		"parent": "typescript-node",
-		"parentVariant": "14-buster",
+		"parentVariant": "14-bullseye",
 		"tags": [
 			"repos/microsoft/vscode:${VERSION}"
 		]


### PR DESCRIPTION
As described in https://github.com/microsoft/vscode-dev-containers/issues/558#issuecomment-905117722, the situation for Docker on M1 macs is not ideal since both `debian:buster` nor `ubuntu:focal` experience segmentation faults due to an issue in `libss1.1`. It seems unlikely that `buster` will be patched now that `bullseye` is out (and buster therefore gets security fixes only). 

Therefore this PR:
1. Adds arm64 builds for Debian `bullseye` 
2. Adds `buster` variants that are x86 only for backwards compat.
3. Defaults to `bullseye` since this is what the upstream `python` image has done.
4. Makes a few README tweaks to the js/ts definition for consistency.

//cc: @joshspicer @2percentsilk @bamurtaugh @chrmarti 
