### PR TITLE
Codespaces: Change reference from .env to .env-secrets

### DIFF
--- a/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/sshd-debian.sh
@@ -104,10 +104,14 @@ if [ "${CODESPACES}" != "true" ] || [ "${VSCDC_FIXED_SECRETS}" = "true" ] || [ !
     # Not codespaces, already run, or secrets already in environment, so return
     return
 fi
-if [ -f /workspaces/.codespaces/shared/.env ]; then
-    set -o allexport
-    . /workspaces/.codespaces/shared/.env
-    set +o allexport
+if [ -f /workspaces/.codespaces/shared/.env-secrets ]; then
+    while read line
+    do
+        key=$(echo $line | sed "s/=.*//")
+        value=$(echo $line | sed "s/$key=//1")
+        decodedValue=$(echo $value | base64 -d)
+        export $key="$decodedValue"
+    done < /workspaces/.codespaces/shared/.env-secrets
 fi
 export VSCDC_FIXED_SECRETS=true
 EOF

--- a/script-library/sshd-debian.sh
+++ b/script-library/sshd-debian.sh
@@ -104,10 +104,14 @@ if [ "${CODESPACES}" != "true" ] || [ "${VSCDC_FIXED_SECRETS}" = "true" ] || [ !
     # Not codespaces, already run, or secrets already in environment, so return
     return
 fi
-if [ -f /workspaces/.codespaces/shared/.env ]; then
-    set -o allexport
-    . /workspaces/.codespaces/shared/.env
-    set +o allexport
+if [ -f /workspaces/.codespaces/shared/.env-secrets ]; then
+    while read line
+    do
+        key=$(echo $line | sed "s/=.*//")
+        value=$(echo $line | sed "s/$key=//1")
+        decodedValue=$(echo $value | base64 -d)
+        export $key="$decodedValue"
+    done < /workspaces/.codespaces/shared/.env-secrets
 fi
 export VSCDC_FIXED_SECRETS=true
 EOF


### PR DESCRIPTION
Closes [#4095](https://github.com/github/codespaces/issues/4095)

In order to support multi-line secrets, we now encode secrets and write to  `/workspaces/.codespaces/shared/.env-secrets` file. We encode to this file, and decode while exporting env variables.

The codespaces image is however referencing to old `.env` file which prompts errors while connecting via ssh. Hence, changing the reference. 

