### PR TITLE
Update the install fish script

### DIFF
--- a/script-library/fish-debian.sh
+++ b/script-library/fish-debian.sh
@@ -49,11 +49,11 @@ if grep -q 'Ubuntu' < /etc/os-release; then
     apt-get autoremove -y
 elif grep -q 'Debian' < /etc/os-release; then
     if grep -q 'stretch' < /etc/os-release; then
-        echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_9.0/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
-        curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_9.0/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
+        echo 'deb http://download.opensuse.org/repositories/shells:/fish/Debian_9.0/ /' | tee /etc/apt/sources.list.d/shells:fish.list
+        curl -fsSL https://download.opensuse.org/repositories/shells:fish/Debian_9.0/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish.gpg > /dev/null
     elif grep -q 'buster' < /etc/os-release; then
-        echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_10/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
-        curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_10/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
+        echo 'deb http://download.opensuse.org/repositories/shells:/fish/Debian_10/ /' | tee /etc/apt/sources.list.d/shells:fish.list
+        curl -fsSL https://download.opensuse.org/repositories/shells:fish/Debian_10/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish.gpg > /dev/null
     elif grep -q 'bullseye' < /etc/os-release; then
         echo 'deb http://download.opensuse.org/repositories/shells:/fish/Debian_11/ /' | tee /etc/apt/sources.list.d/shells:fish.list
         curl -fsSL https://download.opensuse.org/repositories/shells:fish/Debian_11/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish.gpg > /dev/null

--- a/script-library/fish-debian.sh
+++ b/script-library/fish-debian.sh
@@ -54,6 +54,9 @@ elif grep -q 'Debian' < /etc/os-release; then
     elif grep -q 'buster' < /etc/os-release; then
         echo 'deb http://download.opensuse.org/repositories/shells:/fish:/release:/3/Debian_10/ /' | tee /etc/apt/sources.list.d/shells:fish:release:3.list
         curl -fsSL https://download.opensuse.org/repositories/shells:fish:release:3/Debian_10/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish_release_3.gpg > /dev/null
+    elif grep -q 'bullseye' < /etc/os-release; then
+        echo 'deb http://download.opensuse.org/repositories/shells:/fish/Debian_11/ /' | tee /etc/apt/sources.list.d/shells:fish.list
+        curl -fsSL https://download.opensuse.org/repositories/shells:fish/Debian_11/Release.key | gpg --dearmor | tee /etc/apt/trusted.gpg.d/shells_fish.gpg > /dev/null
     fi
     apt update
     apt install -y fish


### PR DESCRIPTION
- Support `debian:bullseye`
- Update the install comand for debian (see https://software.opensuse.org/download.html?project=shells%3Afish&package=fish)

cc @andreiborisov