### PR TITLE
[WIP] Example of devcontainer features workflow to expose features to tooling

### DIFF
--- a/.github/workflows/deploy-container-features.yml
+++ b/.github/workflows/deploy-container-features.yml
@@ -1,0 +1,32 @@
+name: 'Deploy Devcontainer Features'
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Get tag name
+        id: get_tag_name  
+        run: echo "::set-output name=tag::$(echo "${{ github.ref }}" | grep -oP 'refs/tags/\K(.+)')"
+        
+      - name: Copy scripts to src folder
+        id: copy_scripts
+        run: cp -r ./script-library/*.sh ./script-library/container-features/src
+          
+      - name: Devcontainer features
+        uses: joshspicer/devcontainer-features-action@main
+        with:
+          path-to-features: './script-library/container-features/src'
+          
+      - name: Get or Create Release at current tag
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true # Lets us upload our own artifact from previous step
+          artifactErrorsFailBuild: true
+          artifacts: './features.tgz'
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[Work in progress/subject to change] 

Example of the workflow I will merge to neatly add a `features.tgz` archive to a release, which the `devcontainer-cli` can pick up to install remote features.

As you can see, the GH action i'm using is still under my personal user. This functionality in the CLI is not yet documented, so this is more a "get everything prepped" PR.  

Todo:
- move action to an organization
- Add features.json validation/linting to action (once finalized @chrmarti)

Example release with the `features.tgz` file: https://github.com/joshspicer/vscode-dev-containers/releases/tag/v0.0.2-jospicer

cc/ @2percentsilk 