### PR TITLE
Update docker-in-debian.sh for Docker compose v2

### DIFF
--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -114,11 +114,11 @@ echo "Finished installing docker / moby"
 if type docker-compose > /dev/null 2>&1; then
     echo "Docker Compose already installed."
 else
-    target_compose_arch="${architecture}"
-    if [ "${target_compose_arch}" = "amd64" ]; then
-        target_compose_arch="x86_64"
+    target_compose_arch="${architecture}"    
+    if [ "${target_compose_arch}" = "x86_64" ]; then
+        target_compose_arch="amd64"
     fi
-    if [ "${target_compose_arch}" != "x86_64" ]; then
+    if [ "${target_compose_arch}" != "amd64" ]; then
         # Use pip to get a version that runns on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed


### PR DESCRIPTION
Starting with Docker Compose v2, x86_64 suffixed builds have been replaced with AMD64.  Updating the logic to find the right package.