### PR TITLE
Fix .npmignore to include common-debian.sh

### DIFF
--- a/containers/mit-scheme/.npmignore
+++ b/containers/mit-scheme/.npmignore
@@ -1,5 +1,3 @@
 README.md
-test-project
-.devcontainer/library-scripts
-.vscode
+.devcontainer/library-scripts/README.md
 .npmignore


### PR DESCRIPTION
mit-scheme's .npmignore was excluding library-scripts/common-debian.sh, which meant that the image couldn't build.

This PR also removes nonexistent files from the .npmignore.