### PR TITLE
Update simplify compose definitions, update to cover arm64 support, misc edits

### DIFF
--- a/container-templates/docker-compose/.devcontainer/Dockerfile
+++ b/container-templates/docker-compose/.devcontainer/Dockerfile
@@ -1,10 +1,16 @@
-# Add your image here
-ARG VARIANT="buster"
+# Use the [Choice] comment to indicate option arguments that should appear in VS Code UX. Use a comma separated list.
+#
+# [Choice] Debian OS version: bullseye, buster, stretch
+ARG VARIANT="bullseye"
 FROM buildpack-deps:${VARIANT}-curl
 
-# Options for setup script
+# Use the [Option] comment to specify true/false arguments that should appear in VS Code UX
+#
+# [Option] Install zsh
 ARG INSTALL_ZSH="true"
+# [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="false"
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID

--- a/container-templates/dockerfile/.devcontainer/Dockerfile
+++ b/container-templates/dockerfile/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Use the [Choice] comment to indicate option arguments that should appear in VS Code UX. Use a comma separated list.
 #
-# [Choice] Debian OS version: buster, stretch
+# [Choice] Debian OS version: bullseye, buster, stretch
 ARG VARIANT="buster"
 FROM buildpack-deps:${VARIANT}-curl
 

--- a/container-templates/image/.devcontainer/devcontainer.json
+++ b/container-templates/image/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "Your Definition Name Here (Community)",
 
 	// Update the 'image' property with your Docker image name.
-	"image": "mcr.microsoft.com/vscode/devcontainers/base:debian-10",
+	"image": "mcr.microsoft.com/vscode/devcontainers/base:debian-11",
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": {},

--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 COPY library-scripts/*.sh /tmp/library-scripts/
 

--- a/containers/azure-ansible/README.md
+++ b/containers/azure-ansible/README.md
@@ -9,6 +9,7 @@
 | *Contributors* | [Carlos Mendible](https://github.com/cmendible) |
 | *Categories* | Community, Azure, Other |
 | *Definition type* | Dockerfile |
+| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/azure-cli/.devcontainer/Dockerfile
+++ b/containers/azure-cli/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/containers/azure-cli/README.md
+++ b/containers/azure-cli/README.md
@@ -9,6 +9,7 @@
 | *Contributors* | The VS Code Team |
 | *Categories* | Services, Azure |
 | *Definition type* | Dockerfile |
+| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 COPY library-scripts/*.sh /tmp/library-scripts/
 

--- a/containers/azure-terraform/README.md
+++ b/containers/azure-terraform/README.md
@@ -11,6 +11,7 @@ This recipe allows you to get going quickly with Terraform in Azure. Includes Te
 | *Contributors* | [Carlos Mendible](https://github.com/cmendible), [Charles Zipp](https://github.com/charleszipp), [Lila Molyva](https://github.com/norelina), [Tas Devani](https://github.com/tasdevani21)  |
 | *Categories* | Community, Azure, Other |
 | *Definition type* | Dockerfile |
+| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/bash/.devcontainer/Dockerfile
+++ b/containers/bash/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Debian / Ubuntu version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
-ARG VARIANT=debian-10
+# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT=debian-11
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 WORKDIR /src
 

--- a/containers/bash/.devcontainer/devcontainer.json
+++ b/containers/bash/.devcontainer/devcontainer.json
@@ -2,8 +2,9 @@
 	"name": "Bash (Community)",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-10, debian-9, ubuntu-20.04, ubuntu-18.04
-		"args": { "VARIANT": "debian-10" }
+		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+		// Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 on local arm64/Apple Silicon
+		"args": { "VARIANT": "debian-11" }
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 # Options for setup script
 ARG INSTALL_ZSH="true"

--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/base:buster
 
 # Options for setup script
 ARG INSTALL_ZSH="true"

--- a/containers/bazel/README.md
+++ b/containers/bazel/README.md
@@ -9,7 +9,7 @@
 | *Contributors* | William Phetsinorath <deva.shikanime@protonmail.com> |
 | *Categories* | Community, Other |
 | *Definition type* | Dockerfile |
-| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
+| *Supported architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/bazel/README.md
+++ b/containers/bazel/README.md
@@ -9,6 +9,7 @@
 | *Contributors* | William Phetsinorath <deva.shikanime@protonmail.com> |
 | *Categories* | Community, Other |
 | *Definition type* | Dockerfile |
+| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/cpp/.devcontainer/Dockerfile
+++ b/containers/cpp/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
-ARG VARIANT=debian-10
+# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+ARG VARIANT=debian-11
 FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional packages.

--- a/containers/cpp/.devcontainer/base.Dockerfile
+++ b/containers/cpp/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 ARG VARIANT=debian-10
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 

--- a/containers/cpp/.devcontainer/devcontainer.json
+++ b/containers/cpp/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
-		// Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 when on arm64/Apple Silicon
+		// Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 on local arm64/Apple Silicon
 		"args": { "VARIANT": "debian-11" }
 	},
 	"runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],

--- a/containers/dart/README.md
+++ b/containers/dart/README.md
@@ -9,6 +9,7 @@
 | *Contributors* | The VS Code Team |
 | *Categories* | Languages |
 | *Definition type* | Dockerfile |
+| *Supported architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/debian/.devcontainer/Dockerfile
+++ b/containers/debian/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Debian version: bullseye, buster, stretch
-ARG VARIANT=buster
+# [Choice] Debian version (use bullseye or stretch on local arm64/Apple Silicon): bullseye, buster, stretch
+ARG VARIANT=bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 
 # ** [Optional] Uncomment this section to install additional packages. **

--- a/containers/debian/.devcontainer/base.Dockerfile
+++ b/containers/debian/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Debian version: bullseye, buster, stretch
-ARG VARIANT="buster"
+# [Choice] Debian version (use bullseye or stretch on local arm64/Apple Silicon): bullseye, buster, stretch
+ARG VARIANT="bullseye"
 FROM buildpack-deps:${VARIANT}-curl
 
 # [Option] Install zsh

--- a/containers/debian/.devcontainer/devcontainer.json
+++ b/containers/debian/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Debian version: bullseye, buster, stretch
-		"args": { "VARIANT": "buster" }
+		// Use bullseye or stretch on local arm64/Apple Silicon.
+		"args": { "VARIANT": "bullseye" }
 	},
 
 	// Set *default* container specific settings.json values on container create.

--- a/containers/deno/.devcontainer/Dockerfile
+++ b/containers/deno/.devcontainer/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:debian-10
+# [Choice] Debian OS version (use bullseye on arm64/Apple Silicon): bullseye, buster
+ARG VARIANT=debian-11
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian-11
 
 ENV DENO_INSTALL=/deno
 RUN mkdir -p /deno \

--- a/containers/deno/.devcontainer/Dockerfile
+++ b/containers/deno/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-# [Choice] Debian OS version (use bullseye on arm64/Apple Silicon): bullseye, buster
-ARG VARIANT=debian-11
-FROM mcr.microsoft.com/vscode/devcontainers/base:debian-11
+# [Choice] Debian OS version: bullseye, buster
+ARG VARIANT=bullseye
+FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 ENV DENO_INSTALL=/deno
 RUN mkdir -p /deno \

--- a/containers/deno/.devcontainer/devcontainer.json
+++ b/containers/deno/.devcontainer/devcontainer.json
@@ -3,7 +3,6 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Debian OS version: bullseye, buster
-		// Use bullseye when on local arm64/Apple Silicon.
 		"args": {
 			"VARIANT": "bullseye"
 		}

--- a/containers/deno/.devcontainer/devcontainer.json
+++ b/containers/deno/.devcontainer/devcontainer.json
@@ -1,17 +1,26 @@
 {
-    "name": "Deno",
-    "dockerFile": "Dockerfile",
-    "settings": {
-        // Enables the project as a Deno project
-        "deno.enable": true,
-        // Enables Deno linting for the project
-        "deno.lint": true,
-        // Sets Deno as the default formatter for the project
-        "editor.defaultFormatter": "denoland.vscode-deno"
-    },
-    // This will install the vscode-deno extension
-    "extensions": [
-        "denoland.vscode-deno"
-    ],
-    "remoteUser": "vscode"
+	"name": "Deno",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Debian OS version: bullseye, buster
+		// Use bullseye when on local arm64/Apple Silicon.
+		"args": {
+			"VARIANT": "bullseye"
+		}
+	},
+	"settings": {
+		// Enables the project as a Deno project
+		"deno.enable": true,
+		// Enables Deno linting for the project
+		"deno.lint": true,
+		// Sets Deno as the default formatter for the project
+		"editor.defaultFormatter": "denoland.vscode-deno"
+	},
+
+	// This will install the vscode-deno extension
+	"extensions": [
+		"denoland.vscode-deno"
+	],
+
+	"remoteUser": "vscode"
 }

--- a/containers/deno/README.md
+++ b/containers/deno/README.md
@@ -9,6 +9,7 @@ _Develop Deno applications. Includes the latest Deno runtime and extension._
 | _Contributors_              | @anthonychu, @kitsonk        |
 | _Categories_                | Community, Languages         |
 | _Definition type_           | Dockerfile                   |
+| _Supported architecture(s)_ | x86-64                       |
 | _Works in Codespaces_       | Yes                          |
 | _Container host OS support_ | Linux, macOS, Windows        |
 | _Container OS_              | Debian                       |

--- a/containers/docker-from-docker-compose/.devcontainer/Dockerfile
+++ b/containers/docker-from-docker-compose/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Note: You can use any Debian/Ubuntu based image you want. 
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/containers/docker-from-docker-compose/.devcontainer/docker-compose.yml
+++ b/containers/docker-from-docker-compose/.devcontainer/docker-compose.yml
@@ -5,10 +5,6 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-      args:
-        # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-        USER_UID: 1000
-        USER_GID: 1000
 
     init: true
     volumes:

--- a/containers/docker-from-docker/.devcontainer/Dockerfile
+++ b/containers/docker-from-docker/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Note: You can use any Debian/Ubuntu based image you want. 
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/containers/docker-in-docker/.devcontainer/Dockerfile
+++ b/containers/docker-in-docker/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Note: You can use any Debian/Ubuntu based image you want. 
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/containers/dotnet-mssql/.devcontainer/Dockerfile
+++ b/containers/dotnet-mssql/.devcontainer/Dockerfile
@@ -17,12 +17,6 @@ COPY mssql/installSQLtools.sh installSQLtools.sh
 RUN bash ./installSQLtools.sh \
      && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
-# Update args in docker-compose.yaml to set the UID/GID of the "vscode" user.
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
-
-
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/containers/dotnet-mssql/.devcontainer/docker-compose.yml
+++ b/containers/dotnet-mssql/.devcontainer/docker-compose.yml
@@ -12,9 +12,6 @@ services:
         NODE_VERSION: "lts/*"
         # [Option] Install Azure CLI
         INSTALL_AZURE_CLI: "false"
-        # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-        USER_UID: 1000
-        USER_GID: 1000
 
     volumes:
       - ..:/workspace:cached

--- a/containers/go/.devcontainer/Dockerfile
+++ b/containers/go/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version: 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
 ARG VARIANT=1-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 

--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version: 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
 ARG VARIANT=1-bullseye
 FROM golang:${VARIANT}
 

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"args": {
 			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
 			// Append -bullseye or -buster to pin to an OS version.
-			// Use the -bullseye variants if you are on a M1 mac.
+			// Use -bullseye variants on local arm64/Apple Silicon.
 			"VARIANT": "1-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"

--- a/containers/java-8/.devcontainer/Dockerfile
+++ b/containers/java-8/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian OS version (use bullseye for arm64/Apple Silicon): buster, bullseye
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
 ARG VARIANT="buster"
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-8-${VARIANT}
 

--- a/containers/java-8/.devcontainer/base.Dockerfile
+++ b/containers/java-8/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian OS version (use bullseye for arm64/Apple Silicon): buster, bullseye
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
 ARG VARIANT="buster"
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-11-${VARIANT}
 

--- a/containers/java-8/.devcontainer/base.Dockerfile
+++ b/containers/java-8/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
-ARG VARIANT="buster"
+ARG VARIANT="bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-11-${VARIANT}
 
 # Install JDK 8 and optionally Maven and Gradle - version of "" installs latest

--- a/containers/java-8/.devcontainer/devcontainer.json
+++ b/containers/java-8/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
-			// Use bullseye when running locally on arm64/Apple Silicon.
+			// Use bullseye when running on local arm64/Apple Silicon.
 			"VARIANT": "buster",
 			// Options
 			"INSTALL_MAVEN": "false",

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 16, 11-bullseye, 16-bullseye, 11-buster, 16-buster
-ARG VARIANT=11-buster
+ARG VARIANT=11-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
 # [Option] Install Maven

--- a/containers/java/.devcontainer/Dockerfile
+++ b/containers/java/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Java version (use -bullseye variants for arm64/Apple Silicon): 11, 16, 11-bullseye, 16-bullseye, 11-buster, 16-buster
+# [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 16, 11-bullseye, 16-bullseye, 11-buster, 16-buster
 ARG VARIANT=11-buster
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Java version (use -bullseye variants for arm64/Apple Silicon): 11-jdk-bullseye, 16-jdk-bullseye, 11-jdk-buster, 16-jdk-buster
+# [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11-jdk-bullseye, 16-jdk-bullseye, 11-jdk-buster, 16-jdk-buster
 ARG VARIANT=11-jdk-buster
 FROM openjdk:${VARIANT}
 

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"args": {
 			// Update the VARIANT arg to pick a Java version: 11, 16
 			// Append -bullseye or -buster to pin to an OS version.
-			// Use the -bullseye variants if you are on arm64/Apple Silicon.
+			// Use the -bullseye variants on local arm64/Apple Silicon.
 			"VARIANT": "11-jdk-bullseye",
 			// Options
 			"INSTALL_MAVEN": "false",

--- a/containers/javascript-node-azurite/.devcontainer/Dockerfile
+++ b/containers/javascript-node-azurite/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Update the VARIANT arg in docker-compose.yml to pick a Node version: 10, 12, 14
-ARG VARIANT=12
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=14-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 USER root
 RUN apt-get update

--- a/containers/javascript-node-azurite/.devcontainer/Dockerfile
+++ b/containers/javascript-node-azurite/.devcontainer/Dockerfile
@@ -1,19 +1,9 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT=14-bullseye
+ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 USER root
 RUN apt-get update
 RUN apt-get install libsecret-1-dev -y
-
-# Update args in docker-compose.yaml to set the UID/GID of the "node" user.
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then \
-        groupmod --gid $USER_GID node \
-        && usermod --uid $USER_UID --gid $USER_GID node \
-        && chmod -R $USER_UID:$USER_GID /home/node \
-        && chmod -R $USER_UID:root /usr/local/share/nvm /usr/local/share/npm-global; \
-    fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/javascript-node-azurite/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-azurite/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// Update the VARIANT arg in docker-compose.yml to pick a Node.js version: 10, 12, 14 
+// Update the VARIANT arg in docker-compose.yml to pick a Node.js version
 {
 	"name": "Node.js & Azurite (Community)",
 	"dockerComposeFile": "docker-compose.yml",

--- a/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Node.js version: 16, 14, 12
+        # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: 14-buster

--- a/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
@@ -9,10 +9,7 @@ services:
         # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 14-buster
-        # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-        USER_UID: 1000
-        USER_GID: 1000
+        VARIANT: 16-bullseye
 
     volumes:
       - ..:/workspace:cached

--- a/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       dockerfile: Dockerfile
       args:
         # [Choice] Node.js version: 16, 14, 12
-        VARIANT: 14
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 14-buster
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000
         USER_GID: 1000

--- a/containers/javascript-node-azurite/README.md
+++ b/containers/javascript-node-azurite/README.md
@@ -18,6 +18,19 @@ Everything you need to get started using Node with Azurite.
 
 This setup creates two containers, one for Node.js and one for Azurite. Both will be accessable on localhost, Blob storage will be available on port 10000 and queue will be available on port 10001
 
+While the definition itself works unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/javascript-node` image which includes `git`, `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick either Node.js version.
+
+```yaml
+build:
+  context: .
+  dockerfile: Dockerfile
+  args:
+    # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
+    # Append -bullseye or -buster to pin to an OS version.
+    # Use -bullseye variants on local arm64/Apple Silicon.
+    VARIANT: 14-bullseye
+```
+
 ### Adding another service
 
 You can add other services to your `docker-compose.yml` file [as described in Docker's documentaiton](https://docs.docker.com/compose/compose-file/#service-configuration-reference). However, if you want anything running in this service to be available in the container on localhost, or want to forward the service locally, be sure to add this line to the service config:

--- a/containers/javascript-node-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-mongo/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT=14-bullseye
+ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # Install MongoDB command line tools if on buster and x86_64 (arm64 not supported)
@@ -12,11 +12,6 @@ RUN . /etc/os-release \
         && apt-get install -y mongodb-database-tools mongodb-mongosh \
         && apt-get clean -y && rm -rf /var/lib/apt/lists/*; \
     fi
-
-# Update args in docker-compose.yaml to set the UID/GID of the "node" user.
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID node && usermod --uid $USER_UID --gid $USER_GID node; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/javascript-node-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-mongo/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Update the VARIANT arg in docker-compose.yml to pick a Node version: 16, 14, 12
-ARG VARIANT=14
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=14-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # Install MongoDB command line tools if on buster and x86_64 (arm64 not supported)

--- a/containers/javascript-node-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-mongo/.devcontainer/Dockerfile
@@ -1,14 +1,17 @@
-# Update the VARIANT arg in docker-compose.yml to pick a Node version: 10, 12, 14
-ARG VARIANT=12
+# Update the VARIANT arg in docker-compose.yml to pick a Node version: 16, 14, 12
+ARG VARIANT=14
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
-# Install MongoDB command line tools
-ARG MONGO_TOOLS_VERSION=4.2
-RUN curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | (OUT=$(apt-key add - 2>&1) || echo $OUT) \
-    && echo "deb http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
-    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get install -y mongodb-org-tools mongodb-org-shell \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
+# Install MongoDB command line tools if on buster and x86_64 (arm64 not supported)
+ARG MONGO_TOOLS_VERSION=5.0
+RUN . /etc/os-release \
+    && if [ "${VERSION_CODENAME}" = "buster" ] && [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+        curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
+        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
+        && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+        && apt-get install -y mongodb-database-tools mongodb-mongosh \
+        && apt-get clean -y && rm -rf /var/lib/apt/lists/*; \
+    fi
 
 # Update args in docker-compose.yaml to set the UID/GID of the "node" user.
 ARG USER_UID=1000

--- a/containers/javascript-node-mongo/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-mongo/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// Update the VARIANT arg in docker-compose.yml to pick a Node.js version: 10, 12, 14 
+// Update the VARIANT arg in docker-compose.yml to pick a Node.js version
 {
 	"name": "Node.js & Mongo DB",
 	"dockerComposeFile": "docker-compose.yml",

--- a/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Node.js version: 16, 14, 12
+        # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: 14-buster

--- a/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
@@ -10,9 +10,6 @@ services:
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: 14-buster
-        # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-        USER_UID: 1000
-        USER_GID: 1000
 
     volumes:
       - ..:/workspace:cached

--- a/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-mongo/.devcontainer/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       dockerfile: Dockerfile
       args:
         # [Choice] Node.js version: 16, 14, 12
-        VARIANT: 14
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 14-buster
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000
         USER_GID: 1000

--- a/containers/javascript-node-mongo/README.md
+++ b/containers/javascript-node-mongo/README.md
@@ -18,14 +18,17 @@
 
 This definition creates two containers, one for Node.js and one for MongoDB. VS Code will attach to the Node.js container, and from within that container the MongoDB container will be available on on **`localhost`** port 27017 The MongoDB instance can be managed in VS Code via the automatically installed MongoDB extension. Database options can be configured in `.devcontainer/docker-compose.yml` and data is persisted in a volume called `mongo-data`.
 
-While the definition itself works unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/javascript-node` image which includes `git`, `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick either Node.js version 10, 12, or 14.
+While the definition itself works unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/javascript-node` image which includes `git`, `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick either Node.js version.
 
 ```yaml
 build:
   context: .
   dockerfile: Dockerfile
   args:
-    VARIANT: 14
+    # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
+    # Append -bullseye or -buster to pin to an OS version.
+    # Use -bullseye variants on local arm64/Apple Silicon.
+    VARIANT: 14-bullseye
 ```
 
 You also can connect to MongoDB from an external tool when using VS Code by updating `.devcontainer/devcontainer.json` as follows:

--- a/containers/javascript-node-mongo/README.md
+++ b/containers/javascript-node-mongo/README.md
@@ -25,7 +25,7 @@ build:
   context: .
   dockerfile: Dockerfile
   args:
-    VARIANT: 12
+    VARIANT: 14
 ```
 
 You also can connect to MongoDB from an external tool when using VS Code by updating `.devcontainer/devcontainer.json` as follows:

--- a/containers/javascript-node-postgres/.devcontainer/Dockerfile
+++ b/containers/javascript-node-postgres/.devcontainer/Dockerfile
@@ -1,11 +1,6 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
-ARG VARIANT=14-bullseye
+ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
-
-# Update args in docker-compose.yaml to set the UID/GID of the "node" user.
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID node && usermod --uid $USER_UID --gid $USER_GID node; fi
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/javascript-node-postgres/.devcontainer/Dockerfile
+++ b/containers/javascript-node-postgres/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Update the VARIANT arg in docker-compose.yml to pick a Node version: 10, 12, 14
-ARG VARIANT=12
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+ARG VARIANT=14-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 # Update args in docker-compose.yaml to set the UID/GID of the "node" user.

--- a/containers/javascript-node-postgres/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-postgres/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // Update the VARIANT arg in docker-compose.yml to pick a Node.js version
 {
-	"name": "Node.js & PostgreSQL (Community)",
+	"name": "Node.js & PostgreSQL",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",

--- a/containers/javascript-node-postgres/.devcontainer/devcontainer.json
+++ b/containers/javascript-node-postgres/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// Update the VARIANT arg in docker-compose.yml to pick a Node.js version: 10, 12, 14 
+// Update the VARIANT arg in docker-compose.yml to pick a Node.js version
 {
 	"name": "Node.js & PostgreSQL (Community)",
 	"dockerComposeFile": "docker-compose.yml",

--- a/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Node.js version: 16, 14, 12
+        # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: 14-buster

--- a/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
@@ -9,10 +9,7 @@ services:
         # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 14-buster
-        # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-        USER_UID: 1000
-        USER_GID: 1000
+        VARIANT: 16-bullseye
 
     volumes:
       - ..:/workspace:cached

--- a/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-postgres/.devcontainer/docker-compose.yml
@@ -6,8 +6,10 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Node.js version: 14, 12, 10
-        VARIANT: 14
+        # [Choice] Node.js version: 16, 14, 12
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 14-buster
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000
         USER_GID: 1000

--- a/containers/javascript-node-postgres/README.md
+++ b/containers/javascript-node-postgres/README.md
@@ -1,4 +1,4 @@
-# Node.js & PostgreSQL (Community)
+# Node.js & PostgreSQL
 
 ## Summary
 
@@ -6,8 +6,8 @@
 
 | Metadata | Value |  
 |----------|-------|
-| *Contributors* | [Mehant](mailto:kmehant@gmail.com) |
-| *Categories* | Community, Languages |
+| *Contributors* | [Mehant](mailto:kmehant@gmail.com), the VS Code Team |
+| *Categories* | Core, Languages |
 | *Definition type* | Docker Compose |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -18,14 +18,17 @@
 
 This definition creates two containers, one for Node.js and one for PostgreSQL. VS Code will attach to the Node.js container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `docker-compose.yml`. Data is stored in a volume named `postgres-data`.
 
-While the definition itself works unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/javascript-node` image which includes `git`, `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick either Node.js version 10, 12, or 14.
+While the definition itself works unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/javascript-node` image which includes `git`, `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick a Node.js version. 
 
 ```yaml
 build:
   context: .
   dockerfile: Dockerfile
   args:
-    VARIANT: 12
+    # Update 'VARIANT' to pick an LTS version of Node.js: 16, 14, 12.
+    # Append -bullseye or -buster to pin to an OS version.
+    # Use -bullseye variants on local arm64/Apple Silicon.
+    VARIANT: 14-bullseye
 ```
 
 You also can connect to PostgreSQL from an external tool when using VS Code by updating `.devcontainer/devcontainer.json` as follows:

--- a/containers/javascript-node/.devcontainer/Dockerfile
+++ b/containers/javascript-node/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Node.js version: 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
 ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 

--- a/containers/javascript-node/.devcontainer/base.Dockerfile
+++ b/containers/javascript-node/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Node.js version: 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
 ARG VARIANT=16-bullseye
 FROM node:${VARIANT}
 

--- a/containers/javascript-node/.devcontainer/devcontainer.json
+++ b/containers/javascript-node/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
-		// Use the -bullseye variants if you are on a M1 mac.
+		// Use -bullseye variants on local arm64/Apple Silicon.
 		"args": { "VARIANT": "16-bullseye" }
 	},
 

--- a/containers/jekyll/.devcontainer/Dockerfile
+++ b/containers/jekyll/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian OS version: bullseye, buster
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): bullseye, buster
 ARG VARIANT=bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/jekyll:0-${VARIANT}
 

--- a/containers/jekyll/.devcontainer/base.Dockerfile
+++ b/containers/jekyll/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian OS version: 2.7-bullseye, 2.7-buster
+# [Choice] Debian OS version (use 2.7-bullseye on local arm64/Apple Silicon): 2.7-bullseye, 2.7-buster
 ARG VARIANT=2.7-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 COPY library-scripts/meta.env /usr/local/etc/vscode-dev-containers

--- a/containers/jekyll/.devcontainer/devcontainer.json
+++ b/containers/jekyll/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update 'VARIANT' to pick a Debian OS version: bullseye, buster
-			// Use bullseye if you are on a M1 mac.
+			// Use bullseye when on local arm64/Apple Silicon.
 			"VARIANT": "bullseye",
 			// Enable Node.js: pick the latest LTS version
 			"NODE_VERSION": "lts/*"

--- a/containers/kubernetes-helm-minikube/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm-minikube/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Note: You can use any Debian/Ubuntu based image you want. 
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
 
 # Options
 ARG INSTALL_ZSH="true"

--- a/containers/kubernetes-helm/.devcontainer/Dockerfile
+++ b/containers/kubernetes-helm/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Note: You can use any Debian/Ubuntu based image you want. 
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
 
 # Options
 ARG INSTALL_ZSH="true"

--- a/containers/markdown/.devcontainer/Dockerfile
+++ b/containers/markdown/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/base:0-debian-10
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
 
 # [Optional] Uncomment this section to install additional packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/php-mariadb/.devcontainer/Dockerfile
+++ b/containers/php-mariadb/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Update the VARIANT arg in docker-compose.yml to pick a PHP version: 7, 7.4, 7.3
-ARG VARIANT=7
+# [Choice] PHP version (use -bullseye variants on local arm64/Apple Silicon): 8, 8.0, 7, 7.4, 7.3, 8-bullseye, 8.0-bullseye, 7-bullseye, 7.4-bullseye, 7.3-bullseye, 8-buster, 8.0-buster, 7-buster, 7.4-buster, 7.3-buster
+ARG VARIANT=7-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/php:0-${VARIANT}
 
 # Install MariaDB client

--- a/containers/php-mariadb/.devcontainer/Dockerfile
+++ b/containers/php-mariadb/.devcontainer/Dockerfile
@@ -7,11 +7,6 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get install -y mariadb-client \ 
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# Update args in docker-compose.yaml to set the UID/GID of the "vscode" user.
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
-
 # Install php-mysql driver
 RUN docker-php-ext-install mysqli pdo pdo_mysql
 

--- a/containers/php-mariadb/.devcontainer/devcontainer.json
+++ b/containers/php-mariadb/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// Update the VARIANT arg in docker-compose.yml to pick a PHP version: 7, 7.3, 7.4 
+// Update the VARIANT arg in docker-compose.yml to pick a PHP version
 {
 	"name": "PHP & MariaDB (Community)",
 	"dockerComposeFile": "docker-compose.yml",

--- a/containers/php-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/php-mariadb/.devcontainer/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] PHP version: 7, 7.4, 7.3
+        # Update 'VARIANT' to pick a version of PHP version: 8, 8.0, 7, 7.4, 7.3
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: "7-bullseye"
-        # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+        VARIANT: "8-bullseye"
+        # Optional Node.js version
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/php-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/php-mariadb/.devcontainer/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       dockerfile: Dockerfile
       args:
         # [Choice] PHP version: 7, 7.4, 7.3
-        VARIANT: "7"
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: "7-bullseye"
         # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.

--- a/containers/php-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/php-mariadb/.devcontainer/docker-compose.yml
@@ -12,9 +12,6 @@ services:
         VARIANT: "8-bullseye"
         # Optional Node.js version
         NODE_VERSION: "lts/*"
-        # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-        USER_UID: 1000
-        USER_GID: 1000
 
     volumes:
       - ..:/workspace:cached

--- a/containers/php/.devcontainer/Dockerfile
+++ b/containers/php/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] PHP version: 8, 8.0, 7, 7.4, 7.3, 8-bullseye, 8.0-bullseye, 7-bullseye, 7.4-bullseye, 7.3-bullseye, 8-buster, 8.0-buster, 7-buster, 7.4-buster, 7.3-buster
+# [Choice] PHP version (use -bullseye variants on local arm64/Apple Silicon): 8, 8.0, 7, 7.4, 7.3, 8-bullseye, 8.0-bullseye, 7-bullseye, 7.4-bullseye, 7.3-bullseye, 8-buster, 8.0-buster, 7-buster, 7.4-buster, 7.3-buster
 ARG VARIANT=7-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/php:${VARIANT}
 

--- a/containers/php/.devcontainer/base.Dockerfile
+++ b/containers/php/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] PHP version: 8-apache-bullseye, 8.0-apache-bullseye, 7-apache-bullseye, 7.4-apache-bullseye, 7.3-apache-bullseye, 8-apache-buster, 8.0-apache-buster, 7-apache-buster, 7.4-apache-buster, 7.3-apache-buster
+# [Choice] PHP version (use -bullseye variants on local arm64/Apple Silicon): 8-apache-bullseye, 8.0-apache-bullseye, 7-apache-bullseye, 7.4-apache-bullseye, 7.3-apache-bullseye, 8-apache-buster, 8.0-apache-buster, 7-apache-buster, 7.4-apache-buster, 7.3-apache-buster
 ARG VARIANT=7-apache-bullseye
 FROM php:${VARIANT}
 

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -5,8 +5,8 @@
 		"args": { 
 			// Update VARIANT to pick a PHP version: 8, 8.0, 7, 7.4, 7.3
 			// Append -bullseye or -buster to pin to an OS version.
-			// Use the -bullseye variants if you are on a M1 mac.
-			"VARIANT": "8-apache-bullseye",
+			// Use -bullseye variants on local on arm64/Apple Silicon.
+			"VARIANT": "8-bullseye",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/powershell/.devcontainer/Dockerfile
+++ b/containers/powershell/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/powershell:lts-debian-10
+FROM mcr.microsoft.com/powershell:lts-debian-11
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"

--- a/containers/powershell/README.md
+++ b/containers/powershell/README.md
@@ -9,6 +9,7 @@
 | *Contributors* | The VS Code Team |
 | *Categories* | Languages |
 | *Definition type* | Dockerfile |
+| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/python-3-device-simulator-express/.devcontainer/Dockerfile
+++ b/containers/python-3-device-simulator-express/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# Update the VARIANT arg in devcontainer.json to pick a Python version: 3.7, 3.8 or higher
-ARG VARIANT=3.8
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT=3.8-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}-bullseye
 
 # Create venv for device simulator

--- a/containers/python-3-device-simulator-express/.devcontainer/Dockerfile
+++ b/containers/python-3-device-simulator-express/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster
 ARG VARIANT=3.8-bullseye
-FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 # Create venv for device simulator
 RUN python3 -m venv /opt/vscode/extensions/ms-python.devicesimulatorexpress/venv \

--- a/containers/python-3-device-simulator-express/.devcontainer/Dockerfile
+++ b/containers/python-3-device-simulator-express/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Update the VARIANT arg in devcontainer.json to pick a Python version: 3.7, 3.8 or higher
 ARG VARIANT=3.8
-FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}-bullseye
 
 # Create venv for device simulator
 RUN python3 -m venv /opt/vscode/extensions/ms-python.devicesimulatorexpress/venv \

--- a/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
+++ b/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
-		// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
+		// Update 'VARIANT' to pick a Python version: 3, 3.7, 3.8, 3.9
 		// Append -bullseye or -buster to pin to an OS version.
 		// Use -bullseye variants on local on arm64/Apple Silicon.
 		"args": {

--- a/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
+++ b/containers/python-3-device-simulator-express/.devcontainer/devcontainer.json
@@ -3,9 +3,11 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"context": "..",
-		// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8
+		// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
+		// Append -bullseye or -buster to pin to an OS version.
+		// Use -bullseye variants on local on arm64/Apple Silicon.
 		"args": {
-			"VARIANT": "3.8"
+			"VARIANT": "3.8-bullseye"
 		}
 	},
 	// Set *default* container specific settings.json values on container create.

--- a/containers/python-3-device-simulator-express/README.md
+++ b/containers/python-3-device-simulator-express/README.md
@@ -9,7 +9,7 @@
 | *Contributors* | [Carlos Mendible](https://github.com/cmendible) |
 | *Categories* | Community, Other |
 | *Definition type* | Dockerfile |
-| *Published image architecture(s)* | x86-64 |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` image variants |
 | *Works in Codespaces* | Yes |
 | *Container Host OS Support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -17,23 +17,14 @@
 
 ## Using this definition
 
-### Configuration
+# Configuration
 
-While the definition itself works unmodified, you can select the version of Python the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
+While the definition itself works unmodified, you can select the version of Python 3.7 or higher the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "3.8" }
+// Or you can use 3.7-bullseye or 3.7-buster if you want to pin to an OS version
+"args": { "VARIANT": "3.7" }
 ```
-
-You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own `Dockerfile` with one of the following:
-
-- `mcr.microsoft.com/vscode/devcontainers/python:3` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/python:3.7`
-- `mcr.microsoft.com/vscode/devcontainers/python:3.8`
-
-Alternatively, you can use the contents of `base.Dockerfile` to fully customize the your container's contents or build for a container architecture the image does not support.
-
-Beyond Python and `git`, this image / `Dockerfile` includes a number of Python tools, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies for development.
 
 #### Installing or updating Python utilities
 

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Python version: 3, 3.8, 3.7, 3.6
-ARG VARIANT=3
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG VARIANT=3-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 ENV PYTHONUNBUFFERED 1

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -4,11 +4,6 @@ FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 
 ENV PYTHONUNBUFFERED 1
 
-# Update args in docker-compose.yaml to set the UID/GID of the "vscode" user.
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN if [ "$USER_GID" != "1000" ] || [ "$USER_UID" != "1000" ]; then groupmod --gid $USER_GID vscode && usermod --uid $USER_UID --gid $USER_GID vscode; fi
-
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi

--- a/containers/python-3-postgres/.devcontainer/devcontainer.json
+++ b/containers/python-3-postgres/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-// Update the VARIANT arg in docker-compose.yml to pick a Python version: 3, 3.8, 3.7, 3.6 
+// Update the VARIANT arg in docker-compose.yml to pick a Python version
 {
 	"name": "Python 3 & PostgreSQL",
 	"dockerComposeFile": "docker-compose.yml",

--- a/containers/python-3-postgres/.devcontainer/docker-compose.yml
+++ b/containers/python-3-postgres/.devcontainer/docker-compose.yml
@@ -12,9 +12,6 @@ services:
         VARIANT: 3-bullseye
         # Optional Node.js version to install
         NODE_VERSION: "lts/*"
-        # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
-        USER_UID: 1000
-        USER_GID: 1000
 
     volumes:
       - ..:/workspace:cached

--- a/containers/python-3-postgres/.devcontainer/docker-compose.yml
+++ b/containers/python-3-postgres/.devcontainer/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        # [Choice] Python version: 3, 3.8, 3.7, 3.6
+        # Update 'VARIANT' to pick a version of Python: 3, 3.9, 3.8, 3.7, 3.6
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: 3-bullseye
-        # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+        # Optional Node.js version to install
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.
         USER_UID: 1000

--- a/containers/python-3-postgres/.devcontainer/docker-compose.yml
+++ b/containers/python-3-postgres/.devcontainer/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       dockerfile: .devcontainer/Dockerfile
       args:
         # [Choice] Python version: 3, 3.8, 3.7, 3.6
-        VARIANT: 3
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 3-bullseye
         # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # On Linux, you may need to update USER_UID and USER_GID below if not your local UID is not 1000.

--- a/containers/python-3-postgres/README.md
+++ b/containers/python-3-postgres/README.md
@@ -18,14 +18,17 @@
 
 This definition creates two containers, one for Python and one for PostgreSQL. VS Code will attach to the Python container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and if desired this may be changed in `docker-compose.yml`. Data is stored in a volume named `postgres-data`.
 
-While the definition itself works unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/python` image which includes `git`, `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies and Python tools for development. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick either Python version 3, 3.8, 3.7, or 3.6.
+While the definition itself works unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/python` image which includes `git`, `eslint`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), a non-root `vscode` user with `sudo` access, and a set of common dependencies and Python tools for development. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick a Python version.
 
 ```yaml
 build:
   context: ..
   dockerfile: .devcontainer/Dockerfile
   args:
-    VARIANT: 3.7
+    # Update 'VARIANT' to pick a version of Python: 3, 3.9, 3.8, 3.7, 3.6
+    # Append -bullseye or -buster to pin to an OS version.
+    # Use -bullseye variants on local arm64/Apple Silicon.
+    VARIANT: 3.7-bullseye
 ```
 
 You also can connect to PostgreSQL from an external tool when using VS Code by updating `.devcontainer/devcontainer.json` as follows:

--- a/containers/python-3-postgres/README.md
+++ b/containers/python-3-postgres/README.md
@@ -10,6 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Docker Compose |
 | *Works in Codespaces* | Yes |
+| *Available image variants* | [See Python 3 definition](../python-3). |
+| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Python |

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
 ARG VARIANT=3-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
 ARG VARIANT=3-bullseye
 FROM python:${VARIANT}
 

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"args": { 
 			// Update 'VARIANT' to pick a Python version: 3, 3.9, 3.8, 3.7, 3.6.
 			// Append -bullseye or -buster to pin to an OS version.
-			// Use the -bullseye variants if you are on a M1 mac.
+			// Use -bullseye variants on local on arm64/Apple Silicon.
 			"VARIANT": "3-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"

--- a/containers/reasonml/.devcontainer/Dockerfile
+++ b/containers/reasonml/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:12
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:14-bullseye
 
 RUN sudo -u node npm install -g bs-platform esy@latest
 

--- a/containers/ruby-rails-postgres/.devcontainer/Dockerfile
+++ b/containers/ruby-rails-postgres/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Ruby version: 2, 2.7, 2.6, 2.5
-ARG VARIANT=2
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 # Install Rails

--- a/containers/ruby-rails-postgres/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails-postgres/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 // Update the VARIANT arg in docker-compose.yml to pick a Ruby version
 {
-	"name": "Ruby on Rails & Postgres (Community)",
+	"name": "Ruby on Rails & Postgres",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspace",

--- a/containers/ruby-rails-postgres/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails-postgres/.devcontainer/devcontainer.json
@@ -1,3 +1,4 @@
+// Update the VARIANT arg in docker-compose.yml to pick a Ruby version
 {
 	"name": "Ruby on Rails & Postgres (Community)",
 	"dockerComposeFile": "docker-compose.yml",

--- a/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -7,7 +7,9 @@ services:
       dockerfile: .devcontainer/Dockerfile
       args:
         # [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
-        VARIANT: 2
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 2-bullseye
         # [Choice] Node.js version: lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
 

--- a/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -6,11 +6,11 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        # [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+        # Update 'VARIANT' to pick a version of Ruby: 3, 3.0, 2, 2.7, 2.6, 2.5
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: 2-bullseye
-        # [Choice] Node.js version: lts/*, 16, 14, 12, 10
+        # Optional Node.js version to install
         NODE_VERSION: "lts/*"
 
     volumes:

--- a/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -6,10 +6,10 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        # Update 'VARIANT' to pick a version of Ruby: 3, 3.0, 2, 2.7, 2.6, 2.5
+        # Update 'VARIANT' to pick a version of Ruby: 3, 3.0, 2, 2.7, 2.6
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 2-bullseye
+        VARIANT: "2-bullseye"
         # Optional Node.js version to install
         NODE_VERSION: "lts/*"
 

--- a/containers/ruby-rails-postgres/README.md
+++ b/containers/ruby-rails-postgres/README.md
@@ -1,4 +1,4 @@
-# Ruby on Rails (Community)
+# Ruby on Rails & Postgres
 
 ## Summary
 
@@ -6,10 +6,12 @@
 
 | Metadata | Value |  
 |----------|-------|
-| *Contributors* | [Jarrod Davis][jld] |
-| *Categories* | Community, Frameworks |
+| *Contributors* | [Jarrod Davis][jld], the VS Code Team |
+| *Categories* | Core, Frameworks |
 | *Definition type* | Docker Compose |
 | *Works in Codespaces* | Yes |
+| *Available image variants* | 3 / 3-bullseye, 3.0 / 3.0-bullseye, 2 / 2-bullseye, 2.7 / 2.7-bullseye, 2.6 / 2.7-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
+| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Ruby |
@@ -18,14 +20,17 @@
 
 This definition creates two containers, one for Ruby and one for PostgreSQL. VS Code will attach to the Ruby container, and from within that container the PostgreSQL container will be available on **`localhost`** port 5432. The default database is named `postgres` with a user of `postgres` whose password is `postgres`, and an additional user (`vscode`) is added to support common Rails development database configurations. You can use `rake db:setup` (or `rake db:create`) to setup the databases your Rails application needs for development and testing. Data is stored in a volume named `postgres-data`.
 
-While the definition itself works (mostly) unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/ruby` image which includes `git`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), and a non-root `vscode` user with `sudo` access. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick either Ruby version 3, 3.0, 2, 2.7, 2.6, or 2.5.
+While the definition itself works (mostly) unmodified, it uses the `mcr.microsoft.com/vscode/devcontainers/ruby` image which includes `git`, `zsh`, [Oh My Zsh!](https://ohmyz.sh/), and a non-root `vscode` user with `sudo` access. You can pick a different version of this image by updating the `VARIANT` arg in `.devcontainer/docker-compose.yml` to pick a Ruby version.
 
 ```yaml
 build:
   context: ..
   dockerfile: .devcontainer/Dockerfile
   args:
-    VARIANT: 2.6
+    # Update 'VARIANT' to pick a version of Ruby: 3, 3.0, 2, 2.7, 2.6
+    # Append -bullseye or -buster to pin to an OS version.
+    # Use -bullseye variants on local arm64/Apple Silicon.
+    VARIANT: "2-bullseye"
 ```
 
 To get the best experience, you'll need to update the [SQLTools configuration][sqltools] in `.devcontainer/devcontainer.json` to match the database names used by your application:
@@ -78,8 +83,8 @@ This container also includes Node.js. You can change the version of Node.js by u
 
 ```yaml
 args:
-  VARIANT: 2.6
-  NODE_VERSION: "12" # Set to "none" to skip Node.js installation
+  VARIANT: "2-bullseye"
+  NODE_VERSION: "14" # Set to "none" to skip Node.js installation
 ```
 
 ### Adding the definition to your folder

--- a/containers/ruby-rails-postgres/README.md
+++ b/containers/ruby-rails-postgres/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Frameworks |
 | *Definition type* | Docker Compose |
 | *Works in Codespaces* | Yes |
-| *Available image variants* | 3 / 3-bullseye, 3.0 / 3.0-bullseye, 2 / 2-bullseye, 2.7 / 2.7-bullseye, 2.6 / 2.7-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
+| *Available image variants* | [See Ruby definition](../ruby). |
 | *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Ruby version: 2, 2.7, 2.6, 2.5
-ARG VARIANT=2
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 # Install Rails

--- a/containers/ruby-rails/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails/.devcontainer/devcontainer.json
@@ -3,8 +3,10 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5
-			"VARIANT": "2",
+			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local on arm64/Apple Silicon.
+			"VARIANT": "2-bullseye",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/ruby-rails/README.md
+++ b/containers/ruby-rails/README.md
@@ -4,21 +4,24 @@
 
 _Develop Ruby on Rails applications, includes everything you need to get up and running._
 
-| Metadata                    | Value                 |
-| --------------------------- | --------------------- |
-| _Contributors_              | [Amblizer][la]        |
-| _Categories_                | Community, Frameworks |
-| _Definition type_           | Dockerfile            |
-| _Works in Codespaces_       | Yes                   |
-| _Container host OS support_ | Linux, macOS, Windows |
-| _Container OS_              | Debian                |
-| _Languages, platforms_      | Ruby                  |
+| Metadata                    | Value                                             |
+| --------------------------- | ------------------------------------------------- |
+| _Contributors_              | [Amblizer][la]                                    |
+| _Categories_                | Community, Frameworks                             |
+| _Definition type_           | Dockerfile                                        |
+| _Works in Codespaces_       | Yes                                               |
+| _Available image variants_  | [See Ruby definition](../ruby).                   |
+| _Supported architecture(s)_ | x86-64, arm64/aarch64 for `bullseye` based images |
+| _Container host OS support_ | Linux, macOS, Windows                             |
+| _Container OS_              | Debian                                            |
+| _Languages, platforms_      | Ruby                                              |
 
 ## Using this definition
 
-While this definition should work unmodified, you can select the version of Ruby the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
+While this definition should work unmodified, you can select [an available version Ruby](../ruby) the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
+// Or you can use 2.7-bullseye or 2.7-buster if you want to pin to an OS version
 "args": { "VARIANT": "2.7" }
 ```
 

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Ruby version: 2, 2.7, 2.6, 2.5
-ARG VARIANT=2
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 # Install Sinatra

--- a/containers/ruby-sinatra/.devcontainer/devcontainer.json
+++ b/containers/ruby-sinatra/.devcontainer/devcontainer.json
@@ -3,8 +3,10 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 2, 2.7, 2.6, 2.5
-			"VARIANT": "2",
+			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local on arm64/Apple Silicon.
+			"VARIANT": "2-bullseye",
 			"NODE_VERSION": "lts/*"
 		}
 	},

--- a/containers/ruby-sinatra/README.md
+++ b/containers/ruby-sinatra/README.md
@@ -10,15 +10,18 @@
 | *Categories* | Community, Frameworks |
 | *Definition type* | Dockerfile |
 | *Works in Codespaces* | Yes |
+| *Available image variants* | [See Ruby definition](../ruby). |
+| *Supported architecture(s)* | x86-64, arm64/aarch64 for `bullseye` based images |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
 | *Languages, platforms* | Ruby |
 
 ## Using this definition
 
-While this definition should work unmodified, you can select the version of Ruby the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
+While this definition should work unmodified, you can select [an available version Ruby](../ruby) the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
+// Or you can use 2.7-bullseye or 2.7-buster if you want to pin to an OS version
 "args": { "VARIANT": "2.7" }
 ```
 

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version: 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=2-bullseye
 FROM ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"args": { 
 			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
 			// Append -bullseye or -buster to pin to an OS version.
-			// Use the -bullseye variants if you are on a M1 mac.
+			// Use -bullseye variants on local on arm64/Apple Silicon.
 			"VARIANT": "3-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"

--- a/containers/rust/.devcontainer/Dockerfile
+++ b/containers/rust/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian OS version (use bullseye for arm64/Apple Silicon): buster, bullseye
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
 ARG VARIANT="buster"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:1-${VARAINT}
 

--- a/containers/rust/.devcontainer/Dockerfile
+++ b/containers/rust/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
-ARG VARIANT="buster"
+ARG VARIANT="bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:1-${VARAINT}
 
 # [Optional] Uncomment this section to install additional packages.

--- a/containers/rust/.devcontainer/base.Dockerfile
+++ b/containers/rust/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
-ARG VARIANT="buster"
+ARG VARIANT="bullseye"
 FROM rust:1-${VARIANT}
 
 # [Option] Install zsh

--- a/containers/rust/.devcontainer/base.Dockerfile
+++ b/containers/rust/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian OS version (use bullseye for arm64/Apple Silicon): buster, bullseye
+# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
 ARG VARIANT="buster"
 FROM rust:1-${VARIANT}
 

--- a/containers/rust/.devcontainer/devcontainer.json
+++ b/containers/rust/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
-			// Use bullseye when running locally on arm64/Apple Silicon.
+			// Use bullseye when on local on arm64/Apple Silicon.
 			"VARIANT": "buster"
 		}
 	},

--- a/containers/swift/README.md
+++ b/containers/swift/README.md
@@ -9,6 +9,7 @@
 | *Contributors* | [cloudnull](https://github.com/cloudnull) |
 | *Categories* | Community, Languages |
 | *Definition type* | Dockerfile |
+| *Supported architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |

--- a/containers/typescript-node/.devcontainer/Dockerfile
+++ b/containers/typescript-node/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Node.js version: 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
 ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:${VARIANT}
 

--- a/containers/typescript-node/.devcontainer/base.Dockerfile
+++ b/containers/typescript-node/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Node.js version: 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 16, 14, 12, 16-bullseye, 14-bullseye, 12-bullseye, 16-buster, 14-buster, 12-buster
 ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
@@ -15,7 +15,3 @@ RUN su node -c "umask 0002 && npm install -g ${NODE_MODULES}" \
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10
 # RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
-
-
-
-

--- a/containers/typescript-node/.devcontainer/devcontainer.json
+++ b/containers/typescript-node/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick a Node version: 16, 14, 12.
 		// Append -bullseye or -buster to pin to an OS version.
-		// Use the -bullseye variants if you are on a M1 mac.
+		// Use -bullseye variants on local on arm64/Apple Silicon.
 		"args": { 
 			"VARIANT": "16-bullseye"
 		}

--- a/containers/ubuntu/.devcontainer/Dockerfile
+++ b/containers/ubuntu/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ubuntu version: hirsute, bionic, focal
+# [Choice] Ubuntu version (use hirsuite or bionic on local arm64/Apple Silicon): hirsute, focal, bionic
 ARG VARIANT=focal
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 

--- a/containers/ubuntu/.devcontainer/base.Dockerfile
+++ b/containers/ubuntu/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# Update the VARIANT arg in devcontainer.json to pick an Ubuntu version: hirsute, focal, bionic
+# [Choice] Ubuntu version (use hirsuite or bionic on local arm64/Apple Silicon): hirsute, focal, bionic
 ARG VARIANT="focal"
 FROM buildpack-deps:${VARIANT}-curl
 

--- a/containers/ubuntu/.devcontainer/devcontainer.json
+++ b/containers/ubuntu/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
+		// Use hirsute or bionic on local arm64/Apple Silicon.
 		"args": { "VARIANT": "focal" }
 	},
 


### PR DESCRIPTION
This PR is related to #558 and covers the fact that bullseye variants are available for key compose based definitions.

It also:
1. Removes the UID/GID sync'ing code since this is no longer required
2. Adds needded comments to get the VS Code selection UX to present [Choice] and [Options] now that theres are supported for compose as well
3. Corrects some READMEs
4. Pins the deno definition to x86 since there's no ARM64 binaries available yet