### PR TITLE
Make VNC work with Python 3.9

### DIFF
--- a/script-library/desktop-lite-debian.sh
+++ b/script-library/desktop-lite-debian.sh
@@ -14,7 +14,7 @@ VNC_PASSWORD=${2:-"vscode"}
 INSTALL_NOVNC=${3:-"true"}
 
 NOVNC_VERSION=1.2.0
-WEBSOCKETIFY_VERSION=0.9.0
+WEBSOCKETIFY_VERSION=0.10.0
 
 package_list="
     tigervnc-standalone-server \


### PR DESCRIPTION
* update WEBSOCKETIFY to version 0.10.0 to make it work with Python 3.9
* version 0.9.0 resulted in error "handler exception: 'array.array' object has no attribute 'fromstring'
* upstream fix: https://github.com/novnc/websockify/issues/473