### PR TITLE
Ruby, Jekyll arm64 images, buster variants for back compat

### DIFF
--- a/.github/workflows/push-and-package.yml
+++ b/.github/workflows/push-and-package.yml
@@ -11,8 +11,8 @@ jobs:
     name: Build and push images
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5, 6, 7, 8, 9]
-        page-total: [9]
+        page: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        page-total: [10]
       fail-fast: false
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/push-dev.yml
+++ b/.github/workflows/push-dev.yml
@@ -30,8 +30,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'Automated update') && !contains(github.event.head_commit.message, 'CI ignore')"
     strategy:
       matrix:
-        page: [1, 2, 3, 4, 5, 6, 7, 8]
-        page-total: [8]
+        page: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        page-total: [9]
       fail-fast: true
     runs-on: ubuntu-latest
     steps:

--- a/build/config.json
+++ b/build/config.json
@@ -28,7 +28,9 @@
 	],
 
 	"needsDedicatedPage": [ 
-		"codespaces-linux"
+		"codespaces-linux",
+		"php",
+		"python-3"
 	],
 
 	"flattenBaseImage": [],

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -17,10 +17,14 @@
 			"1.17-bullseye": [ 
 				"go:${VERSION}-1.17",
 				"go:${VERSION}-1",
-				"go:${VERSION}-1-bullseye" 
+				"go:${VERSION}-1-bullseye",
+				"go:${VERSION}-bullseye" 
 			],
 			"1.16-bullseye": ["go:${VERSION}-1.16"],
-			"1.17-buster": ["go:${VERSION}-1-buster"]
+			"1.17-buster": [
+				"go:${VERSION}-1-buster",
+				"go:${VERSION}-buster"
+			]
 		}
 	},
 	"dependencies": {

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -16,7 +16,13 @@
 			"javascript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"16-buster": [ "javascript-node:${VERSION}-16" ],
+			"16-bullseye": [ 
+				"javascript-node:${VERSION}-bullseye"
+			],
+			"16-buster": [ 
+				"javascript-node:${VERSION}-16",
+				"javascript-node:${VERSION}-buster"
+			],
 			"14-buster": [ "javascript-node:${VERSION}-14" ],
 			"12-buster": [ "javascript-node:${VERSION}-12" ]
 		}

--- a/containers/jekyll/.devcontainer/Dockerfile
+++ b/containers/jekyll/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/vscode/devcontainers/jekyll:0
+# [Choice] Debian OS version: bullseye, buster
+ARG VARIANT=bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/jekyll:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/containers/jekyll/.devcontainer/base.Dockerfile
+++ b/containers/jekyll/.devcontainer/base.Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/vscode/devcontainers/ruby:2.7
+# [Choice] Debian OS version: 2.7-bullseye, 2.7-buster
+ARG VARIANT=2.7-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 COPY library-scripts/meta.env /usr/local/etc/vscode-dev-containers
 
 # ENV Variables required by Jekyll

--- a/containers/jekyll/.devcontainer/devcontainer.json
+++ b/containers/jekyll/.devcontainer/devcontainer.json
@@ -3,6 +3,9 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
+			// Update 'VARIANT' to pick a Debian OS version: bullseye, buster
+			// Use bullseye if you are on a M1 mac.
+			"VARIANT": "bullseye",
 			// Enable Node.js: pick the latest LTS version
 			"NODE_VERSION": "lts/*"
 		}	

--- a/containers/jekyll/README.md
+++ b/containers/jekyll/README.md
@@ -10,7 +10,8 @@
 | *Categories* | Community, Languages, Frameworks |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/jekyll |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | bullseye, buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variant |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -25,11 +26,26 @@ In addition to Ruby and Bundler, this development container installs Jekyll and 
 - If your Jekyll project contains a `Gemfile` in the root folder, the development container will install all gems at startup by running `bundle install`. This is the [recommended](https://jekyllrb.com/docs/step-by-step/10-deployment/#gemfile) approach as it allows you to specify the exact Jekyll version your project requires and list all additional Jekyll plugins.
 - If there's no `Gemfile`, the development container will install Jekyll automatically, picking the latest version. You might need to manually install the other dependencies your project relies on, including all relevant Jekyll plugins.
 
+While this definition should work unmodified, you can select the version of Debian the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
+
+```json
+"args": { "VARIANT": "bullseye" }
+```
+
+You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
+
+
+- `mcr.microsoft.com/vscode/devcontainers/jekyll` (latest)
+- `mcr.microsoft.com/vscode/devcontainers/jekyll:bullseye`
+- `mcr.microsoft.com/vscode/devcontainers/jekyll:buster`
+
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/jekyll:0`
-- `mcr.microsoft.com/vscode/devcontainers/jekyll:0.0`
-- `mcr.microsoft.com/vscode/devcontainers/jekyll:0.0.1`
+- `mcr.microsoft.com/vscode/devcontainers/jekyll:0` (or `0-bullseye`, `0-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/jekyll:0.1` (or `0.1-bullseye`, `0.1-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/jekyll:0.1.0` (or `0.1.0-bullseye`, `0.1.0-buster` to pin to an OS version)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-bullseye`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/jekyll/tags/list).
 

--- a/containers/jekyll/definition-manifest.json
+++ b/containers/jekyll/definition-manifest.json
@@ -1,16 +1,25 @@
 {
-	"definitionVersion": "0.0.3",
+	"variants": ["2.7-bullseye", "2.7-buster"],
+	"definitionVersion": "0.1.0",
 	"build": {
-		"latest": true,
+		"latest": "2.7-bullseye",
 		"parent": "ruby",
-		"parentVariant": "2.7",
+		"parentVariant": "2.7-bullseye",
 		"rootDistro": "debian",
+		"architectures": {
+			"2.7-bullseye": ["linux/amd64", "linux/arm64"],
+			"2.7-buster": ["linux/amd64"]
+		},
 		"tags": [
 			"jekyll:${VERSION}"
-		]
+		],
+		"variantTags": {
+			"2.7-bullseye": [ "jekyll:${VERSION}-bullseye" ],
+			"2.7-buster": [ "jekyll:${VERSION}-buster" ]
+		}
 	},
 	"dependencies": {
-		"image": "mcr.microsoft.com/vscode/devcontainers/ruby:2.7",
+		"image": "mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}",
 		"imageLink": "https://github.com/microsoft/vscode-dev-containers",
 		"debian": [{
 			"cgIgnore": false,

--- a/containers/php/.devcontainer/Dockerfile
+++ b/containers/php/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] PHP version: 8, 8.0, 7, 7.4, 7.3, 8-bullseye, 8.0-bullseye, 7-bullseye, 7.4-bullseye, 7.3-bullseye, 8-buster, 8.0-buster, 7-buster, 7.4-buster, 7.3-buster
-ARG VARIANT=7
+ARG VARIANT=7-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/php:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/containers/php/README.md
+++ b/containers/php/README.md
@@ -9,6 +9,7 @@
 | *Contributors* | The VS Code Team |
 | *Categories* | Languages |
 | *Definition type* | Dockerfile |
+| *Published images* | mcr.microsoft.com/vscode/devcontainers/php |
 | *Available image variants* | 8 / 8-bullseye, 8.0 / 8.0-bullseye, 7 / 7-bullseye, 7.4 / 7.4-bullseye, 7.3 / 7.3-bullseye, 8-buster, 8.0-buster, 7-buster, 7.5-buster, 7.3-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/php/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -19,7 +19,8 @@
 			"8.0-apache-bullseye": [ 
 				"php:${VERSION}-8",
 				"php:${VERSION}-8-bullseye",
-				"php:${VERSION}-8.0-bullseye"
+				"php:${VERSION}-8.0-bullseye",
+				"php:${VERSION}-bullseye"
 			],
 			"7.4-apache-bullseye": [ 
 				"php:${VERSION}-7" ,
@@ -31,8 +32,15 @@
 				"php:${VERSION}-7.3",
 				"php:${VERSION}-7.3-bullseye"
 			],
-			"8.0-apache-buster": [ "php:${VERSION}-8.0-buster" ],
-			"7.4-apache-buster": [ "php:${VERSION}-7.4-buster" ],
+			"8.0-apache-buster": [ 
+				"php:${VERSION}-8-buster",
+				"php:${VERSION}-8.0-buster",
+				"php:${VERSION}-buster"
+			],
+			"7.4-apache-buster": [
+				"php:${VERSION}-7-buster",
+				"php:${VERSION}-7.4-buster"
+			],
 			"7.3-apache-buster": [ "php:${VERSION}-7.3-buster" ]
 		}
 	},

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -20,12 +20,16 @@
 		"variantTags": {
 			"3.9-bullseye": [ 
 				"python:${VERSION}-3.9",
-				"python:${VERSION}-3"
+				"python:${VERSION}-3",
+				"python:${VERSION}-bullseye"
 			], 
 			"3.8-bullseye": [ "python:${VERSION}-3.8" ],
 			"3.7-bullseye": [ "python:${VERSION}-3.7" ],
 			"3.6-bullseye": [ "python:${VERSION}-3.6" ],
-			"3.9-buster": ["python:${VERSION}-3-buster"]
+			"3.9-buster": [ 
+				"python:${VERSION}-3-buster",
+				"python:${VERSION}-buster"
+			]
 		}
 	},
 	"dependencies": {

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
-ARG VARIANT=2
+# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6
-ARG VARIANT=2
+# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+ARG VARIANT=2-bullseye
 FROM ruby:${VARIANT}
 
 # Copy library scripts to execute

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 		"dockerfile": "Dockerfile",
 		"args": { 
 			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
-			"VARIANT": "3",
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use the -bullseye variants if you are on a M1 mac.
+			"VARIANT": "3-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/containers/ruby/README.md
+++ b/containers/ruby/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/ruby |
-| *Available image variants* | 3, 3.0, 2, 2.7, 2.6 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 3 / 3-bullseye, 3.0 / 3.0-bullseye, 2 / 2-bullseye, 2.7 / 2.7-bullseye, 2.6 / 2.7-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,23 +24,26 @@ See **[history](history)** for information on the contents of published images.
 While this definition should work unmodified, you can select the version of Ruby the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
+// Or you can use 2.7-bullseye or 2.7-buster if you want to pin to an OS version
 "args": { "VARIANT": "2.7" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/vscode/devcontainers/ruby` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/ruby:3`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:3.0`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:2`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:2.7`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:2.6`
+- `mcr.microsoft.com/vscode/devcontainers/ruby:3` (or `3-bullseye`, `3-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:3.0` (or `3.0-bullseye`, `3.0-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:2` (or `2-bullseye`, `2-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:2.7` (or `2.7-bullseye`, `2.7-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:2.6` (or `2.6-bullseye`, `2.6-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0-3`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0.201-3`
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0.201.5-3`
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0-3` (or `0-3-bullseye`, `0-3-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.202-3` (or `0.202-3-bullseye`, `0.202-3-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.202.0-3` (or `0.202.0-3-bullseye`, `0.202.0-3-buster` to pin to an OS version)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-2.7`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list).
 

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,15 +1,38 @@
 {
-	"variants": ["3.0", "2.7", "2.6"],
-	"definitionVersion": "0.201.9",
+	"variants": ["3.0-bullseye", "2.7-bullseye", "2.6-bullseye","3.0-buster", "2.7-buster", "2.6-buster"],
+	"definitionVersion": "0.202.0",
 	"build": {
-		"latest": true,
+		"latest": "3.0-bullseye",
 		"rootDistro": "debian",
+		"architectures": {
+			"3.0-bullseye": ["linux/amd64", "linux/arm64"],
+			"2.7-bullseye": ["linux/amd64", "linux/arm64"],
+			"2.6-bullseye": ["linux/amd64", "linux/arm64"],
+			"3.0-buster": ["linux/amd64"],
+			"2.7-buster": ["linux/amd64"],
+			"2.6-buster": ["linux/amd64"]
+		},
 		"tags": [
 			"ruby:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"3.0": [ "ruby:${VERSION}-3" ],
-			"2.7": [ "ruby:${VERSION}-2" ]
+			"3.0-bullseye": [ 
+				"ruby:${VERSION}-3",
+				"ruby:${VERSION}-3.0",
+				"ruby:${VERSION}-3-bullseye",
+				"ruby:${VERSION}-bullseye"
+			],
+			"2.7-bullseye": [ 
+				"ruby:${VERSION}-2",
+				"ruby:${VERSION}-2.7",
+				"ruby:${VERSION}-2-bullseye"
+			 ],
+			"2.6-bullseye": [ "ruby:${VERSION}-2.6" ],
+			"3.0-buster": [ 
+				"ruby:${VERSION}-3-buster",
+				"ruby:${VERSION}-buster"
+			],
+			"2.7-buster": [ "ruby:${VERSION}-2-buster" ]
 		}
 	},
 	"dependencies": {

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -17,7 +17,13 @@
 			"typescript-node:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"16-buster": [ "typescript-node:${VERSION}-16" ],
+			"16-bullseye": [ 
+				"typescript-node:${VERSION}-bullseye"
+			],
+			"16-buster": [ 
+				"typescript-node:${VERSION}-16",
+				"typescript-node:${VERSION}-buster"
+			],
 			"14-buster": [ "typescript-node:${VERSION}-14" ],
 			"12-buster": [ "typescript-node:${VERSION}-12" ]
 		}


### PR DESCRIPTION
As described in https://github.com/microsoft/vscode-dev-containers/issues/558#issuecomment-905117722, the situation for Docker on M1 macs is not ideal since both `debian:buster` nor `ubuntu:focal` experience segmentation faults due to an issue in `libss1.1`. It seems unlikely that `buster` will be patched now that `bullseye` is out (and buster therefore gets security fixes only). 

Therefore this PR:
1. Adds arm64 builds for Debian `bullseye` 
2. Adds `buster` variants that are x86 only for backwards compat.
3. Defaults to `bullseye` since this is what the upstream `ruby` image has done.

It also fixes a couple of tags for other images for consistency.

//cc: @joshspicer @2percentsilk @bamurtaugh @chrmarti 
