### PR TITLE
Fix Node script checksum verification

### DIFF
--- a/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
+++ b/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update \
   # [Optional] Install Node.js for use with web applications
   && if [ "$NODE_VERSION" != "none" ]; then \
   curl -sSL ${NODE_SCRIPT_SOURCE} -o /tmp/node-setup.sh \
-  && ([ "${NODE_SCRIPT_SHA}" = "dev-mode" ] || (echo "${COMMON_SCRIPT_SHA} */tmp/node-setup.sh" | sha256sum -c -)) \
+  && ([ "${NODE_SCRIPT_SHA}" = "dev-mode" ] || (echo "${NODE_SCRIPT_SHA} */tmp/node-setup.sh" | sha256sum -c -)) \
   && /bin/bash /tmp/node-setup.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}"; \
   fi \
   #


### PR DESCRIPTION
The checksum verification is comparing the node-debian.sh to the
common-debian.sh checksum, which fails if the `COMMON_SCRIPT_SHA`
environment variable is set.

This PR fixes the issue, comparing the node-debian.sh checksum to
the `NODE_SCRIPT_SHA` environment variable.