### PR TITLE
PHP arm64 support, buster variants for back compat

### DIFF
--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -11,8 +11,8 @@ jobs:
     name: Build and push images
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5, 6, 7]
-        page-total: [7]
+        page: [1, 2, 3, 4, 5, 6, 7, 8]
+        page-total: [8]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -30,8 +30,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5, 6]
-        page-total: [6]
+        page: [1, 2, 3, 4, 5, 6, 7]
+        page-total: [7]
       fail-fast: true
     runs-on: ubuntu-latest
     steps:

--- a/containers/php/.devcontainer/Dockerfile
+++ b/containers/php/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] PHP version: 8, 8.0, 7, 7.4, 7.3
+# [Choice] PHP version: 8, 8.0, 7, 7.4, 7.3, 8-bullseye, 8.0-bullseye, 7-bullseye, 7.4-bullseye, 7.3-bullseye, 8-buster, 8.0-buster, 7-buster, 7.4-buster, 7.3-buster
 ARG VARIANT=7
 FROM mcr.microsoft.com/vscode/devcontainers/php:${VARIANT}
 

--- a/containers/php/.devcontainer/base.Dockerfile
+++ b/containers/php/.devcontainer/base.Dockerfile
@@ -1,6 +1,6 @@
-# [Choice] PHP version: 8, 8.0, 7, 7.4, 7.3
-ARG VARIANT=7
-FROM php:${VARIANT}-apache
+# [Choice] PHP version: 8-apache-bullseye, 8.0-apache-bullseye, 7-apache-bullseye, 7.4-apache-bullseye, 7.3-apache-bullseye, 8-apache-buster, 8.0-apache-buster, 7-apache-buster, 7.4-apache-buster, 7.3-apache-buster
+ARG VARIANT=7-apache-bullseye
+FROM php:${VARIANT}
 
 # Copy library scripts to execute
 COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 		"dockerfile": "Dockerfile",
 		"args": { 
 			// Update VARIANT to pick a PHP version: 8, 8.0, 7, 7.4, 7.3
-			"VARIANT": "8",
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use the -bullseye variants if you are on a M1 mac.
+			"VARIANT": "8-bullseye",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/php/README.md
+++ b/containers/php/README.md
@@ -9,9 +9,8 @@
 | *Contributors* | The VS Code Team |
 | *Categories* | Languages |
 | *Definition type* | Dockerfile |
-| *Published images* | mcr.microsoft.com/vscode/devcontainers/php |
-| *Available image variants* | 8, 8.0, 7, 7.3, 7.4 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 8 / 8-bullseye, 8.0 / 8.0-bullseye, 7 / 7-bullseye, 7.4 / 7.4-bullseye, 7.3 / 7.3-bullseye, 8-buster, 8.0-buster, 7-buster, 7.5-buster, 7.3-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,23 +23,26 @@ See **[history](history)** for information on the contents of published images.
 While the definition itself works unmodified, you can select the version of PHP the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
+// Or you can use 7-bullseye or 7-buster if you want to pin to an OS version
 "args": { "VARIANT": "7" }
 ```
 
-You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
+You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
 
 - `mcr.microsoft.com/vscode/devcontainers/php` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/php:8`
-- `mcr.microsoft.com/vscode/devcontainers/php:8.0`
-- `mcr.microsoft.com/vscode/devcontainers/php:7`
-- `mcr.microsoft.com/vscode/devcontainers/php:7.4`
-- `mcr.microsoft.com/vscode/devcontainers/php:7.3`
+- `mcr.microsoft.com/vscode/devcontainers/php:8` (or `8-bullseye`, `8-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/php:8.0` (or `8.0-bullseye`, `8.0-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/php:7` (or `7-bullseye`, `7-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/php:7.4` (or `7.4-bullseye`, `7.4-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/php:7.3` (or `7.3-bullseye`, `7.3-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/php:0-7`
-- `mcr.microsoft.com/vscode/devcontainers/php:0.201-7`
-- `mcr.microsoft.com/vscode/devcontainers/php:0.201.5-7`
+- `mcr.microsoft.com/vscode/devcontainers/python:0-7` (or `0-7-bullseye`, `0-7-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/python:0.202-7` (or `0.202-7-bullseye`, `0.202-7-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/python:0.202.0-7` (or `0.202.0-7-bullseye`, `0.202.0-7-buster`)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-7`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list).
 

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,15 +1,39 @@
 {
-	"variants": ["8.0", "7.4", "7.3"],
-	"definitionVersion": "0.201.9",
+	"variants": ["8.0-apache-bullseye", "7.4-apache-bullseye", "7.3-apache-bullseye", "8.0-apache-buster", "7.4-apache-buster", "7.3-apache-buster"],
+	"definitionVersion": "0.202.0",
 	"build": {
-		"latest": true,
+		"latest": "8.0-apache-bullseye",
 		"rootDistro": "debian",
+		"architectures": {
+			"8.0-apache-bullseye": ["linux/amd64", "linux/arm64"],
+			"7.4-apache-bullseye": ["linux/amd64", "linux/arm64"],
+			"7.3-apache-bullseye": ["linux/amd64", "linux/arm64"],
+			"8.0-apache-buster": ["linux/amd64"],
+			"7.4-apache-buster": ["linux/amd64"],
+			"7.3-apache-buster": ["linux/amd64"]
+		},
 		"tags": [
 			"php:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"8.0": [ "php:${VERSION}-8" ],
-			"7.4": [ "php:${VERSION}-7" ]
+			"8.0-apache-bullseye": [ 
+				"php:${VERSION}-8",
+				"php:${VERSION}-8-bullseye",
+				"php:${VERSION}-8.0-bullseye"
+			],
+			"7.4-apache-bullseye": [ 
+				"php:${VERSION}-7" ,
+				"php:${VERSION}-7-bullseye",
+				"php:${VERSION}-7.4",
+				"php:${VERSION}-7.4-bullseye"
+			],
+			"7.3-apache-bullseye": [ 
+				"php:${VERSION}-7.3",
+				"php:${VERSION}-7.3-bullseye"
+			],
+			"8.0-apache-buster": [ "php:${VERSION}-8.0-buster" ],
+			"7.4-apache-buster": [ "php:${VERSION}-7.4-buster" ],
+			"7.3-apache-buster": [ "php:${VERSION}-7.3-buster" ]
 		}
 	},
 	"dependencies": {

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/python |
-| *Available image variants* | 3 / 3-bullseye, 3.6 / 3.6-bullseye, 3.7 / 3.7-bullseye, 3.8 / 3.8-bullseye, 3.9 / 3.9-bullseye, 3-buster, 3.6-buster, 3.7-buster, 3.8-buster, 3.9-buster,  ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list)) |
+| *Available image variants* | 3 / 3-bullseye, 3.6 / 3.6-bullseye, 3.7 / 3.7-bullseye, 3.8 / 3.8-bullseye, 3.9 / 3.9-bullseye, 3-buster, 3.6-buster, 3.7-buster, 3.8-buster, 3.9-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container Host OS Support* | Linux, macOS, Windows |
@@ -42,7 +42,7 @@ You can decide how often you want updates by referencing a [semantic version](ht
 
 - `mcr.microsoft.com/vscode/devcontainers/python:0-3.9` (or `0-3.9-bullseye`, `0-3.9-buster`)
 - `mcr.microsoft.com/vscode/devcontainers/python:0.202-3.9` (or `0.202-3.9-bullseye`, `0.202-3.9-buster`)
-- `mcr.microsoft.com/vscode/devcontainers/python:0.202.0-3.9` (or `0.202.0-3.9-bullseye`, `0.202/0-3.9-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/python:0.202.0-3.9` (or `0.202.0-3.9-bullseye`, `0.202.0-3.9-buster`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-14`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -24,7 +24,8 @@
 			], 
 			"3.8-bullseye": [ "python:${VERSION}-3.8" ],
 			"3.7-bullseye": [ "python:${VERSION}-3.7" ],
-			"3.6-bullseye": [ "python:${VERSION}-3.6" ]
+			"3.6-bullseye": [ "python:${VERSION}-3.6" ],
+			"3.9-buster": ["python:${VERSION}-3-buster"]
 		}
 	},
 	"dependencies": {


### PR DESCRIPTION
As described in https://github.com/microsoft/vscode-dev-containers/issues/558#issuecomment-905117722, the situation for Docker on M1 macs is not ideal since both `debian:buster` nor `ubuntu:focal` experience segmentation faults due to an issue in `libss1.1`. It seems unlikely that `buster` will be patched now that `bullseye` is out (and buster therefore gets security fixes only). 

Therefore this PR:
1. Adds arm64 builds for Debian `bullseye` 
2. Adds `buster` variants that are x86 only for backwards compat.
3. Defaults to `bullseye` since this is what the upstream `php` image has done.
4. Makes a few minor edits to the python definition `README.md` and `definition-manifest.json`.

This also adds `php:<PHP VESION>-apache-<OS>` tags because of the tagging scheme used in the `php` upstream image, but is really only there to enable `base.Dockerfile` to function during build.

//cc: @joshspicer @2percentsilk @bamurtaugh @chrmarti 
