### PR TITLE
Update to latest dind script, reduce overhead

### DIFF
--- a/containers/docker-in-docker/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/containers/docker-in-docker/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -244,72 +244,73 @@ fi
 
 tee /usr/local/share/docker-init.sh > /dev/null \
 << 'EOF'
-#!/usr/bin/env bash
+#!/bin/sh
 #-------------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-sudoIf()
-{
-    if [ "$(id -u)" -ne 0 ]; then
-        sudo "$@"
-    else
-        "$@"
+set -e
+
+dockerd_start() {
+    # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
+    # ie: docker kill <ID>
+    find /run /var/run -iname 'docker*.pid' -delete || :
+    find /run /var/run -iname 'container*.pid' -delete || :
+
+    ## Dind wrapper script from docker team, adapted to a function
+    # Maintained: https://github.com/moby/moby/blob/master/hack/dind
+
+    export container=docker
+
+    if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+        mount -t securityfs none /sys/kernel/security || {
+            echo >&2 'Could not mount /sys/kernel/security.'
+            echo >&2 'AppArmor detection and --privileged mode might break.'
+        }
     fi
+
+    # Mount /tmp (conditionally)
+    if ! mountpoint -q /tmp; then
+        mount -t tmpfs none /tmp
+    fi
+
+    # cgroup v2: enable nesting
+    if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+        # move the processes from the root group to the /init group,
+        # otherwise writing subtree_control fails with EBUSY.
+        # An error during moving non-existent process (i.e., "cat") is ignored.
+        mkdir -p /sys/fs/cgroup/init
+        xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+        # enable controllers
+        sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+            > /sys/fs/cgroup/cgroup.subtree_control
+    fi
+    ## Dind wrapper over.
+
+    # Handle DNS
+    set +e
+    cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
+    if [ $? -eq 0 ]
+    then
+        echo "Setting dockerd Azure DNS."
+        CUSTOMDNS="--dns 168.63.129.16"
+    else
+        echo "Not setting dockerd DNS manually."
+        CUSTOMDNS=""
+    fi
+    set -e
+
+    # Start docker/moby engine
+    ( dockerd $CUSTOMDNS > /tmp/dockerd.log 2>&1 ) &
 }
 
-# explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
-# ie: docker kill <ID>
-sudoIf find /run /var/run -iname 'docker*.pid' -delete || :
-sudoIf find /run /var/run -iname 'container*.pid' -delete || :
-
-set -e
-
-## Dind wrapper script from docker team
-# Maintained: https://github.com/moby/moby/blob/master/hack/dind
-
-export container=docker
-
-if [ -d /sys/kernel/security ] && ! sudoIf mountpoint -q /sys/kernel/security; then
-	sudoIf mount -t securityfs none /sys/kernel/security || {
-		echo >&2 'Could not mount /sys/kernel/security.'
-		echo >&2 'AppArmor detection and --privileged mode might break.'
-	}
-fi
-
-# Mount /tmp (conditionally)
-if ! sudoIf mountpoint -q /tmp; then
-	sudoIf mount -t tmpfs none /tmp
-fi
-
-# cgroup v2: enable nesting
-if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
-	# move the init process (PID 1) from the root group to the /init group,
-	# otherwise writing subtree_control fails with EBUSY.
-	sudoIf mkdir -p /sys/fs/cgroup/init
-	sudoIf echo 1 > /sys/fs/cgroup/init/cgroup.procs
-	# enable controllers
-	sudoIf sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
-		> /sys/fs/cgroup/cgroup.subtree_control
-fi
-## Dind wrapper over.
-
-# Handle DNS
-set +e
-cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
-if [ $? -eq 0 ]
-then
-  echo "Setting dockerd Azure DNS."
-  CUSTOMDNS="--dns 168.63.129.16"
+# Start using sudo if not invoked as root
+if [ "$(id -u)" -ne 0 ]; then
+    sudo /bin/sh -c "$(declare -f dockerd_start); dockerd_start"
 else
-  echo "Not setting dockerd DNS manually."
-  CUSTOMDNS=""
+    dockerd_start
 fi
-set -e
-
-# Start docker/moby engine
-( sudoIf dockerd $CUSTOMDNS > /tmp/dockerd.log 2>&1 ) &
 
 set +e
 

--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -244,72 +244,73 @@ fi
 
 tee /usr/local/share/docker-init.sh > /dev/null \
 << 'EOF'
-#!/usr/bin/env bash
+#!/bin/sh
 #-------------------------------------------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-sudoIf()
-{
-    if [ "$(id -u)" -ne 0 ]; then
-        sudo "$@"
-    else
-        "$@"
+set -e
+
+dockerd_start() {
+    # explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
+    # ie: docker kill <ID>
+    find /run /var/run -iname 'docker*.pid' -delete || :
+    find /run /var/run -iname 'container*.pid' -delete || :
+
+    ## Dind wrapper script from docker team, adapted to a function
+    # Maintained: https://github.com/moby/moby/blob/master/hack/dind
+
+    export container=docker
+
+    if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+        mount -t securityfs none /sys/kernel/security || {
+            echo >&2 'Could not mount /sys/kernel/security.'
+            echo >&2 'AppArmor detection and --privileged mode might break.'
+        }
     fi
+
+    # Mount /tmp (conditionally)
+    if ! mountpoint -q /tmp; then
+        mount -t tmpfs none /tmp
+    fi
+
+    # cgroup v2: enable nesting
+    if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+        # move the processes from the root group to the /init group,
+        # otherwise writing subtree_control fails with EBUSY.
+        # An error during moving non-existent process (i.e., "cat") is ignored.
+        mkdir -p /sys/fs/cgroup/init
+        xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :
+        # enable controllers
+        sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
+            > /sys/fs/cgroup/cgroup.subtree_control
+    fi
+    ## Dind wrapper over.
+
+    # Handle DNS
+    set +e
+    cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
+    if [ $? -eq 0 ]
+    then
+        echo "Setting dockerd Azure DNS."
+        CUSTOMDNS="--dns 168.63.129.16"
+    else
+        echo "Not setting dockerd DNS manually."
+        CUSTOMDNS=""
+    fi
+    set -e
+
+    # Start docker/moby engine
+    ( dockerd $CUSTOMDNS > /tmp/dockerd.log 2>&1 ) &
 }
 
-# explicitly remove dockerd and containerd PID file to ensure that it can start properly if it was stopped uncleanly
-# ie: docker kill <ID>
-sudoIf find /run /var/run -iname 'docker*.pid' -delete || :
-sudoIf find /run /var/run -iname 'container*.pid' -delete || :
-
-set -e
-
-## Dind wrapper script from docker team
-# Maintained: https://github.com/moby/moby/blob/master/hack/dind
-
-export container=docker
-
-if [ -d /sys/kernel/security ] && ! sudoIf mountpoint -q /sys/kernel/security; then
-	sudoIf mount -t securityfs none /sys/kernel/security || {
-		echo >&2 'Could not mount /sys/kernel/security.'
-		echo >&2 'AppArmor detection and --privileged mode might break.'
-	}
-fi
-
-# Mount /tmp (conditionally)
-if ! sudoIf mountpoint -q /tmp; then
-	sudoIf mount -t tmpfs none /tmp
-fi
-
-# cgroup v2: enable nesting
-if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
-	# move the init process (PID 1) from the root group to the /init group,
-	# otherwise writing subtree_control fails with EBUSY.
-	sudoIf mkdir -p /sys/fs/cgroup/init
-	sudoIf echo 1 > /sys/fs/cgroup/init/cgroup.procs
-	# enable controllers
-	sudoIf sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers \
-		> /sys/fs/cgroup/cgroup.subtree_control
-fi
-## Dind wrapper over.
-
-# Handle DNS
-set +e
-cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
-if [ $? -eq 0 ]
-then
-  echo "Setting dockerd Azure DNS."
-  CUSTOMDNS="--dns 168.63.129.16"
+# Start using sudo if not invoked as root
+if [ "$(id -u)" -ne 0 ]; then
+    sudo /bin/sh -c "$(declare -f dockerd_start); dockerd_start"
 else
-  echo "Not setting dockerd DNS manually."
-  CUSTOMDNS=""
+    dockerd_start
 fi
-set -e
-
-# Start docker/moby engine
-( sudoIf dockerd $CUSTOMDNS > /tmp/dockerd.log 2>&1 ) &
 
 set +e
 


### PR DESCRIPTION
This PR updates to the latest docker-in-docker script from the github.com/moby/moby (and docker/docker) repo. The script update improves things by moving all processes in the root cgroup to the init cgroup instead of just process 1. Not doing this causes errors in some cases - I stubmled on this when experimenting with using "lima" and "colima" to host Docker, but there are other cases that could happen whenever running directly on Linux as the host.

Given the nature of this update, it also switches from using lots of "sudo" statments when required to one sudo statement that is only fired of the main container user is non-root. It then also switches to /bin/sh to further improve performance given it is lower overhead.