### PR TITLE
Add option to install node-gyp dependencies in Node script

### DIFF
--- a/script-library/docs/node.md
+++ b/script-library/docs/node.md
@@ -11,7 +11,7 @@
 ## Syntax
 
 ```text
-./node-debian.sh [Location to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]
+./node-debian.sh [Location to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag] [Install node-gyp deps flag]
 ```
 
 |Argument|Default|Description|
@@ -20,6 +20,7 @@
 |Node version to install|`lts/*`| Node.js version to install. Use `none` to skip installing anything and just install nvm and yarn. |
 |Non-root user|`automatic`| Specifies a user in the container other than root that will use Node.js. A value of `automatic` will cause the script to check for a user called `vscode`, then `node`, `codespace`, and finally a user with a UID of `1000` before falling back to `root`. |
 | Add to rc files flag | `true` | A `true`/`false` flag that indicates whether sourcing the nvm script should be added to `/etc/bash.bashrc` and `/etc/zsh/zshrc`. |
+| Install node-gyp deps flag | `true` | A `true`/`false` flag that indicates whether the script should check for key requirements for node-gyp (python, make, gcc) and install them if missing. |
 
 ## Usage
 

--- a/script-library/node-debian.sh
+++ b/script-library/node-debian.sh
@@ -146,9 +146,17 @@ if [ "${INSTALL_TOOLS_FOR_NODE_GYP}" = "true" ]; then
         apt_get_update_if_needed
         apt-get -y install --no-install-recommends build-essential
     fi
+    if ! type python3 > /dev/null 2>&1; then
+        apt_get_update_if_needed
+        apt-get -y install --no-install-recommends python3-minimal
+    fi
+    # Debian bullseye does not have the "python" command by default since it doesn't include python2.
+    # This can cause errors when using node-gyp, so alias python to python3 in this case to avoid it.
     if ! type python > /dev/null 2>&1; then
         apt_get_update_if_needed
-        apt-get -y install --no-install-recommends python-is-python3
+        if [ ! -z "$(apt-cache --names-only search ^python-is-python3$)" ]; then
+            apt-get -y install --no-install-recommends python-is-python3
+        fi
     fi
 fi
 

--- a/script-library/node-debian.sh
+++ b/script-library/node-debian.sh
@@ -139,24 +139,25 @@ EOF
 )"
 fi
 
-# If enabled, verify "python", "make" commands are available so node-gyp works (e.g. in bullseye it is not)
+# If enabled, verify "python3", "make", "gcc", "g++" commands are available so node-gyp works - https://github.com/nodejs/node-gyp
 if [ "${INSTALL_TOOLS_FOR_NODE_GYP}" = "true" ]; then
     echo "Verifying node-gyp OS requirements..."
-    if ! type make > /dev/null 2>&1 || ! type gcc > /dev/null 2>&1; then
-        apt_get_update_if_needed
-        apt-get -y install --no-install-recommends build-essential
+    to_install=""
+    if ! type make > /dev/null 2>&1; then
+        to_install="${to_install} make"
+    fi
+    if ! type gcc > /dev/null 2>&1; then
+        to_install="${to_install} gcc"
+    fi
+    if ! type g++ > /dev/null 2>&1; then
+        to_install="${to_install} g++"
     fi
     if ! type python3 > /dev/null 2>&1; then
-        apt_get_update_if_needed
-        apt-get -y install --no-install-recommends python3-minimal
+        to_install="${to_install} python3-minimal"
     fi
-    # Debian bullseye does not have the "python" command by default since it doesn't include python2.
-    # This can cause errors when using node-gyp, so alias python to python3 in this case to avoid it.
-    if ! type python > /dev/null 2>&1; then
+    if [ ! -z "${to_install}" ]; then
         apt_get_update_if_needed
-        if [ ! -z "$(apt-cache --names-only search ^python-is-python3$)" ]; then
-            apt-get -y install --no-install-recommends python-is-python3
-        fi
+        apt-get -y install ${to_install}
     fi
 fi
 

--- a/script-library/node-debian.sh
+++ b/script-library/node-debian.sh
@@ -7,12 +7,13 @@
 # Docs: https://github.com/microsoft/vscode-dev-containers/blob/main/script-library/docs/node.md
 # Maintainer: The VS Code and Codespaces Teams
 #
-# Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag]
+# Syntax: ./node-debian.sh [directory to install nvm] [node version to install (use "none" to skip)] [non-root user] [Update rc files flag] [install node-gyp deps]
 
 export NVM_DIR=${1:-"/usr/local/share/nvm"}
 export NODE_VERSION=${2:-"lts"}
 USERNAME=${3:-"automatic"}
 UPDATE_RC=${4:-"true"}
+INSTALL_TOOLS_FOR_NODE_GYP="${5:-true}"
 export NVM_VERSION="0.38.0"
 
 set -e
@@ -136,6 +137,19 @@ export NVM_DIR="${NVM_DIR}"
 [ -s "\$NVM_DIR/bash_completion" ] && . "\$NVM_DIR/bash_completion"
 EOF
 )"
-fi 
+fi
+
+# If enabled, verify "python", "make" commands are available so node-gyp works (e.g. in bullseye it is not)
+if [ "${INSTALL_TOOLS_FOR_NODE_GYP}" = "true" ]; then
+    echo "Verifying node-gyp OS requirements..."
+    if ! type make > /dev/null 2>&1 || ! type gcc > /dev/null 2>&1; then
+        apt_get_update_if_needed
+        apt-get -y install --no-install-recommends build-essential
+    fi
+    if ! type python > /dev/null 2>&1; then
+        apt_get_update_if_needed
+        apt-get -y install --no-install-recommends python-is-python3
+    fi
+fi
 
 echo "Done!"


### PR DESCRIPTION
Currently it is possible to install node with the library script in such a way that needed commands for installing packages that use node-gyp are not present. This update defaults to checking for the presence of python, make, and gcc and installs them if they are missing.