### PR TITLE
C++ arm64 images

### DIFF
--- a/containers/cpp/.devcontainer/Dockerfile
+++ b/containers/cpp/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian / Ubuntu version: debian-11, debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
+# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 ARG VARIANT=debian-10
 FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 

--- a/containers/cpp/.devcontainer/base.Dockerfile
+++ b/containers/cpp/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian / Ubuntu version: debian-11, debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
+# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 ARG VARIANT=debian-10
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 

--- a/containers/cpp/.devcontainer/devcontainer.json
+++ b/containers/cpp/.devcontainer/devcontainer.json
@@ -2,8 +2,9 @@
 	"name": "C++",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
-		"args": { "VARIANT": "debian-10" }
+		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+		// Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 when on arm64/Apple Silicon
+		"args": { "VARIANT": "debian-11" }
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 

--- a/containers/cpp/README.md
+++ b/containers/cpp/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/cpp |
-| *Available image variants* | stretch, buster, bullseye, bionic, focal ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | stretch, buster, bullseye, bionic, focal, hirsute ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `bullseye`, `stretch`, `bionic`, and `hirsute` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian, Ubuntu |
@@ -24,24 +24,28 @@ See **[history](history)** for information on the contents of published images.
 While the definition itself works unmodified, you can select the version of Debian or Ubuntu the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "focal" }
+"args": { "VARIANT": "bullseye" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
-- `mcr.microsoft.com/vscode/devcontainers/cpp` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/cpp:debian` (latest)
+- `mcr.microsoft.com/vscode/devcontainers/cpp` (latest Debian GA)
+- `mcr.microsoft.com/vscode/devcontainers/cpp:debian` (latest Debian GA)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:bullseye` (or `debian-11`)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:buster` (or `debian-10`)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:stretch` (or `debian-9`)
+- `mcr.microsoft.com/vscode/devcontainers/cpp:ubuntu` (latest Ubuntu LTS)
+- `mcr.microsoft.com/vscode/devcontainers/cpp:hirsute` (or `ubuntu-21.04`)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:focal` (or `ubuntu-20.04`)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:bionic` (or `ubuntu-18.04`)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/cpp:0-focal`
-- `mcr.microsoft.com/vscode/devcontainers/cpp:0.201-focal`
-- `mcr.microsoft.com/vscode/devcontainers/cpp:0.201.5-focal`
+- `mcr.microsoft.com/vscode/devcontainers/cpp:0-bullseye`
+- `mcr.microsoft.com/vscode/devcontainers/cpp:0.203-bullseye`
+- `mcr.microsoft.com/vscode/devcontainers/cpp:0.203.0-bullseye`
+
+However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-bullseye`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list).
 

--- a/containers/cpp/definition-manifest.json
+++ b/containers/cpp/definition-manifest.json
@@ -1,33 +1,46 @@
 {
-	"variants": ["buster", "bullseye", "focal", "bionic", "stretch"],
-	"definitionVersion": "0.202.1",
+	"variants": ["bullseye", "buster", "hirsute", "focal", "bionic", "stretch"],
+	"definitionVersion": "0.203.0",
 	"build": {
-		"latest": true,
+		"latest": "bullseye",
 		"parent": {
 			"bullseye": "debian",
 			"buster": "debian", 
 			"stretch": "debian", 
+			"hirsute": "ubuntu",
 			"focal": "ubuntu",
 			"bionic": "ubuntu"
 		},
 		"rootDistro": "debian",
+		"architectures": {
+			"bullseye": ["linux/amd64", "linux/arm64"],
+			"buster": ["linux/amd64"],
+			"stretch": ["linux/amd64", "linux/arm64"],
+			"hirsute": ["linux/amd64", "linux/arm64"],
+			"focal": ["linux/amd64"],
+			"bionic": ["linux/amd64", "linux/arm64"]
+		},
 		"tags": [
 			"cpp:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
 			"bullseye": [
 				"cpp:${VERSION}-debian-11",
-				"cpp:${VERSION}-debian11"
+				"cpp:${VERSION}-debian11",
+				"cpp:${VERSION}-debian",
+				"cpp:${VERSION}"
 			],
 			"buster": [
 				"cpp:${VERSION}-debian-10",
-				"cpp:${VERSION}-debian10",
-				"cpp:${VERSION}-debian",
-				"cpp:${VERSION}"
+				"cpp:${VERSION}-debian10"
 			],
 			"stretch": [
 				"cpp:${VERSION}-debian-9",
 				"cpp:${VERSION}-debian9"
+			],
+			"hirsute": [
+				"cpp:${VERSION}-ubuntu-21.04",
+				"cpp:${VERSION}-ubuntu21.04"
 			],
 			"focal": [
 				"cpp:${VERSION}-ubuntu-20.04",


### PR DESCRIPTION
As described in https://github.com/microsoft/vscode-dev-containers/issues/558#issuecomment-905117722, the situation for Docker on M1 macs is not ideal since both `debian:buster` nor `ubuntu:focal` experience segmentation faults due to an issue in `libss1.1`. It seems unlikely that `buster` will be patched now that `bullseye` is out (and buster therefore gets security fixes only). 

Therefore this PR:
1. Adds arm64 build for Debian `bullseye` , `stretch`,  `hirsute`m `bionic`
2. Leaves `buster`, `focal` variants that are x86 only
3. Set the default image to `bullseye`

//cc: @joshspicer @2percentsilk @bamurtaugh @chrmarti 
