### PR TITLE
Fix kubectl script when USERNAME is not set

### DIFF
--- a/script-library/kubectl-helm-debian.sh
+++ b/script-library/kubectl-helm-debian.sh
@@ -140,7 +140,7 @@ fi
 kubectl completion bash > /etc/bash_completion.d/kubectl
 
 # kubectl zsh completion
-if [ "${USERNAME}" != "root"  ]; then
+if [ -n "${USERNAME}" && "${USERNAME}" != "root"  ]; then
   omz_dir="/home/${USERNAME}/.oh-my-zsh"
   zsh_completion_dir="${omz_dir}/completions"
   mkdir -p "${zsh_completion_dir}"


### PR DESCRIPTION
I noticed this in one of my images: https://github.com/felipecrs/docker-images/runs/4541686579?check_suite_focus=true#step:7:4000