### PR TITLE
Add vscode-remote-try-shellscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If you want to try a sample project which already has a dev container, check out
 - [Rust Sample](https://github.com/microsoft/vscode-remote-try-rust)
 - [C++ Sample](https://github.com/microsoft/vscode-remote-try-cpp)
 - [PHP Sample](https://github.com/microsoft/vscode-remote-try-php)
+- [Shell Script Sample](https://github.com/microsoft/vscode-remote-try-shellscript)
 
 ## Contents
 


### PR DESCRIPTION
Here is a Try Out Bash Shell Script project. 

https://github.com/zcsizmadia/vscode-remote-try-shellscript

The .devcontainer enables bash shell script:

- Running
- Debugging
- Intellisense
- Code snippets

READMD.md points to the  expected  final Github location, however the example itself is still at https://github.com/zcsizmadia/vscode-remote-try-shellscript. I am not sure what the process is to create a PR for a new repository.
