### PR TITLE
Add plain Ansible devcontainer

### DIFF
--- a/containers/ansible/.devcontainer/Dockerfile
+++ b/containers/ansible/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+# [Choice] Python version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.10, 3.9, 3.8, 3.7, 3.6, 3-bullseye, 3.10-bullseye, 3.9-bullseye, 3.8-bullseye, 3.7-bullseye, 3.6-bullseye, 3-buster, 3.10-buster, 3.9-buster, 3.8-buster, 3.7-buster, 3.6-buster
+ARG PYTHON_VARIANT=3-bullseye
+
+FROM mcr.microsoft.com/vscode/devcontainers/python:${PYTHON_VARIANT}
+
+# [Choice] Ansible variant: ansible, ansible-core, ansible-base
+ARG ANSIBLE_VARIANT=ansible-core
+
+# [Choice] Ansible Version: 2.9.*, 2.10.*, 2.11.*, 2.12.*
+ARG ANSIBLE_VERSION=2.11
+
+RUN pip3 --disable-pip-version-check --no-cache-dir install --upgrade pip wheel \
+    && pip3 --disable-pip-version-check --no-cache-dir install ${ANSIBLE_VARIANT}==${ANSIBLE_VERSION}
+
+# Create some default directories for ansible
+RUN mkdir -p /ansible_collections \
+    && mkdir -p ~/.ansible/collections
+
+# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
+# COPY requirements.txt /tmp/pip-tmp/
+# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+#    && rm -rf /tmp/pip-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>

--- a/containers/ansible/.devcontainer/devcontainer.json
+++ b/containers/ansible/.devcontainer/devcontainer.json
@@ -1,0 +1,62 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/python-3
+{
+	"name": "Ansible",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": "..",
+		"args": { 
+			// Update 'PYTHON_VARIANT' to pick a Python version: 3, 3.10, 3.9, 3.8, 3.7, 3.6
+			// Append -bullseye or -buster to pin to an OS version.
+			// Use -bullseye variants on local on arm64/Apple Silicon.
+			"PYTHON_VARIANT": "3.10-bullseye",
+			
+			// Update 'ANSIBLE_VARIANT' to pick your desired ansible variant: ansible, ansible-core, ansible-base
+			"ANSIBLE_VARIANT": "ansible-core",
+
+			// Update 'ANSILBE_VERSION' to choose the version of your variant (for example): 2.9.*, 2.10.*, 2.11.*, 2.12.*
+			"ANSIBLE_VERSION": "2.11.*"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"python.defaultInterpreterPath": "/usr/local/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-python.python",
+		"ms-python.vscode-pylance",
+		"redhat.ansible",
+	],
+
+	// If you want to develop a collection, you can also mount the folders and ease your ansible-test experience
+	//"workspaceFolder": "/ansible_collections/community/your-collection",
+	//"workspaceMount": "source=${localWorkspaceFolder},target=/ansible_collections/community/your-collection,type=bind,consistency=cached",
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt && ansible-galaxy collection install -r requirements.yml",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+
+	"features": {
+		"docker-from-docker": "latest",
+		"git": "os-provided"
+	}
+}

--- a/containers/ansible/.npmignore
+++ b/containers/ansible/.npmignore
@@ -1,0 +1,7 @@
+README.md
+test-project
+history
+.devcontainer/library-scripts
+definition-manifest.json
+.vscode
+.npmignore

--- a/containers/ansible/README.md
+++ b/containers/ansible/README.md
@@ -18,6 +18,14 @@
 
 The environment is heavily based on the [Python 3 devcontainers](https://github.com/rockaut/vscode-dev-containers/tree/main/containers/python-3) and slightly modified to automate the Ansible installs. So maybe also look at those too.
 
+### Included
+
+The container as such already includes pip and wheel for easier installation of ansible things.
+It also creates the basic directory requirements for ansible itself and also for collection/role creation.
+You may just mount your workspace folder (see devcontainer.json).
+
+The devcontainer also enables redhat.ansible plugin (see devcontainer.json).
+
 ### Configuration
 
 While the definition itself works unmodified, you can select the version of Python the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
@@ -38,33 +46,6 @@ RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requ
 ```
 
 Since `requirements.txt` is likely in the folder you opened rather than the `.devcontainer` folder, be sure to include `"context": ".."` to `devcontainer.json`. This allows the Dockerfile to access everything in the opened folder instead of just the contents of the `.devcontainer` folder.
-
-#### [Optional] Allowing the non-root vscode user to pip install globally without sudo
-
-You can opt into using the `vscode` non-root user in the container by adding `"remoteUser": "vscode"` to `devcontainer.json`. However, by default, this you will need to use `sudo` to perform global pip installs.
-
-```bash
-sudo pip install <your-package-here>
-```
-
-Or stick with user installs:
-
-```bash
-pip install --user <your-package-here>
-```
-
-If you prefer, you can add the following to your `Dockerfile` to cause global installs to go into a different folder that the `vscode` user can write to.
-
-```Dockerfile
-ENV PIP_TARGET=/usr/local/pip-global
-ENV PYTHONPATH=${PIP_TARGET}:${PYTHONPATH}
-ENV PATH=${PIP_TARGET}/bin:${PATH}
-RUN if ! cat /etc/group | grep -e "^pip-global:" > /dev/null 2>&1; then groupadd -r pip-global; fi \
-    && usermod -a -G pip-global vscode \
-    && umask 0002 && mkdir -p ${PIP_TARGET} \
-    && chown :pip-global ${PIP_TARGET} \
-    && ( [ ! -f "/etc/profile.d/00-restore-env.sh" ] || sed -i -e "s/export PATH=/export PATH=\/usr\/local\/pip-global:/" /etc/profile.d/00-restore-env.sh )
-```
 
 ### Adding the definition to a project or codespace
 

--- a/containers/ansible/README.md
+++ b/containers/ansible/README.md
@@ -1,0 +1,93 @@
+# Ansible
+
+## Summary
+
+*Develop Ansible automations and collections/roles*
+
+| Metadata | Value |
+| -------- | ----- |
+| *Contributors* | [Fischbacher Markus](https://gitlab.com/rockaut) |
+| *Categories* | Community, Ansible |
+| *Definition type* | Dockerfile |
+| *Works in Codespaces* | Yes |
+| *Container Host OS Support* | Linux, macOS, Windows |
+| *Container OS* | Debian |
+| *Languages, platforms* | Python |
+
+## Using this definition
+
+The environment is heavily based on the [Python 3 devcontainers](https://github.com/rockaut/vscode-dev-containers/tree/main/containers/python-3) and slightly modified to automate the Ansible installs. So maybe also look at those too.
+
+### Configuration
+
+While the definition itself works unmodified, you can select the version of Python the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
+
+```json
+// Or you can use 3.7-bullseye or 3.7-buster if you want to pin to an OS version
+"args": { "VARIANT": "3.10-bullseye" }
+```
+
+#### [Optional] Building your requirements into the container image
+
+If your requirements rarely change, you can include the contents of `requirements.txt` in the container by adding the following to your `Dockerfile`:
+
+```Dockerfile
+COPY requirements.txt /tmp/pip-tmp/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \
+    && rm -rf /tmp/pip-tmp
+```
+
+Since `requirements.txt` is likely in the folder you opened rather than the `.devcontainer` folder, be sure to include `"context": ".."` to `devcontainer.json`. This allows the Dockerfile to access everything in the opened folder instead of just the contents of the `.devcontainer` folder.
+
+#### [Optional] Allowing the non-root vscode user to pip install globally without sudo
+
+You can opt into using the `vscode` non-root user in the container by adding `"remoteUser": "vscode"` to `devcontainer.json`. However, by default, this you will need to use `sudo` to perform global pip installs.
+
+```bash
+sudo pip install <your-package-here>
+```
+
+Or stick with user installs:
+
+```bash
+pip install --user <your-package-here>
+```
+
+If you prefer, you can add the following to your `Dockerfile` to cause global installs to go into a different folder that the `vscode` user can write to.
+
+```Dockerfile
+ENV PIP_TARGET=/usr/local/pip-global
+ENV PYTHONPATH=${PIP_TARGET}:${PYTHONPATH}
+ENV PATH=${PIP_TARGET}/bin:${PATH}
+RUN if ! cat /etc/group | grep -e "^pip-global:" > /dev/null 2>&1; then groupadd -r pip-global; fi \
+    && usermod -a -G pip-global vscode \
+    && umask 0002 && mkdir -p ${PIP_TARGET} \
+    && chown :pip-global ${PIP_TARGET} \
+    && ( [ ! -f "/etc/profile.d/00-restore-env.sh" ] || sed -i -e "s/export PATH=/export PATH=\/usr\/local\/pip-global:/" /etc/profile.d/00-restore-env.sh )
+```
+
+### Adding the definition to a project or codespace
+
+1. If this is your first time using a development container, please see getting started information on [setting up](https://aka.ms/vscode-remote/containers/getting-started) Remote-Containers or [creating a codespace](https://aka.ms/ghcs-open-codespace) using GitHub Codespaces.
+
+2. To use the pre-built image:
+   1. Start VS Code and open your project folder or connect to a codespace.
+   2. Press <kbd>F1</kbd> select and **Add Development Container Configuration Files...** command for **Remote-Containers** or **Codespaces**.
+   4. Select this definition. You may also need to select **Show All Definitions...** for it to appear.
+
+3. To build a custom version of the image instead:
+   1. Clone this repository locally.
+   2. Start VS Code and open your project folder or connect to a codespace.
+   3. Use your local operating system's file explorer to drag-and-drop the locally cloned copy of the `.devcontainer` folder for this definition into the VS Code file explorer for your opened project or codespace.
+   4. Update `.devcontainer/devcontainer.json`
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** or **Codespaces: Rebuild Container** to start using the definition.
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE)
+


### PR DESCRIPTION
A simple devcontainer (based on the python-3) for developing Ansible projects and collections/roles - without ballast not really needed.