### PR TITLE
Add arm64 support to Hugo container

### DIFF
--- a/containers/hugo/.devcontainer/Dockerfile
+++ b/containers/hugo/.devcontainer/Dockerfile
@@ -15,7 +15,14 @@ RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \
     export VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}') ;;\
     esac && \
     echo ${VERSION} && \
-    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-64bit.tar.gz && \
+    case $(uname -m) in \
+    aarch64) \
+    export ARCH=ARM64 ;; \
+    *) \
+    export ARCH=64bit ;; \
+    esac && \
+    echo ${ARCH} && \
+    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-${ARCH}.tar.gz && \
     tar xf ${VERSION}.tar.gz && \
     mv hugo /usr/bin/hugo
 


### PR DESCRIPTION
Recently `javascript-node`, the base image of Hugo container, [supports arm64 architecture](https://github.com/microsoft/vscode-dev-containers/blob/04c2d3ff7950d3f71fd1716ac131497f21c3fea5/containers/javascript-node/README.md).

> x86-64, arm64/aarch64 for bullseye variants

That means you can use Hugo container with arm64 by specifying kind of `16-bullseye` as `NODE_VERSION` argument. However, since it downloads amd64 binary version of `hugo` executable for the moment, hugo does not work natively in arm64 container.

This pull request makes it possible to switch the downloadable binary version by checking container OS processor architecture using `umame`.