### PR TITLE
Bump minor version to pick up latest OS, runtime updates for 1.63 release

### DIFF
--- a/containers/codespaces-linux/definition-manifest.json
+++ b/containers/codespaces-linux/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "1.6.8",
+	"definitionVersion": "1.6.9",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/cpp/definition-manifest.json
+++ b/containers/cpp/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["bullseye", "buster", "hirsute", "focal", "bionic", "stretch"],
-	"definitionVersion": "0.203.2",
+	"definitionVersion": "0.203.3",
 	"build": {
 		"latest": "bullseye",
 		"parent": {

--- a/containers/debian/definition-manifest.json
+++ b/containers/debian/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "bullseye",  "stretch"],
-	"definitionVersion": "0.202.3",
+	"definitionVersion": "0.202.4",
 	"build": {
 		"latest": "bullseye",
 		"rootDistro": "debian",

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["6.0-bullseye-slim", "6.0-focal", "5.0-bullseye-slim", "5.0-focal", "3.1-bullseye", "3.1-focal"],
-	"definitionVersion": "0.202.0",
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": "6.0-bullseye-slim",
 		"rootDistro": "debian",

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["1.17-bullseye", "1.16-bullseye", "1.17-buster", "1.16-buster"],
-	"definitionVersion": "0.205.1",
+	"definitionVersion": "0.205.2",
 	"build": {
 		"latest": "1.17-bullseye",
 		"rootDistro": "debian",

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["16-bullseye", "14-bullseye", "12-bullseye", "16-buster", "14-buster", "12-buster"],
-	"definitionVersion": "0.203.1",
+	"definitionVersion": "0.203.2",
 	"build": {
 		"latest": "16-buster",
 		"rootDistro": "debian",

--- a/containers/jekyll/definition-manifest.json
+++ b/containers/jekyll/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["2.7-bullseye", "2.7-buster"],
-	"definitionVersion": "0.1.3",
+	"definitionVersion": "0.1.4",
 	"build": {
 		"latest": "2.7-bullseye",
 		"parent": "ruby",

--- a/containers/python-3-anaconda/definition-manifest.json
+++ b/containers/python-3-anaconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.202.2",
+	"definitionVersion": "0.202.3",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3-miniconda/definition-manifest.json
+++ b/containers/python-3-miniconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.202.0",
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.10-bullseye", "3.9-bullseye", "3.8-bullseye", "3.7-bullseye", "3.6-bullseye", "3.10-buster", "3.9-buster", "3.8-buster", "3.7-buster", "3.6-buster"],
-	"definitionVersion": "0.203.0",
+	"definitionVersion": "0.203.1",
 	"build": {
 		"latest": "3.10-bullseye",
 		"rootDistro": "debian",

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.0-bullseye", "2.7-bullseye", "2.6-bullseye","3.0-buster", "2.7-buster", "2.6-buster"],
-	"definitionVersion": "0.202.1",
+	"definitionVersion": "0.202.2",
 	"build": {
 		"latest": "3.0-bullseye",
 		"rootDistro": "debian",

--- a/containers/rust/definition-manifest.json
+++ b/containers/rust/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "bullseye"],
-	"definitionVersion": "0.201.1",
+	"definitionVersion": "0.201.2",
 	"build": {
 		"latest": "buster",
 		"rootDistro": "debian",

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["16-bullseye", "14-bullseye", "12-bullseye", "16-buster", "14-buster", "12-buster"],
-	"definitionVersion": "0.203.1",
+	"definitionVersion": "0.203.2",
 	"build": {
 		"latest": "16-buster",
 		"rootDistro": "debian",

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["hirsute", "focal", "bionic"],
-	"definitionVersion": "0.202.2",
+	"definitionVersion": "0.202.3",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",


### PR DESCRIPTION
Alpine and PHP were skipped due to #1181 and #1179.