### PR TITLE
Symlink legacy JAVA_HOME location

### DIFF
--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_VERSION_CODENAME=bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/base:${BASE_IMAGE_VERSION_CODENAME}
 
 ARG TARGET_JAVA_VERSION
-ENV JAVA_HOME /usr/lib/jvm/msopenjdk-${TARGET_JAVA_VERSION}
+ENV JAVA_HOME /usr/local/openjdk-${TARGET_JAVA_VERSION}
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8

--- a/containers/java/.devcontainer/base.Dockerfile
+++ b/containers/java/.devcontainer/base.Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_VERSION_CODENAME=bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/base:${BASE_IMAGE_VERSION_CODENAME}
 
 ARG TARGET_JAVA_VERSION
-ENV JAVA_HOME /usr/local/openjdk-${TARGET_JAVA_VERSION}
+ENV JAVA_HOME /usr/lib/jvm/msopenjdk-${TARGET_JAVA_VERSION}
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 # Default to UTF-8 file.encoding
 ENV LANG en_US.UTF-8
@@ -37,7 +37,8 @@ RUN arch="$(dpkg --print-architecture)" \
 		--no-same-owner \
 	&& rm msopenjdk.tar.gz* \
 	\
-	&& ln -s ${JAVA_HOME} /docker-java-home
+	&& ln -s ${JAVA_HOME} /docker-java-home \
+	&& ln -s ${JAVA_HOME} /usr/local/openjdk-${TARGET_JAVA_VERSION}
 
 # Copy library scripts to execute
 COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/


### PR DESCRIPTION
The new Microsoft OpenJDK version of the Java image works great! However, one thing I noticed is the current openjdk:bullseye image we have been using has a different JAVA_HOME location.

This PR tweaks JAVA_HOME to match the current images in the event someone has added this exact path to their settings.json for the various Java VS Code extensions instead of the common `/docker_java_home` folder.