### PR TITLE
fix(script-library): kubectl zsh completion file permission

### DIFF
--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -140,10 +140,14 @@ fi
 kubectl completion bash > /etc/bash_completion.d/kubectl
 
 # kubectl zsh completion
-zsh_completion_dir="/home/${USERNAME}/.oh-my-zsh/completions"
-mkdir -p "$zsh_completion_dir"
-kubectl completion zsh > "$zsh_completion_dir/_kubectl"
-chown ${USERNAME}:${group_name} "$zsh_completion_dir/_kubectl"
+if [ ! -z $USERNAME  ]; then
+  zsh_completion_dir="/home/${USERNAME}/.oh-my-zsh/completions"
+  mkdir -p "$zsh_completion_dir"
+  kubectl completion zsh > "$zsh_completion_dir/_kubectl"
+  if [ ! -z $group_name  ]; then
+    chown ${USERNAME}:${group_name} "$zsh_completion_dir/_kubectl"
+  fi
+fi
 
 # Install Helm, verify signature and checksum
 echo "Downloading Helm..."

--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -140,8 +140,10 @@ fi
 kubectl completion bash > /etc/bash_completion.d/kubectl
 
 # kubectl zsh completion
-mkdir -p /home/${USERNAME}/.oh-my-zsh/completions
-kubectl completion zsh > /home/${USERNAME}/.oh-my-zsh/completions/_kubectl
+zsh_completion_dir="/home/${USERNAME}/.oh-my-zsh/completions"
+mkdir -p "$zsh_completion_dir"
+kubectl completion zsh > "$zsh_completion_dir/_kubectl"
+chown ${USERNAME}:${group_name} "$zsh_completion_dir/_kubectl"
 
 # Install Helm, verify signature and checksum
 echo "Downloading Helm..."

--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -140,7 +140,7 @@ fi
 kubectl completion bash > /etc/bash_completion.d/kubectl
 
 # kubectl zsh completion
-if [ ! -z $USERNAME  ]; then
+if [ "$USERNAME" != "root"  ]; then
   zsh_completion_dir="/home/${USERNAME}/.oh-my-zsh/completions"
   mkdir -p "$zsh_completion_dir"
   kubectl completion zsh > "$zsh_completion_dir/_kubectl"

--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -144,9 +144,8 @@ if [ ! -z $USERNAME  ]; then
   zsh_completion_dir="/home/${USERNAME}/.oh-my-zsh/completions"
   mkdir -p "$zsh_completion_dir"
   kubectl completion zsh > "$zsh_completion_dir/_kubectl"
-  if [ ! -z $group_name  ]; then
-    chown ${USERNAME}:${group_name} "$zsh_completion_dir/_kubectl"
-  fi
+  group_name=$(id -g $USERNAME)
+  chown ${USERNAME}:${group_name} "$zsh_completion_dir/_kubectl"
 fi
 
 # Install Helm, verify signature and checksum


### PR DESCRIPTION
Allow user to replace `.oh-my-zsh` folder.
Useful when install `dotfiles` repo in `codespace`, it run `dotfiles` repo's install script with non-root user.