### PR TITLE
[R] install packages from GitHub without using GitHub API

### DIFF
--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -32,8 +32,10 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         httpgd \
     && rm -rf /tmp/downloaded_packages
 
-# VSCode R Debugger dependency, install the latest release version from GitHub.
-RUN Rscript -e 'remotes::install_github("ManuelHentschel/vscDebugger@*release", dependencies = FALSE)'
+# VSCode R Debugger dependency. Install the latest release version from GitHub without using GitHub API.
+# See https://github.com/microsoft/vscode-dev-containers/issues/1032
+RUN export TAG=$(git ls-remote --tags --refs --sort='version:refname' https://github.com/ManuelHentschel/vscDebugger v\* | tail -n 1 | cut --delimiter='/' --fields=3) \
+    && Rscript -e "remotes::install_git('https://github.com/ManuelHentschel/vscDebugger.git', ref = '"${TAG}"', dependencies = FALSE)"
 
 # R Session watcher settings.
 # See more details: https://github.com/REditorSupport/vscode-R/wiki/R-Session-watcher


### PR DESCRIPTION
Fix #1032

Since The `remotes::install_github` function uses the GitHub API, the build will fail at the end of the build in an environment where the GitHub API cannot be used.
Switch to an installation method that does not use the GitHub API to reduce the chance of a build failure.

After building this Dockerfile, I checked the number of `resources.core.remaining` with the following command, and confirmed that the GitHub API was not used.

```shell
curl \
  -H "Accept: application/vnd.github.v3+json" \
  https://api.github.com/rate_limit
```

https://docs.github.com/en/rest/reference/rate-limit

cc @kmehant