### PR TITLE
Fix OMZ folder ownership after installing completions

### DIFF
--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -140,12 +140,13 @@ fi
 kubectl completion bash > /etc/bash_completion.d/kubectl
 
 # kubectl zsh completion
-if [ "$USERNAME" != "root"  ]; then
-  zsh_completion_dir="/home/${USERNAME}/.oh-my-zsh/completions"
-  mkdir -p "$zsh_completion_dir"
-  kubectl completion zsh > "$zsh_completion_dir/_kubectl"
-  group_name=$(id -g $USERNAME)
-  chown ${USERNAME}:${group_name} "$zsh_completion_dir/_kubectl"
+if [ "${USERNAME}" != "root"  ]; then
+  omz_dir="/home/${USERNAME}/.oh-my-zsh"
+  zsh_completion_dir="${omz_dir}/completions"
+  mkdir -p "${zsh_completion_dir}"
+  kubectl completion zsh > "${zsh_completion_dir}/_kubectl"
+  group_name=$(id -g "${USERNAME}")
+  chown -R "${USERNAME}:${group_name}" "${omz_dir}"
 fi
 
 # Install Helm, verify signature and checksum


### PR DESCRIPTION
My devcontainer was failing to install my dotfiles because of this since many days, and I spent several days to track this change to here. That was mainly because I didn't pin the revision of the script to use, so I was always using the latest.

The problem is that, this script creates the OMZ folder as root since https://github.com/microsoft/vscode-dev-containers/pull/1163, and forgets to change its ownership back to the original non-root user.

Also, this PR addresses some ShellCheck warnings.