### PR TITLE
Update Docker in Docker documentation

### DIFF
--- a/script-library/docs/docker-in-docker.md
+++ b/script-library/docs/docker-in-docker.md
@@ -28,7 +28,7 @@
 
 See the [`docker-in-docker`](../../containers/docker-in-docker) definition for a complete working example. However, here are the general steps to use the script:
 
-1. Add [`docker-debian.sh`](../docker-debian.sh) to `.devcontainer/library-scripts`
+1. Add [`docker-debian.sh`](../docker-debian.sh) to `.devcontainer/library-scripts`. Make this file executable: `chmod +x .devcontainer/library-scripts/docker-debian.sh`
 
 2. Add the following to your `.devcontainer/Dockerfile`:
 

--- a/script-library/docs/docker-in-docker.md
+++ b/script-library/docs/docker-in-docker.md
@@ -33,9 +33,9 @@ See the [`docker-in-docker`](../../containers/docker-in-docker) definition for a
 2. Add the following to your `.devcontainer/Dockerfile`:
 
     ```Dockerfile
-    COPY library-scripts/*.sh /tmp/library-scripts/
+    COPY .devcontainer/library-scripts/docker-debian.sh /tmp/library-scripts/
     ENV DOCKER_BUILDKIT=1
-    RUN apt-get update && /bin/bash /tmp/library-scripts/docker-in-docker-debian.sh
+    RUN apt-get update && /bin/bash /tmp/library-scripts/docker-debian.sh
     ENTRYPOINT ["/usr/local/share/docker-init.sh"]
     VOLUME [ "/var/lib/docker" ]
     CMD ["sleep", "infinity"]


### PR DESCRIPTION
@gwincr11 and I worked through this documentation today to add it to our project.  We had a few suggestions for improvements:

- Add a note about making the new file `docker-debian.sh` executable.
- In the Dockerfile, update the filepath for the copy command.
  - Add the `.devcontainer` prefix
  - Specify the `docker-debian.sh` file instead of using *
- Update the filename in the run command to `docker-debian.sh` to match the new file.
