### PR TITLE
Bump versions to pick up security fixes for 1.61 release

### DIFF
--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "1.6.5",
+	"definitionVersion": "1.6.6",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/cpp/definition-manifest.json
+++ b/containers/cpp/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["bullseye", "buster", "hirsute", "focal", "bionic", "stretch"],
-	"definitionVersion": "0.203.0",
+	"definitionVersion": "0.203.1",
 	"build": {
 		"latest": "bullseye",
 		"parent": {

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["hirsute", "focal", "bionic"],
-	"definitionVersion": "0.202.0",
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",


### PR DESCRIPTION
The C++, base, and universal image versions need  to be bumped up to pick up the following recently reported OS security updates:

- Ubuntu Security Notification for curl Vulnerabilities (USN-5079-1)
- Ubuntu Security Notification for Git Vulnerability (USN-5076-1)
- Ubuntu Security Notification for GNU cpio Vulnerability (USN-5064-1)
