### PR TITLE
Python 3.10 and .NET 6.0

### DIFF
--- a/containers/dotnet-mssql/.devcontainer/Dockerfile
+++ b/containers/dotnet-mssql/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] .NET Core version: 5.0, 3.1, 2.1
-ARG VARIANT=3.1
+# [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
+ARG VARIANT=5.0-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/containers/dotnet-mssql/.devcontainer/docker-compose.yml
+++ b/containers/dotnet-mssql/.devcontainer/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
-        VARIANT: 5.0
+        # [Choice] Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0, 6.0-bullseye, 6.0-buster
+        VARIANT: 5.0-bullseye
         # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
         NODE_VERSION: "lts/*"
         # [Option] Install Azure CLI

--- a/containers/dotnet-mssql/README.md
+++ b/containers/dotnet-mssql/README.md
@@ -10,10 +10,10 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Docker Compose |
 | *Published image architecture(s)* | x86-64 |
-| *Available image variants* | 2.1, 3.1, 5.0 |
+| *Available image variants* | [See .NET definition](../dotnet). |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
-| *Container OS* | Ubuntu |
+| *Container OS* | Ubuntu (.NET 3.1-6.0), Debian (.NET 6.0 default) |
 | *Languages, platforms* | .NET, .NET Core, C#, Microsoft SQL |
 
 ## Description

--- a/containers/dotnet/.devcontainer/Dockerfile
+++ b/containers/dotnet/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] .NET version: 5.0, 3.1, 2.1
-ARG VARIANT=3.1
+# [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
+ARG VARIANT=5.0-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/containers/dotnet/.devcontainer/base.Dockerfile
+++ b/containers/dotnet/.devcontainer/base.Dockerfile
@@ -1,6 +1,6 @@
-# [Choice] .NET version: 5.0, 3.1, 2.1
-ARG VARIANT="3.1"
-FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}-focal
+# [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 
+ARG VARIANT="5.0-bullseye"
+FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 
 # Copy library scripts to execute
 COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/

--- a/containers/dotnet/.devcontainer/devcontainer.json
+++ b/containers/dotnet/.devcontainer/devcontainer.json
@@ -4,8 +4,9 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a .NET Core version: 2.1, 3.1, 5.0
-			"VARIANT": "5.0",
+			// Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
+			// Append -bullseye or -buster to pin to an OS version.
+			"VARIANT": "5.0-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*",
 			"INSTALL_AZURE_CLI": "false"

--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -9,12 +9,12 @@
 | *Contributors* | The VS Code Team |
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
-| *Published images* | mcr.microsoft.com/vscode/devcontainers/dotnet <br/> mcr.microsoft.com/vscode/devcontainers/dotnetcore |
-| *Available image variants* | 2.1, 3.1, 5.0 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list)) |
+| *Published images* | mcr.microsoft.com/vscode/devcontainers/dotnet |
+| *Available image variants* | 3.1 / 3.1-focal, 5.0 / 5.0-focal, 6.0 /6.0-bullseye, 6.0-focal, 5.0-bullseye, 3.1-bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list)) |
 | *Published image architecture(s)* | x86-64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
-| *Container OS* | Ubuntu |
+| *Container OS* | Ubuntu (`-focal`), Debian (`-bullseye`) |
 | *Languages, platforms* | .NET, .NET Core, C# |
 
 See **[history](history)** for information on the contents of published images.
@@ -24,21 +24,24 @@ See **[history](history)** for information on the contents of published images.
 While this definition should work unmodified, you can select the version of .NET / .NET Core the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
+// Or you can use 3.1-bullseye or 3.1-focal if you want to pin to an OS version
 "args": { "VARIANT": "3.1" }
 ```
+
+Note that .NET 6.0 has switched its default OS to Debian 12 / bullseye. We also offer a `6.0-focal` image if you would prefer to use Ubuntu 20.04 / Focal.
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/vscode/devcontainers/dotnet` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:2.1` (or `dotnetcore:2.1`)
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:3.1` (or `dotnetcore:3.1`)
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:5.0`
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:3.1` (or `3.1-bullseye`, `3.1-focal` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:5.0` (or `5.0-bullseye`, `5.0-focal` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:6.0` (or `6.0-bullseye`, `6.0-focal` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/dotnet:0-3.1`
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.201-3.1`
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.201.6-3.1`
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.203-3.1`
+- `mcr.microsoft.com/vscode/devcontainers/dotnet:0.203.0-3.1`
 
 See [history](history) for information on the contents of each version and [here for a complete list of available tags](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list).
 

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -1,16 +1,36 @@
 {
-	"variants": ["5.0", "3.1", "2.1"],
-	"definitionVersion": "0.201.10",
+	"variants": ["6.0-bullseye-slim", "6.0-focal", "5.0-bullseye-slim", "5.0-focal", "3.1-bullseye", "3.1-focal"],
+	"definitionVersion": "0.201.11",
 	"build": {
-		"latest": true,
+		"latest": "5.0-focal",
 		"rootDistro": "debian",
 		"tags": [
-			"dotnet:${VERSION}-${VARIANT}",
-			"dotnetcore:${VERSION}-${VARIANT}"
-		]
+			"dotnet:${VERSION}-${VARIANT}"
+		],
+		"variantTags": {
+			"6.0-bullseye-slim": [
+				"dotnet:${VERSION}-6.0",
+				"dotnet:${VERSION}-6.0-bullseye"
+			],
+			"5.0-focal": [ 
+				"dotnet:${VERSION}-5.0",
+				"dotnetcore:${VERSION}-5.0"
+			],
+			"5.0-bullseye-slim": [ 
+				"dotnet:${VERSION}-5.0-bullseye",
+				"dotnetcore:${VERSION}-5.0-bullseye"
+			],
+			"3.1-focal": [ 
+				"dotnet:${VERSION}-3.1",
+				"dotnetcore:${VERSION}-3.1"
+			],
+			"3.1-bullseye": [
+				"dotnetcore:${VERSION}-3.1-bullseye"
+			]
+		}
 	},
 	"dependencies": {
-		"image": "mcr.microsoft.com/dotnet/sdk:${VARIANT}-focal",
+		"image": "mcr.microsoft.com/dotnet/sdk:${VARIANT}",
 		"imageLink": "https://hub.docker.com/_/microsoft-dotnet-sdk",
 		"apt": [{
 			"cgIgnore": false,

--- a/containers/python-3-postgres/.devcontainer/Dockerfile
+++ b/containers/python-3-postgres/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
 ARG VARIANT=3-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 

--- a/containers/python-3-postgres/.devcontainer/docker-compose.yml
+++ b/containers/python-3-postgres/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        # Update 'VARIANT' to pick a version of Python: 3, 3.9, 3.8, 3.7, 3.6
+        # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: 3-bullseye

--- a/containers/python-3-postgres/README.md
+++ b/containers/python-3-postgres/README.md
@@ -27,7 +27,7 @@ build:
   context: ..
   dockerfile: .devcontainer/Dockerfile
   args:
-    # Update 'VARIANT' to pick a version of Python: 3, 3.9, 3.8, 3.7, 3.6
+    # Update 'VARIANT' to pick a version of Python: 3, 3.10, 3.9, 3.8, 3.7, 3.6
     # Append -bullseye or -buster to pin to an OS version.
     # Use -bullseye variants on local arm64/Apple Silicon.
     VARIANT: 3.7-bullseye

--- a/containers/python-3/.devcontainer/Dockerfile
+++ b/containers/python-3/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
 ARG VARIANT=3-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/python:${VARIANT}
 

--- a/containers/python-3/.devcontainer/base.Dockerfile
+++ b/containers/python-3/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
 ARG VARIANT=3-bullseye
 FROM python:${VARIANT}
 

--- a/containers/python-3/.devcontainer/devcontainer.json
+++ b/containers/python-3/.devcontainer/devcontainer.json
@@ -5,10 +5,10 @@
 		"dockerfile": "Dockerfile",
 		"context": "..",
 		"args": { 
-			// Update 'VARIANT' to pick a Python version: 3, 3.9, 3.8, 3.7, 3.6.
+			// Update 'VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3-bullseye",
+			"VARIANT": "3.10-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/containers/python-3/README.md
+++ b/containers/python-3/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published image* | mcr.microsoft.com/vscode/devcontainers/python |
-| *Available image variants* | 3 / 3-bullseye, 3.6 / 3.6-bullseye, 3.7 / 3.7-bullseye, 3.8 / 3.8-bullseye, 3.9 / 3.9-bullseye, 3-buster, 3.6-buster, 3.7-buster, 3.8-buster, 3.9-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list)) |
+| *Available image variants* | 3 / 3-bullseye, 3.6 / 3.6-bullseye, 3.7 / 3.7-bullseye, 3.8 / 3.8-bullseye, 3.9 / 3.9-bullseye, 3.10 / 3.10-bullseye, 3-buster, 3.6-buster, 3.7-buster, 3.8-buster, 3.9-buster, 3.10-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/python/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container Host OS Support* | Linux, macOS, Windows |
@@ -37,6 +37,7 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/python:3.7` (or `3.7-bullseye`, `3.7-buster` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/python:3.8` (or `3.8-bullseye`, `3.8-buster` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/python:3.9` (or `3.9-bullseye`, `3.9-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/python:3.10` (or `3.10-bullseye`, `3.10-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,14 +1,16 @@
 {
-	"variants": ["3.9-bullseye", "3.8-bullseye", "3.7-bullseye", "3.6-bullseye", "3.6-buster", "3.9-buster", "3.8-buster", "3.7-buster", "3.6-buster"],
-	"definitionVersion": "0.202.1",
+	"variants": ["3.10-bullseye", "3.9-bullseye", "3.8-bullseye", "3.7-bullseye", "3.6-bullseye", "3.10-buster", "3.9-buster", "3.8-buster", "3.7-buster", "3.6-buster"],
+	"definitionVersion": "0.203.0",
 	"build": {
-		"latest": "3.9-bullseye",
+		"latest": "3.10-bullseye",
 		"rootDistro": "debian",
 		"architectures": {
+			"3.10-bullseye": ["linux/amd64", "linux/arm64"],
 			"3.9-bullseye": ["linux/amd64", "linux/arm64"],
 			"3.8-bullseye": ["linux/amd64", "linux/arm64"],
 			"3.7-bullseye": ["linux/amd64", "linux/arm64"],
 			"3.6-bullseye": ["linux/amd64", "linux/arm64"],
+			"3.10-buster": ["linux/arm64"],
 			"3.9-buster": ["linux/amd64"],
 			"3.8-buster": ["linux/amd64"],
 			"3.7-buster": ["linux/amd64"],
@@ -18,16 +20,17 @@
 			"python:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"3.9-bullseye": [ 
-				"python:${VERSION}-3.9",
+			"3.10-bullseye": [ 
+				"python:${VERSION}-3.10",
 				"python:${VERSION}-3",
 				"python:${VERSION}-3-bullseye",
 				"python:${VERSION}-bullseye"
-			], 
+			],
+			"3.9-bullseye": [ "python:${VERSION}-3.9" ], 
 			"3.8-bullseye": [ "python:${VERSION}-3.8" ],
 			"3.7-bullseye": [ "python:${VERSION}-3.7" ],
 			"3.6-bullseye": [ "python:${VERSION}-3.6" ],
-			"3.9-buster": [ 
+			"3.10-buster": [ 
 				"python:${VERSION}-3-buster",
 				"python:${VERSION}-buster"
 			]


### PR DESCRIPTION
This PR implements #1104 and #1070.    We need to do a release for #1106, so it made sense to pick up these tweaks.

.NET 6.0 should be released soon, so this queues up a 6.0 variant for our image. They're switching the default from Ubuntu to bullseye, so this requires a bit more work to get up and running because of it since we'll need to start generating `-focal` and `-bullseye` variants.  This also deprecates 2.1 since it's EOL. 

However, it keeps `latest` at 5.0 since 6.0 is not GA. I left this as a "break fix" update since existing images and latest are unaffected. We can bump up the feature version when 6.0 GAs.

Python 3.10 is just a version addition.  3.6 is EOL in Dec so we'll have a temporary increase in the number of variations we build.