### PR TITLE
fix incorrect github-cli documentation

### DIFF
--- a/script-library/docs/github-cli.md
+++ b/script-library/docs/github-cli.md
@@ -18,7 +18,7 @@ Or as a feature:
 
 ```json
 "features": {
-    "github": "latest"
+    "github-cli": "latest"
 }
 ```
 
@@ -34,7 +34,7 @@ To install these capabilities in your primary dev container, reference it in `de
 
 ```json
 "features": {
-    "github": "latest"
+    "github-cli": "latest"
 }
 ```
 


### PR DESCRIPTION
This documentation says to use `"github": "latest"`. However, it doesn't appear that the GitHub CLI is installed when doing this. Using `"github-cli": "latest"` does install the GitHub CLI tool, though.