### PR TITLE
Fix a bug where `code` in `fish` was incorrectly mapped to `code-insiders`

### DIFF
--- a/containers/codespaces-linux/.devcontainer/setup-user.sh
+++ b/containers/codespaces-linux/.devcontainer/setup-user.sh
@@ -9,7 +9,7 @@ echo "Defaults secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/
 apt-get install -yq fish
 FISH_PROMPT="function fish_prompt\n    set_color green\n    echo -n (whoami)\n    set_color normal\n    echo -n \":\"\n    set_color blue\n    echo -n (pwd)\n    set_color normal\n    echo -n \"> \"\nend\n"
 printf "$FISH_PROMPT" >> /etc/fish/functions/fish_prompt.fish
-printf "if type code-insiders > /dev/null 2>&1 and ! type code > /dev/null 2>&1\n  alias code=code-insiders\nend" >> /etc/fish/conf.d/code_alias.fish
+printf "if type code-insiders > /dev/null 2>&1; and not type code > /dev/null 2>&1\n  alias code=code-insiders\nend" >> /etc/fish/conf.d/code_alias.fish
 
 # Add user to a Docker group
 sudo -u ${USERNAME} mkdir /home/${USERNAME}/.vsonline


### PR DESCRIPTION
In `fish`, `and` requires a semicolon.
https://fishshell.com/docs/current/cmds/and.html

This PR also changes `!` to `not` in order to use https://fishshell.com/docs/current/cmds/not.html instead of relying on https://fishshell.com/docs/3.0/commands.html#test-combinators

--------

The old logic has been causing an issue for me as of yesterday, where an attempt to invoke the `code` command would spew this: 😔

```shell
fish: Unknown command: code-insiders
- (line 1): 
function code --wraps code-insiders --description 'alias code=code-insiders';  code-insiders  $argv; end
```