### PR TITLE
Java arm64 images, buster variants for back compat

### DIFF
--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/vscode/devcontainers/java:0-8
+# [Choice] Debian OS version: buster, bullseye
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/java:0-8-${VARIANT}
 
 # [Option] Install Maven
 ARG INSTALL_MAVEN="false"

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian OS version: buster, bullseye
+# [Choice] Debian OS version (use bullseye for arm64/Apple Silicon): buster, bullseye
 ARG VARIANT="buster"
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-8-${VARIANT}
 

--- a/containers/java-8/.devcontainer/base.Dockerfile
+++ b/containers/java-8/.devcontainer/base.Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/vscode/devcontainers/java:0-11
+# [Choice] Debian OS version: buster, bullseye
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/java:0-11-${VARIANT}
 
 # Install JDK 8 and optionally Maven and Gradle - version of "" installs latest
 ARG JDK8_VERSION=""

--- a/containers/java-8/.devcontainer/base.Dockerfile
+++ b/containers/java-8/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian OS version: buster, bullseye
+# [Choice] Debian OS version (use bullseye for arm64/Apple Silicon): buster, bullseye
 ARG VARIANT="buster"
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-11-${VARIANT}
 

--- a/containers/java-8/.devcontainer/devcontainer.json
+++ b/containers/java-8/.devcontainer/devcontainer.json
@@ -3,6 +3,10 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
+			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
+			// Use bullseye when running locally on a M1 mac.
+			"VARIANT": "buster",
+			// Options
 			"INSTALL_MAVEN": "false",
 			"INSTALL_GRADLE": "false",
 			"NODE_VERSION": "lts/*"

--- a/containers/java-8/.devcontainer/devcontainer.json
+++ b/containers/java-8/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
-			// Use bullseye when running locally on a M1 mac.
+			// Use bullseye when running locally on arm64/Apple Silicon.
 			"VARIANT": "buster",
 			// Options
 			"INSTALL_MAVEN": "false",

--- a/containers/java-8/README.md
+++ b/containers/java-8/README.md
@@ -10,7 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/java:8 |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 8 / 8-buster, 8-bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variant |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -24,15 +25,23 @@ See **[history](history)** for information on the contents of published images.
 
 This definition includes both JDK 8 and JDK 11 due to the fact that the VS Code Java extension requires JDK 11+. The needed `devcontainer.json` settings are present to enable you to work with projects targeting Java 8.
 
+While this definition should work unmodified, you can select the version of Debian the container uses to run Java 8 by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
+
+```json
+"args": { "VARIANT": "bullseye" }
+```
+
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
-- `mcr.microsoft.com/vscode/devcontainers/java:8`
+- `mcr.microsoft.com/vscode/devcontainers/java:8` (or `8-bullseye`, `8-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/java:0-8`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.201-8`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.201.5-8`
+- `mcr.microsoft.com/vscode/devcontainers/java:0-8` (or `0-8-bullseye`, `0-8-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/java:0.203-8` (or `0.203-8-bullseye`, `0.203-8-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/java:0.203.0-8` (or `0.203.0-8-bullseye`, `0.203.0-8-buster` to pin to an OS version)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-8`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
 

--- a/containers/java-8/definition-manifest.json
+++ b/containers/java-8/definition-manifest.json
@@ -6,8 +6,8 @@
 		"rootDistro": "debian",
 		"parent": "java",
 		"parentVariant": {
-			"bullseye": "11-bullseye",
-			"buster": "11-buster"
+			"bullseye": "11-jdk-bullseye",
+			"buster": "11-jdk-buster"
 		},
 		"architectures": {
 			"bullseye": ["linux/amd64", "linux/arm64"],

--- a/containers/java-8/definition-manifest.json
+++ b/containers/java-8/definition-manifest.json
@@ -1,16 +1,31 @@
 {
-	"definitionVersion": "0.202.4",
+	"variants": [ "bullseye", "buster" ],
+	"definitionVersion": "0.203.0",
 	"build": {
-		"latest": false,
+		"latest": "buster",
 		"rootDistro": "debian",
 		"parent": "java",
-		"parentVariant": "11",
+		"parentVariant": {
+			"bullseye": "11-bullseye",
+			"buster": "11-buster"
+		},
+		"architectures": {
+			"bullseye": ["linux/amd64", "linux/arm64"],
+			"buster": ["linux/amd64"]
+		},
 		"tags": [
-			"java:${VERSION}-8"
-		]
+			"java:${VERSION}-8-${VARIANT}"
+		],
+		"variantTags": {
+			"buster": [ 
+				"java:${VERSION}-8",
+				"java:${VERSION}-8-jdk-buster"
+			],
+			"bullseye": [ "java:${VERSION}-8-jdk-bullseye" ]
+		}
 	},
 	"dependencies": {
-		"image": "mcr.microsoft.com/vscode/devcontainers/java:11",
+		"image": "mcr.microsoft.com/vscode/devcontainers/java:11-${VARIANT}",
 		"imageLink": "https://hub.docker.com/_/java",
 		"apt": [{
 			"cgIgnore": false,

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Java version: 11, 16, 11-bullseye, 16-bullseye, 11-buster, 16-buster
+# [Choice] Java version (use -bullseye variants for arm64/Apple Silicon): 11, 16, 11-bullseye, 16-bullseye, 11-buster, 16-buster
 ARG VARIANT=11-buster
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Java version: 11, 16
-ARG VARIANT=11
+# [Choice] Java version: 11, 16, 11-bullseye, 16-bullseye, 11-buster, 16-buster
+ARG VARIANT=11-buster
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
 # [Option] Install Maven

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -1,6 +1,6 @@
-# [Choice] Java version: 11, 16
-ARG VARIANT=11
-FROM openjdk:${VARIANT}-jdk-buster
+# [Choice] Java version: 11-jdk-bullseye, 16-jdk-bullseye, 11-jdk-buster, 16-jdk-buster
+ARG VARIANT=11-jdk-buster
+FROM openjdk:${VARIANT}
 
 # Copy library scripts to execute
 COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Java version: 11-jdk-bullseye, 16-jdk-bullseye, 11-jdk-buster, 16-jdk-buster
+# [Choice] Java version (use -bullseye variants for arm64/Apple Silicon): 11-jdk-bullseye, 16-jdk-bullseye, 11-jdk-buster, 16-jdk-buster
 ARG VARIANT=11-jdk-buster
 FROM openjdk:${VARIANT}
 

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 			// Update the VARIANT arg to pick a Java version: 11, 16
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use the -bullseye variants if you are on a M1 mac.
-			"VARIANT": "11-sdk-buster",
+			"VARIANT": "11-jdk-bullseye",
 			// Options
 			"INSTALL_MAVEN": "false",
 			"INSTALL_GRADLE": "false",

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"args": {
 			// Update the VARIANT arg to pick a Java version: 11, 16
 			// Append -bullseye or -buster to pin to an OS version.
-			// Use the -bullseye variants if you are on a M1 mac.
+			// Use the -bullseye variants if you are on arm64/Apple Silicon.
 			"VARIANT": "11-jdk-bullseye",
 			// Options
 			"INSTALL_MAVEN": "false",

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a Java version: 11, 16
-			"VARIANT": "11",
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use the -bullseye variants if you are on a M1 mac.
+			"VARIANT": "11-sdk-buster",
 			// Options
 			"INSTALL_MAVEN": "false",
 			"INSTALL_GRADLE": "false",

--- a/containers/java/README.md
+++ b/containers/java/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/java |
-| *Available image variants* | 11, 16 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 11 / 11-buster, 16 / 16-buster, 11-bullseye, 16-bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list)) |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -26,20 +26,23 @@ See **[history](history)** for information on the contents of published images.
 While this definition should work unmodified, you can select the version of Java the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
+// Or you can use 16-bullseye or 16-buster if you want to pin to an OS version
 "args": { "VARIANT": "16" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/vscode/devcontainers/java` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/java:11`
-- `mcr.microsoft.com/vscode/devcontainers/java:16`
+- `mcr.microsoft.com/vscode/devcontainers/java:11` (or `11-bullseye`, `11-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/java:16` (or `16-bullseye`, `16-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/java:0-11`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.201-11`
-- `mcr.microsoft.com/vscode/devcontainers/java:0.201.5-11`
+- `mcr.microsoft.com/vscode/devcontainers/java:0-11` (or `0-11-bullseye`, `0-11-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/java:0.203-11` (or `0.203-11-bullseye`, `0.203-11-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/java:0.203.0-11` (or `0.203.0-11-bullseye`, `0.203.0-11-buster` to pin to an OS version)
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-11`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/java/tags/list).
 

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,15 +1,37 @@
 {
-	"variants": [ "16", "11" ],
-	"definitionVersion": "0.202.4",
+	"variants": [ "16-jdk-bullseye", "11-jdk-bullseye", "16-jdk-buster", "11-jdk-buster" ],
+	"definitionVersion": "0.203.0",
 	"build": {
-		"latest": true,
+		"latest": "16-jdk-buster",
 		"rootDistro": "debian",
+		"architectures": {
+			"16-jdk-bullseye": ["linux/amd64", "linux/arm64"],
+			"11-jdk-bullseye": ["linux/amd64", "linux/arm64"],
+			"16-jdk-buster": ["linux/amd64"],
+			"11-jdk-buster": ["linux/amd64"]
+		},
 		"tags": [
 			"java:${VERSION}-${VARIANT}"
-		]
+		],
+		"variantTags": {
+			"16-jdk-bullseye": [ 
+				"java:${VERSION}-16-bullseye",
+				"java:${VERSION}-bullseye"
+			],
+			"11-jdk-bullseye": [ "java:${VERSION}-11-bullseye" ],
+			"16-jdk-buster": [ 
+				"java:${VERSION}-16",
+				"java:${VERSION}-16-buster",
+				"java:${VERSION}-buster"
+			],
+			"11-jdk-buster": [ 
+				"java:${VERSION}-11",
+				"java:${VERSION}-11-buster"
+			]
+		}
 	},
 	"dependencies": {
-		"image": "openjdk:${VARIANT}-jdk-buster",
+		"image": "openjdk:${VARIANT}",
 		"imageLink": "https://hub.docker.com/_/java",
 		"apt": [{
 			"cgIgnore": false,

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 			// Update VARIANT to pick a PHP version: 8, 8.0, 7, 7.4, 7.3
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use the -bullseye variants if you are on a M1 mac.
-			"VARIANT": "8-bullseye",
+			"VARIANT": "8-apache-bullseye",
 			"NODE_VERSION": "lts/*"
 		}
 	},


### PR DESCRIPTION
As described in https://github.com/microsoft/vscode-dev-containers/issues/558#issuecomment-905117722, the situation for Docker on M1 macs is not ideal since both `debian:buster` nor `ubuntu:focal` experience segmentation faults due to an issue in `libss1.1`. It seems unlikely that `buster` will be patched now that `bullseye` is out (and buster therefore gets security fixes only). 

Therefore this PR:
1. Adds arm64 builds for Debian `bullseye` 
2. Adds `buster` variants that are x86 only for backwards compat.
3. Keeps the default image tags (8, 11, 16) at `buster`

@testforstephen @akaroml - Debian `bullseye` is pretty recent, but works on arm64. Would it make sense to default to stick with `buster` as is done here?  Java should be fairly abstracted from OS version updates, but I didn't want to make an update that could break users. Thoughts?

//cc: @joshspicer @2percentsilk @bamurtaugh @chrmarti 
