### PR TITLE
[R] Remove aditional terminal profile

### DIFF
--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -13,12 +13,6 @@
 		"r.plot.useHttpgd": true,
 		"[r]": {
 			"editor.wordSeparators": "`~!@#%$^&*()-=+[{]}\\|;:'\",<>/?"
-		},
-		"terminal.integrated.profiles.linux": {
-			"radian": {
-				"path": "/usr/local/bin/radian",
-				"overrideName": true
-			}
 		}
 	},
 


### PR DESCRIPTION
The extension has been changed to add a terminal profile `R Teminal` (https://github.com/REditorSupport/vscode-R/pull/851), so the profile `radian` defined in `devcontainer.json` is no longer needed.

![image](https://user-images.githubusercontent.com/50911393/144210415-3f7f4921-880e-4961-a2f4-adfbad9200a8.png)
