### PR TITLE
Update Swift versions to include 5.5 & 5.4

### DIFF
--- a/containers/swift/.devcontainer/Dockerfile
+++ b/containers/swift/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Swift version: 5.3, 5.2, 5.1, 4.2
-ARG VARIANT=5.3
+# [Choice] Swift version: 5.5, 5.4, 5.3, 5.2, 5.1, 4.2
+ARG VARIANT=5.5
 FROM swift:${VARIANT}
 
 # [Option] Install zsh

--- a/containers/swift/.devcontainer/devcontainer.json
+++ b/containers/swift/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a Swift version 
-			"VARIANT": "5.3",
+			"VARIANT": "5.5",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}


### PR DESCRIPTION
Quick PR to add Swift 5.5 & 5.4 to the swift .devcontainer

Latest Docker hub links
- 5.5: https://hub.docker.com/layers/swift/library/swift/5.5/images/sha256-a59cc74a241f79280c3401fce46b985965ff4f740c6e64e2df744c7233ebaa2c?context=explore
- 5.4: https://hub.docker.com/layers/swift/library/swift/5.4/images/sha256-059a2a9249f6a6d6fa938a98b021448ef9700468f145529624d236bdb85f4fbc?context=explore