### PR TITLE
SFDX docker image tag change

### DIFF
--- a/containers/sfdx-project/.devcontainer/Dockerfile
+++ b/containers/sfdx-project/.devcontainer/Dockerfile
@@ -1,1 +1,1 @@
-FROM salesforce/salesforcedx
+FROM salesforce/salesforcedx:latest-rc-full


### PR DESCRIPTION
This updates the image tag to the new format as per this stack exchange answer and verified on [docker hub](https://hub.docker.com/r/salesforce/salesforcedx/tags?page=1&ordering=last_updated)

Stack Exchange: https://salesforce.stackexchange.com/questions/354209/manifest-for-salesforce-salesforcedxlatest-not-found-manifest-unknown-manifes