### PR TITLE
Migrate Bazel to Bazelisk version manager

### DIFF
--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:bulleye
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 # Options for setup script
 ARG INSTALL_ZSH="true"
@@ -15,12 +15,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 # Install Bazel
-ARG BAZEL_VERSION=4.2.1
-ARG BAZEL_DOWNLOAD_SHA=dev-mode
-RUN curl -fSsL -o /tmp/bazel-installer.sh https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh \
-    && ([ "${BAZEL_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZEL_DOWNLOAD_SHA} */tmp/bazel-installer.sh" | sha256sum --check - ) \
-    && /bin/bash /tmp/bazel-installer.sh --base=/usr/local/bazel \
-    && rm /tmp/bazel-installer.sh
+ARG BAZELISK_VERSION=v1.10.1
+ARG BAZELISK_DOWNLOAD_SHA=dev-mode
+RUN curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64 \
+    && ([ "${BAZELISK_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check - ) \
+    && chmod 0755 /usr/local/bin/bazelisk
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:buster
+FROM mcr.microsoft.com/vscode/devcontainers/base:bulleye
 
 # Options for setup script
 ARG INSTALL_ZSH="true"
@@ -15,7 +15,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 # Install Bazel
-ARG BAZEL_VERSION=3.4.1
+ARG BAZEL_VERSION=4.2.1
 ARG BAZEL_DOWNLOAD_SHA=dev-mode
 RUN curl -fSsL -o /tmp/bazel-installer.sh https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh \
     && ([ "${BAZEL_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZEL_DOWNLOAD_SHA} */tmp/bazel-installer.sh" | sha256sum --check - ) \

--- a/containers/bazel/.devcontainer/devcontainer.json
+++ b/containers/bazel/.devcontainer/devcontainer.json
@@ -3,28 +3,22 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"BAZEL_VERSION": "3.4.1",
+			"BAZEL_VERSION": "4.2.1",
 			"BAZEL_DOWNLOAD_SHA": "9808adad931ac652e8ff5022a74507c532250c2091d21d6aebc7064573669cc5"
 		}
 	},
-
 	// Set *default* container specific settings.json values on container create.
 	"settings": {},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"devondcarew.bazel-code"
 	],
-
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
-
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
-
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/bazel/.devcontainer/devcontainer.json
+++ b/containers/bazel/.devcontainer/devcontainer.json
@@ -3,8 +3,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"BAZEL_VERSION": "4.2.1",
-			"BAZEL_DOWNLOAD_SHA": "9808adad931ac652e8ff5022a74507c532250c2091d21d6aebc7064573669cc5"
+			"BAZELISK_VERSION": "v1.10.1",
+			"BAZELISK_DOWNLOAD_SHA": "4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd"
 		}
 	},
 	// Set *default* container specific settings.json values on container create.

--- a/containers/bazel/README.md
+++ b/containers/bazel/README.md
@@ -25,7 +25,7 @@ While this definition works unmodified, you can set the Bazelisk version by upda
 }
 ```
 
-Optionally, you can validate the SHA256 checksum for `bazel-installer.sh` by adding it to the `BAZELISK_DOWNLOAD_SHA` argument:
+Optionally, you can validate the SHA256 checksum for `bazelisk` executable by adding it to the `BAZELISK_DOWNLOAD_SHA` argument:
 
 ```json
 "args": {

--- a/containers/bazel/README.md
+++ b/containers/bazel/README.md
@@ -4,33 +4,33 @@
 
 *Develop and compile efficiently on any language with the Bazel compilation tool.*
 
-| Metadata | Value |  
-|----------|-------|
-| *Contributors* | William Phetsinorath <deva.shikanime@protonmail.com> |
-| *Categories* | Community, Other |
-| *Definition type* | Dockerfile |
-| *Supported architecture(s)* | x86-64 |
-| *Works in Codespaces* | Yes |
-| *Container host OS support* | Linux, macOS, Windows |
-| *Container OS* | Debian |
-| *Languages, platforms* | Any |
+| Metadata                    | Value                                                |
+| --------------------------- | ---------------------------------------------------- |
+| *Contributors*              | William Phetsinorath <deva.shikanime@protonmail.com> |
+| *Categories*                | Community, Other                                     |
+| *Definition type*           | Dockerfile                                           |
+| *Supported architecture(s)* | x86-64                                               |
+| *Works in Codespaces*       | Yes                                                  |
+| *Container host OS support* | Linux, macOS, Windows                                |
+| *Container OS*              | Debian                                               |
+| *Languages, platforms*      | Any                                                  |
 
 ## Using this definition
 
-While this definition works unmodified, you can set the Bazel version by updating the `BAZEL_VERSION` argument in `devcontainer.json`.
+While this definition works unmodified, you can set the Bazelisk version by updating the `BAZELISK_VERSION` argument in `devcontainer.json`.
 
 ```json
 "args": {
-   "BAZEL_VERSION": "3.4.1"
+   "BAZELISK_VERSION": "v1.10.1"
 }
 ```
 
-Optionally, you can validate the SHA256 checksum for `bazel-installer.sh` by adding it to the `BAZEL_DOWNLOAD_SHA` argument:
+Optionally, you can validate the SHA256 checksum for `bazel-installer.sh` by adding it to the `BAZELISK_DOWNLOAD_SHA` argument:
 
 ```json
 "args": {
-   "BAZEL_VERSION": "3.4.1",
-   "BAZEL_DOWNLOAD_SHA": "9808adad931ac652e8ff5022a74507c532250c2091d21d6aebc7064573669cc5"
+   "BAZELISK_VERSION": "v1.10.1",
+   "BAZELISK_DOWNLOAD_SHA": "4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd"
 }
 ```
 
@@ -40,7 +40,7 @@ Optionally, you can validate the SHA256 checksum for `bazel-installer.sh` by add
 
 2. Start VS Code and open your project folder or connect to a codespace.
 
-3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**. 
+3. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
 
    > **Note:** If needed, you can drag-and-drop the `.devcontainer` folder from this sub-folder in a locally cloned copy of this repository into the VS Code file explorer instead of using the command.
 
@@ -56,7 +56,7 @@ This definition includes some test code that will help you verify it is working 
 2. Clone this repository.
 3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
 4. Select this folder from the cloned repository.
-5. Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> and type the following command to verify installation: `bazel run //test-project:hello-world`
+5. Press <kbd>ctrl</kbd>+<kbd>shift</kbd>+<kbd>\`</kbd> and type the following command to verify installation: `bazelisk run //test-project:hello-world`
 6. You should see "Hello remote world!" in the Debug Console after the program executes.
 
 ## License


### PR DESCRIPTION
Bazel has been historically painful to manage, Bazelisk is a more flexible official way to manage the version of the Bazel tool similar to nvm (Node Version Manager).

Fix #1153 
Similar context #947