### PR TITLE
Add cmake-tools to default C++ container?

### DIFF
--- a/containers/cpp/.devcontainer/devcontainer.json
+++ b/containers/cpp/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
-		"ms-vscode.cpptools"
+		"ms-vscode.cpptools",
+		"ms-vscode.cmake-tools"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.


### PR DESCRIPTION
@esweet431 - I'm wondering if we should add CMake Tools to VS Code's default C++ dev container. The Dockerfile installs cmake. @bobbrow - Do you know if we do this for Codespaces?