### PR TITLE
Provide VNC env variables in Dockerfile example

### DIFF
--- a/script-library/docs/desktop-lite.md
+++ b/script-library/docs/desktop-lite.md
@@ -31,7 +31,14 @@
     ```Dockerfile
     COPY library-scripts/desktop-lite-debian.sh /tmp/library-scripts/
     RUN apt-get update && bash /tmp/library-scripts/desktop-lite-debian.sh
-    ENV DBUS_SESSION_BUS_ADDRESS="autolaunch:" DISPLAY=":1" LANG="en_US.UTF-8" LANGUAGE="en_US.UTF-8"
+    ENV DBUS_SESSION_BUS_ADDRESS="autolaunch:" \
+        VNC_RESOLUTION="1440x768x16" \
+        VNC_DPI="96" \
+        VNC_PORT="5901" \
+        NOVNC_PORT="6080" \
+        DISPLAY=":1" \
+        LANG="en_US.UTF-8" \
+        LANGUAGE="en_US.UTF-8"
     ENTRYPOINT ["/usr/local/share/desktop-init.sh"]
     CMD ["sleep", "infinity"]
     ```


### PR DESCRIPTION
* without setting VNC_RESOLUTION env variable, tigervnc will not start up
* copied values from repository-containers/images/github.com/microsoft/vscode/.devcontainer/base.Dockerfile