### PR TITLE
Pre-build arm64 image for Alpine base once 1.61 is in stable

### DIFF
--- a/containers/alpine/.devcontainer/devcontainer.json
+++ b/containers/alpine/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Alpine version: 3.11, 3.12, 3.13, 3.14
-		"args": { "VARIANT": "3.13" }
+		"args": { "VARIANT": "3.14" }
 	},
 	
 	// Set *default* container specific settings.json values on container create. 

--- a/containers/alpine/README.md
+++ b/containers/alpine/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Other |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/base:alpine |
-| *Available image variants* | 3.11, 3.12, 3.13, 3.14 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Available image variants* | 3.14, 3.13, 3.12, 3.11 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Alpine Linux |
@@ -24,7 +24,7 @@ See **[history](history)** for information on the contents of published images.
  While the definition itself works unmodified, you can select the version of Alpine the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "3.12" }
+"args": { "VARIANT": "3.13" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.

--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,15 +1,16 @@
 {
 	"variants": ["3.14", "3.13", "3.12", "3.11"],
-	"definitionVersion": "0.202.2",
+	"definitionVersion": "0.203.0",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",
+		"architectures": ["linux/amd64","linux/arm64"],
 		"tags": [
 			"base:${VERSION}-alpine-${VARIANT}",
 			"base:${VERSION}-alpine${VARIANT}"
 		],
 		"variantTags": {
-			"3.13": [
+			"3.14": [
 				"base:${VERSION}-alpine"
 			]
 		}


### PR DESCRIPTION
The 1.61 release of VS Code includes support for an Alpine arm64 remote. We can start pre-building arm64 image for Alpine at this point. (Implements #1067)