### PR TITLE
Adding extension to devcontainer for Salesforce Device Code Auth Flow via Command Palette

### DIFF
--- a/containers/sfdx-project/.devcontainer/devcontainer.json
+++ b/containers/sfdx-project/.devcontainer/devcontainer.json
@@ -5,7 +5,8 @@
       "salesforce.salesforcedx-vscode",
       "redhat.vscode-xml",
       "dbaeumer.vscode-eslint",
-      "esbenp.prettier-vscode"
+      "esbenp.prettier-vscode",
+      "gfarb.sfdx-codespaces-auth"
     ],
     "settings": {
       "salesforcedx-vscode-apex.java.home": "/usr/lib/jvm/java-11-openjdk-amd64"


### PR DESCRIPTION
When using GitHub Codespaces in the browser, all authentication flows provided by Salesforce via their Extension Package do not work because of URL callback. This causes confusion, primarily for folks in the Salesforce ecosystem who do not use Salesforce's CLI.

The extension that I have added to .devcontainer was created and open-sourced by me. The extension simply provides a seamless and intuitive way to leverage Salesforce's Device Code auth flow which is the only known way to authenticate with a Salesforce org while using GitHub Codespaces in the browser.

The code can be found [here](https://github.com/gfarb/sfdx-codepsaces-auth). I would understand if this PR can't be merged due to security concerns, but it would make GitHub Codespaces onboarding a lot easier for many people in the Salesforce ecosystem.