### PR TITLE
Do not recommend Debian 9/stretch

### DIFF
--- a/container-templates/docker-compose/.devcontainer/Dockerfile
+++ b/container-templates/docker-compose/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Use the [Choice] comment to indicate option arguments that should appear in VS Code UX. Use a comma separated list.
 #
-# [Choice] Debian OS version: bullseye, buster, stretch
+# [Choice] Debian OS version: bullseye, buster
 ARG VARIANT="bullseye"
 FROM buildpack-deps:${VARIANT}-curl
 

--- a/container-templates/dockerfile/.devcontainer/Dockerfile
+++ b/container-templates/dockerfile/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Use the [Choice] comment to indicate option arguments that should appear in VS Code UX. Use a comma separated list.
 #
-# [Choice] Debian OS version: bullseye, buster, stretch
+# [Choice] Debian OS version: bullseye, buster
 ARG VARIANT="buster"
 FROM buildpack-deps:${VARIANT}-curl
 

--- a/containers/cpp/.devcontainer/Dockerfile
+++ b/containers/cpp/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+# [Choice] Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 ARG VARIANT=debian-11
 FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 

--- a/containers/cpp/.devcontainer/base.Dockerfile
+++ b/containers/cpp/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
+# [Choice] Debian / Ubuntu version (use Debian 11, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 ARG VARIANT=debian-10
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 

--- a/containers/cpp/README.md
+++ b/containers/cpp/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/cpp |
-| *Available image variants* | stretch, buster, bullseye, bionic, focal, hirsute ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list)) |
-| *Published image architecture(s)* | x86-64, aarch64/arm64 for `bullseye`, `stretch`, `bionic`, and `hirsute` variants |
+| *Available image variants* | buster, bullseye, bionic, focal, hirsute ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/cpp/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `bullseye`, `bionic`, and `hirsute` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian, Ubuntu |
@@ -33,7 +33,6 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/cpp:debian` (latest Debian GA)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:bullseye` (or `debian-11`)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:buster` (or `debian-10`)
-- `mcr.microsoft.com/vscode/devcontainers/cpp:stretch` (or `debian-9`)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:ubuntu` (latest Ubuntu LTS)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:hirsute` (or `ubuntu-21.04`)
 - `mcr.microsoft.com/vscode/devcontainers/cpp:focal` (or `ubuntu-20.04`)

--- a/containers/debian/.devcontainer/Dockerfile
+++ b/containers/debian/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian version (use bullseye or stretch on local arm64/Apple Silicon): bullseye, buster, stretch
+# [Choice] Debian version (use bullseye on local arm64/Apple Silicon): bullseye, buster
 ARG VARIANT=bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 

--- a/containers/debian/.devcontainer/base.Dockerfile
+++ b/containers/debian/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Debian version (use bullseye or stretch on local arm64/Apple Silicon): bullseye, buster, stretch
+# [Choice] Debian version (use bullseye on local arm64/Apple Silicon): bullseye, buster
 ARG VARIANT="bullseye"
 FROM buildpack-deps:${VARIANT}-curl
 

--- a/containers/debian/.devcontainer/devcontainer.json
+++ b/containers/debian/.devcontainer/devcontainer.json
@@ -2,8 +2,8 @@
 	"name": "Debian",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Debian version: bullseye, buster, stretch
-		// Use bullseye or stretch on local arm64/Apple Silicon.
+		// Update 'VARIANT' to pick an Debian version: bullseye, buster
+		// Use bullseye on local arm64/Apple Silicon.
 		"args": { "VARIANT": "bullseye" }
 	},
 

--- a/containers/debian/README.md
+++ b/containers/debian/README.md
@@ -10,8 +10,8 @@
 | *Categories* | Core, Other |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/base:debian |
-| *Available image variants* | stretch, buster, bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
-| *Published image architecture(s)* | x86-64, aarch64/arm64 for `bullseye` and `stretch` variants |
+| *Available image variants* | buster, bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
+| *Published image architecture(s)* | x86-64, aarch64/arm64 for `bullseye` variant |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Debian |
@@ -32,7 +32,6 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/base:debian` (latest)
 - `mcr.microsoft.com/vscode/devcontainers/base:bullseye` (or `debian-11`)
 - `mcr.microsoft.com/vscode/devcontainers/base:buster` (or `debian-10`)
-- `mcr.microsoft.com/vscode/devcontainers/base:stretch` (or `debian-9`)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 


### PR DESCRIPTION
Debian 9 / Stretch is no longer getting security patches as it is EOL and it's community LTS support runs out in June of this year.  https://wiki.debian.org/LTS

We should not be recommending it to people at this point. We can keep pre-building the stretch image for existing use until June as long as there isn't a critical security issue that is "won't fix".