### PR TITLE
Add support for arm architecture for MacOS on M1

### DIFF
--- a/containers/docker-from-docker-compose/README.md
+++ b/containers/docker-from-docker-compose/README.md
@@ -51,7 +51,7 @@ You can adapt your own existing development container Dockerfile to support this
     RUN apt-get update \
         && apt-get install -y apt-transport-https ca-certificates curl gnupg2 lsb-release \
         && curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/gpg | apt-key add - 2>/dev/null \
-        && echo "deb [arch=$(uname -m | sed 's/aarch64/arm64/i')] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list \
+        && echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/$(lsb_release -is | tr '[:upper:]' '[:lower:]') $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list \
         && apt-get update \
         && apt-get install -y docker-ce-cli
 


### PR DESCRIPTION
amd64 is hard to sport when you are coping the lines to your own Dockerfile in haste to get the docker-from-docker working. 

`uname -m` returns `aarch64` but debian needs it as `arm64` hence sed