### PR TITLE
Go arm64, buster variants for back compat

### DIFF
--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -11,8 +11,8 @@ jobs:
     name: Build and push images
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5, 6, 7, 8]
-        page-total: [8]
+        page: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        page-total: [9]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -30,8 +30,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5, 6, 7]
-        page-total: [7]
+        page: [1, 2, 3, 4, 5, 6, 7, 8]
+        page-total: [8]
       fail-fast: true
     runs-on: ubuntu-latest
     steps:

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Go version: 1, 1.16, 1.17
-ARG VARIANT=1
+# [Choice] Go version: 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+ARG VARIANT=1-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Go version: 1, 1.16, 1.17
-ARG VARIANT=1
+# [Choice] Go version: 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+ARG VARIANT=1-bullseye
 FROM golang:${VARIANT}
 
 # Copy library scripts to execute

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
-			"VARIANT": "1",
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use the -bullseye variants if you are on a M1 mac.
+			"VARIANT": "1-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/go |
-| *Available image variants* | 1, 1.16, 1.17 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 1 / 1-bullseye, 1.16 / 1.16-bullseye, 1.17 / 1.17-bullseye, 1-buster, 1.17-buster, 1.16-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,21 +24,24 @@ See **[history](history)** for information on the contents of published images.
 While the definition itself works unmodified, you can select the version of Go the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
+// Or you can use 1.17-bullseye or 1.17-buster if you want to pin to an OS version
 "args": { "VARIANT": "1.17" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/vscode/devcontainers/go` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/go:1`
-- `mcr.microsoft.com/vscode/devcontainers/go:1.16`
-- `mcr.microsoft.com/vscode/devcontainers/go:1.17`
+- `mcr.microsoft.com/vscode/devcontainers/go:1` (or `1-bullseye`, `1-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/go:1.16` (or `1.16-bullseye`, `1.16-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/go:1.17` (or `1.17-bullseye`, `1.17-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/go:0-1.16`
-- `mcr.microsoft.com/vscode/devcontainers/go:0.204-1.16`
-- `mcr.microsoft.com/vscode/devcontainers/go:0.204.5-1.16`
+- `mcr.microsoft.com/vscode/devcontainers/go:0-1.16` (or `0-1.16-bullseye`, `0-1.16-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/go:0.205-1.16` (or `0.205-1.16-bullseye`, `0.205-1.16-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/go:0.205.0-1.16` (or `0.205.0-1.16-bullseye`, `0.205.0-1.16-buster`)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-1.16`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list).
 

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,14 +1,26 @@
 {
-	"variants": ["1.17", "1.16"],
-	"definitionVersion": "0.204.0",
+	"variants": ["1.17-bullseye", "1.16-bullseye", "1.17-buster", "1.16-buster"],
+	"definitionVersion": "0.205.0",
 	"build": {
-		"latest": true,
+		"latest": "1.17-bullseye",
 		"rootDistro": "debian",
 		"tags": [
 			"go:${VERSION}-${VARIANT}"
 		],
+		"architectures": {
+			"1.17-bullseye": ["linux/amd64", "linux/arm64"],
+			"1.16-bullseye": ["linux/amd64", "linux/arm64"],
+			"1.17-buster": ["linux/amd64"],
+			"1.16-buster": ["linux/amd64"]
+		},
 		"variantTags": {
-			"1.17": [ "go:${VERSION}-1" ]
+			"1.17-bullseye": [ 
+				"go:${VERSION}-1.17",
+				"go:${VERSION}-1",
+				"go:${VERSION}-1-bullseye" 
+			],
+			"1.16-bullseye": ["go:${VERSION}-1.16"],
+			"1.17-buster": ["go:${VERSION}-1-buster"]
 		}
 	},
 	"dependencies": {


### PR DESCRIPTION
As described in https://github.com/microsoft/vscode-dev-containers/issues/558#issuecomment-905117722, the situation for Docker on M1 macs is not ideal since both `debian:buster` nor `ubuntu:focal` experience segmentation faults due to an issue in `libss1.1`. It seems unlikely that `buster` will be patched now that `bullseye` is out (and buster therefore gets security fixes only). 

Therefore this PR:
1. Adds arm64 builds for Debian `bullseye` 
2. Adds `buster` variants that are x86 only for backwards compat.
3. Defaults to `bullseye` since this is what the upstream `go` image has done.

//cc: @joshspicer @2percentsilk @bamurtaugh @chrmarti 
