### PR TITLE
Ruby 3.1.0, bump version numbers for release

### DIFF
--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.15", "3.14", "3.13", "3.12"],
-	"definitionVersion": "0.204.0",
+	"definitionVersion": "0.204.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",

--- a/containers/cpp/definition-manifest.json
+++ b/containers/cpp/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["bullseye", "buster", "hirsute", "focal", "bionic", "stretch"],
-	"definitionVersion": "0.203.3",
+	"definitionVersion": "0.203.4",
 	"build": {
 		"latest": "bullseye",
 		"parent": {

--- a/containers/debian/definition-manifest.json
+++ b/containers/debian/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "bullseye",  "stretch"],
-	"definitionVersion": "0.202.4",
+	"definitionVersion": "0.202.5",
 	"build": {
 		"latest": "bullseye",
 		"rootDistro": "debian",

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["6.0-bullseye-slim", "6.0-focal", "5.0-bullseye-slim", "5.0-focal", "3.1-bullseye", "3.1-focal"],
-	"definitionVersion": "0.202.1",
+	"definitionVersion": "0.202.2",
 	"build": {
 		"latest": "6.0-bullseye-slim",
 		"rootDistro": "debian",

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["1.17-bullseye", "1.16-bullseye", "1.17-buster", "1.16-buster"],
-	"definitionVersion": "0.205.2",
+	"definitionVersion": "0.205.3",
 	"build": {
 		"latest": "1.17-bullseye",
 		"rootDistro": "debian",

--- a/containers/java-8/definition-manifest.json
+++ b/containers/java-8/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "bullseye", "buster" ],
-	"definitionVersion": "0.205.0",
+	"definitionVersion": "0.205.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "17-bullseye", "17-buster", "11-bullseye", "11-buster" ],
-	"definitionVersion": "0.205.0",
+	"definitionVersion": "0.205.1",
 	"build": {
 		"latest": "17-bullseye",
 		"rootDistro": "debian",

--- a/containers/javascript-node/definition-manifest.json
+++ b/containers/javascript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["16-bullseye", "14-bullseye", "12-bullseye", "16-buster", "14-buster", "12-buster"],
-	"definitionVersion": "0.203.2",
+	"definitionVersion": "0.203.3",
 	"build": {
 		"latest": "16-buster",
 		"rootDistro": "debian",

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["8.1-apache-bullseye", "8.0-apache-bullseye", "7.4-apache-bullseye", "8.1-apache-buster", "8.0-apache-buster", "7.4-apache-buster" ],
-	"definitionVersion": "0.203.0",
+	"definitionVersion": "0.203.1",
 	"build": {
 		"latest": "8.1-apache-bullseye",
 		"rootDistro": "debian",

--- a/containers/python-3-anaconda/definition-manifest.json
+++ b/containers/python-3-anaconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.202.3",
+	"definitionVersion": "0.202.4",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3-miniconda/definition-manifest.json
+++ b/containers/python-3-miniconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.202.1",
+	"definitionVersion": "0.202.2",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.10-bullseye", "3.9-bullseye", "3.8-bullseye", "3.7-bullseye", "3.6-bullseye", "3.10-buster", "3.9-buster", "3.8-buster", "3.7-buster", "3.6-buster"],
-	"definitionVersion": "0.203.1",
+	"definitionVersion": "0.203.2",
 	"build": {
 		"latest": "3.10-bullseye",
 		"rootDistro": "debian",

--- a/containers/ruby-rails-postgres/.devcontainer/Dockerfile
+++ b/containers/ruby-rails-postgres/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        # Update 'VARIANT' to pick a version of Ruby: 3, 3.0, 2, 2.7, 2.6
+        # Update 'VARIANT' to pick a version of Ruby: 3, 3.1, 3.0, 2, 2.7, 2.6
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: "2-bullseye"

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby-rails/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+			// Update 'VARIANT' to pick a Ruby version: 3, 3.1, 3.0, 2, 2.7, 2.6, 2.5
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
 			"VARIANT": "2-bullseye",

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby-sinatra/.devcontainer/devcontainer.json
+++ b/containers/ruby-sinatra/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6, 2.5
+			// Update 'VARIANT' to pick a Ruby version: 3, 3.1, 3.0, 2, 2.7, 2.6, 2.5
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
 			"VARIANT": "2-bullseye",

--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=2-bullseye
 FROM ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.0, 2, 2.7, 2.6
+			// Update 'VARIANT' to pick a Ruby version: 3, 3.1, 3.0, 2, 2.7, 2.6
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
 			"VARIANT": "3-bullseye",

--- a/containers/ruby/README.md
+++ b/containers/ruby/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/ruby |
-| *Available image variants* | 3 / 3-bullseye, 3.0 / 3.0-bullseye, 2 / 2-bullseye, 2.7 / 2.7-bullseye, 2.6 / 2.7-bullseye, 3-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
+| *Available image variants* | 3 / 3-bullseye, 3.1 / 3.1-bullseye, 3.0 / 3.0-bullseye, 2 / 2-bullseye, 2.7 / 2.7-bullseye, 2.6 / 2.7-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -32,6 +32,7 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 
 - `mcr.microsoft.com/vscode/devcontainers/ruby` (latest)
 - `mcr.microsoft.com/vscode/devcontainers/ruby:3` (or `3-bullseye`, `3-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:3.1` (or `3.1-bullseye`, `3.1-buster` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/ruby:3.0` (or `3.0-bullseye`, `3.0-buster` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2` (or `2-bullseye`, `2-buster` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2.7` (or `2.7-bullseye`, `2.7-buster` to pin to an OS version)
@@ -40,8 +41,8 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
 - `mcr.microsoft.com/vscode/devcontainers/ruby:0-3` (or `0-3-bullseye`, `0-3-buster` to pin to an OS version)
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0.202-3` (or `0.202-3-bullseye`, `0.202-3-buster` to pin to an OS version)
-- `mcr.microsoft.com/vscode/devcontainers/ruby:0.202.0-3` (or `0.202.0-3-bullseye`, `0.202.0-3-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.203-3` (or `0.202-3-bullseye`, `0.202-3-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/ruby:0.203.0-3` (or `0.202.0-3-bullseye`, `0.202.0-3-buster` to pin to an OS version)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-2.7`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,13 +1,15 @@
 {
-	"variants": ["3.0-bullseye", "2.7-bullseye", "2.6-bullseye","3.0-buster", "2.7-buster", "2.6-buster"],
-	"definitionVersion": "0.202.2",
+	"variants": ["3.1-bullseye", "3.0-bullseye", "2.7-bullseye", "2.6-bullseye", "3.1-buster", "3.0-buster", "2.7-buster", "2.6-buster"],
+	"definitionVersion": "0.203.0",
 	"build": {
 		"latest": "3.0-bullseye",
 		"rootDistro": "debian",
 		"architectures": {
+			"3.1-bullseye": ["linux/amd64", "linux/arm64"],
 			"3.0-bullseye": ["linux/amd64", "linux/arm64"],
 			"2.7-bullseye": ["linux/amd64", "linux/arm64"],
 			"2.6-bullseye": ["linux/amd64", "linux/arm64"],
+			"3.1-buster": ["linux/amd64"],
 			"3.0-buster": ["linux/amd64"],
 			"2.7-buster": ["linux/amd64"],
 			"2.6-buster": ["linux/amd64"]
@@ -16,11 +18,14 @@
 			"ruby:${VERSION}-${VARIANT}"
 		],
 		"variantTags": {
-			"3.0-bullseye": [ 
+			"3.1-bullseye": [ 
 				"ruby:${VERSION}-3",
-				"ruby:${VERSION}-3.0",
+				"ruby:${VERSION}-3.1",
 				"ruby:${VERSION}-3-bullseye",
 				"ruby:${VERSION}-bullseye"
+			],
+			"3.0-bullseye": [ 
+				"ruby:${VERSION}-3.0"
 			],
 			"2.7-bullseye": [ 
 				"ruby:${VERSION}-2",
@@ -28,7 +33,7 @@
 				"ruby:${VERSION}-2-bullseye"
 			 ],
 			"2.6-bullseye": [ "ruby:${VERSION}-2.6" ],
-			"3.0-buster": [ 
+			"3.1-buster": [ 
 				"ruby:${VERSION}-3-buster",
 				"ruby:${VERSION}-buster"
 			],

--- a/containers/rust/definition-manifest.json
+++ b/containers/rust/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["buster", "bullseye"],
-	"definitionVersion": "0.201.2",
+	"definitionVersion": "0.201.4",
 	"build": {
 		"latest": "buster",
 		"rootDistro": "debian",

--- a/containers/typescript-node/definition-manifest.json
+++ b/containers/typescript-node/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["16-bullseye", "14-bullseye", "12-bullseye", "16-buster", "14-buster", "12-buster"],
-	"definitionVersion": "0.203.2",
+	"definitionVersion": "0.203.3",
 	"build": {
 		"latest": "16-buster",
 		"rootDistro": "debian",

--- a/containers/ubuntu/definition-manifest.json
+++ b/containers/ubuntu/definition-manifest.json
@@ -1,6 +1,6 @@
 {
-	"variants": ["hirsute", "focal", "bionic"],
-	"definitionVersion": "0.202.3",
+	"variants": ["impish", "focal", "bionic"],
+	"definitionVersion": "0.202.1",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",


### PR DESCRIPTION
This PR implements #1226 and bumps up other version number to pick up the latest break fix updates.