### PR TITLE
Anaconda arm64 image

### DIFF
--- a/containers/python-3-anaconda/README.md
+++ b/containers/python-3-anaconda/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/anaconda:3 |
-| *Published image architecture(s)* | x86-64 |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -29,8 +29,8 @@ While the definition itself works unmodified, you can also directly reference pr
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/anaconda:0-3`
-- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.201-3`
-- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.201.4-3`
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.202-3`
+- `mcr.microsoft.com/vscode/devcontainers/anaconda:0.202.0-3`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/anaconda/tags/list).
 

--- a/containers/python-3-anaconda/definition-manifest.json
+++ b/containers/python-3-anaconda/definition-manifest.json
@@ -1,8 +1,9 @@
 {
-	"definitionVersion": "0.201.8",
+	"definitionVersion": "0.202.0",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",
+		"architectures": ["linux/amd64", "linux/arm64"],
 		"tags": [
 			"anaconda:${VERSION}-3"
 		]


### PR DESCRIPTION
As described in #558 (comment), the situation for Docker on M1 macs is not ideal since both debian:buster nor ubuntu:focal experience segmentation faults due to an issue in libss1.1. It seems unlikely that buster will be patched now that bullseye is out (and buster therefore gets security fixes only).

Now that the `anaconda` image has moved to `bullseye`, we can add an arm64 build for it.