### PR TITLE
Move to Microsoft OpenJDK

### DIFF
--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -1,31 +1,20 @@
 # This base.Dockerfile uses separate build arguments instead of VARIANT
 ARG BASE_IMAGE_VERSION_CODENAME=bullseye
-FROM debian:${BASE_IMAGE_VERSION_CODENAME}
-
-# JDK Version
-ARG TARGET_JAVA_VERSION=11
-ENV LANG en_US.UTF-8
+FROM mcr.microsoft.com/vscode/devcontainers/base:${BASE_IMAGE_VERSION_CODENAME}
 
 # Copy library scripts to execute
 COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 
-# [Option] Install zsh
-ARG INSTALL_ZSH="true"
-# [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="true"
-# Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
-	&& apt-get clean -y && rm -rf /var/lib/apt/lists/*
-
+# JDK Version
+ARG TARGET_JAVA_VERSION=11
 # [Option] Install Maven
 ARG INSTALL_MAVEN="false"
 ARG MAVEN_VERSION=""
 # [Option] Install Gradle
 ARG INSTALL_GRADLE="false"
 ARG GRADLE_VERSION=""
+ENV LANG en_US.UTF-8
 ENV SDKMAN_DIR="/usr/local/sdkman"
 ENV PATH="${SDKMAN_DIR}/candidates/java/current/bin:${PATH}:${SDKMAN_DIR}/candidates/maven/current/bin:${SDKMAN_DIR}/candidates/gradle/current/bin"
 # Install Java tools such as JDK, Maven and Gradle

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -27,6 +27,7 @@ RUN arch="$(dpkg --print-architecture)" \
 	&& sha256sumText=$(cat sha256sum.txt) \
 	&& sha256=$(expr substr "${sha256sumText}" 1 64) \
 	&& echo "${sha256} msopenjdk.tar.gz" | sha256sum --strict --check - \
+	&& rm sha256sum.txt* \
 	\
 	&& mkdir -p "$JAVA_HOME" \
 	&& tar --extract \

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -21,7 +21,13 @@ RUN arch="$(dpkg --print-architecture)" \
 		*) echo >&2 "error: unsupported architecture: '$arch'"; exit 1 ;; \
 	esac \
 	\
-	&& wget --progress=dot:giga -O msopenjdk.tar.gz "$jdkUrl" \
+	&& wget --progress=dot:giga -O msopenjdk.tar.gz "${jdkUrl}" \
+	&& wget --progress=dot:giga -O sha256sum.txt "${jdkUrl}.sha256sum.txt" \
+	\
+	&& sha256sumText=$(cat sha256sum.txt) \
+	&& sha256=$(expr substr "${sha256sumText}" 1 64) \
+	&& echo "${sha256} msopenjdk.tar.gz" | sha256sum --strict --check - \
+	\
 	&& mkdir -p "$JAVA_HOME" \
 	&& tar --extract \
 		--file msopenjdk.tar.gz \

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -49,8 +49,8 @@
 		}
 	},
 	"dependencies": {
-		"image": "openjdk:${VARIANT}",
-		"imageLink": "https://hub.docker.com/_/openjdk",
+		"image": "debian:${BASE_IMAGE_VERSION_CODENAME}",
+		"imageLink": "https://hub.docker.com/_/debian",
 		"apt": [{
 			"cgIgnore": false,
 			"name": "yarn"

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -49,8 +49,8 @@
 		}
 	},
 	"dependencies": {
-		"image": "debian:${BASE_IMAGE_VERSION_CODENAME}",
-		"imageLink": "https://hub.docker.com/_/debian",
+		"image": "buildpack-deps:${BASE_IMAGE_VERSION_CODENAME}-curl",
+		"imageLink": "https://hub.docker.com/_/buildpack-deps",
 		"apt": [{
 			"cgIgnore": false,
 			"name": "yarn"


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fixes #1050

Use debian as the base image, and install Microsoft OpenJDK 11/17 via tar.gz download url on the docker image.