### PR TITLE
Remove explicit debase install for Ruby script

### DIFF
--- a/script-library/ruby-debian.sh
+++ b/script-library/ruby-debian.sh
@@ -15,7 +15,7 @@ UPDATE_RC=${3:-"true"}
 INSTALL_RUBY_TOOLS=${6:-"true"}
 
 # Note: ruby-debug-ide will install the right version of debase if missing and
-# and installing debase directly fails on Ruby 3.1.0 as of 1/7/2022, so omitting.
+# installing debase directly fails on Ruby 3.1.0 as of 1/7/2022, so omitting.
 DEFAULT_GEMS="rake ruby-debug-ide"
 
 RVM_GPG_KEYS="409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"

--- a/script-library/ruby-debian.sh
+++ b/script-library/ruby-debian.sh
@@ -14,7 +14,10 @@ USERNAME=${2:-"automatic"}
 UPDATE_RC=${3:-"true"}
 INSTALL_RUBY_TOOLS=${6:-"true"}
 
-DEFAULT_GEMS="rake ruby-debug-ide debase"
+# Note: ruby-debug-ide will install the right version of debase if missing and
+# and installing debase directly fails on Ruby 3.1.0 as of 1/7/2022, so omitting.
+DEFAULT_GEMS="rake ruby-debug-ide"
+
 RVM_GPG_KEYS="409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB"
 GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com:80
 keyserver hkps://keys.openpgp.org


### PR DESCRIPTION
Resolves #1235, enables #1226 

Installing `ruby-debug-ide` will install the right version of the `debase` gem if missing and installing `debase` directly fails on Ruby 3.1.0 as of 1/7/2022, so omitting.