### PR TITLE
Correct the scipt path in Python feature docs

### DIFF
--- a/script-library/docs/python.md
+++ b/script-library/docs/python.md
@@ -58,7 +58,7 @@ If you have already built your development container, run the **Rebuild Containe
     ENV PIPX_HOME=/usr/local/py-utils \
         PIPX_BIN_DIR=/usr/local/py-utils/bin
     ENV PATH=${PYTHON_PATH}/bin:${PATH}:${PIPX_BIN_DIR}
-    COPY .devcontainer/library-scripts/python-debian.sh /tmp/library-scripts/
+    COPY library-scripts/python-debian.sh /tmp/library-scripts/
     RUN apt-get update && bash /tmp/library-scripts/python-debian.sh "3.8.3" "${PYTHON_PATH}" "${PIPX_HOME}"
     ```
 


### PR DESCRIPTION
The issue this is intended to solve is described in #1242.
I looked through all the other markdown files in the folder and this is the only one that's impacted.