### PR TITLE
Remove "RUN go get" from DockerFile in Go-Postgres container

### DIFF
--- a/containers/go-postgres/.devcontainer/Dockerfile
+++ b/containers/go-postgres/.devcontainer/Dockerfile
@@ -10,10 +10,10 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
-# [Optional] Add more packages to the below lines to use go get to install anything else you need
-USER vscode
-RUN go get -x github.com/lib/pq
-USER root
+# [Optional] Uncomment the next lines to use go get to install anything else you need
+# USER vscode
+# RUN go get -x <your-dependency-or-tool>
+# USER root
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/containers/go-postgres/test-project/go.mod
+++ b/containers/go-postgres/test-project/go.mod
@@ -1,0 +1,5 @@
+module test-project
+
+go 1.17
+
+require github.com/lib/pq v1.10.4

--- a/containers/go-postgres/test-project/go.sum
+++ b/containers/go-postgres/test-project/go.sum
@@ -1,0 +1,2 @@
+github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
+github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=


### PR DESCRIPTION
#920, and follow-up to [PR 1239](https://github.com/microsoft/vscode-dev-containers/pull/1239)


## Description

---
This PR updates the [go-postgress](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/go-postgres) container:
- Removes the need to have `RUN go get ...` called in the _DockerFile_
- Adds _go.mod_ and _go.sum_ to the _test-project_ folder, to keep the CI _test.sh_ script, and _F5-debug_, working

## PR Checklist

---
> Use the check-list below to ensure your branch is ready for PR.  If the item is not applicable, leave it blank.

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
- [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
- [x] I have checked to ensure there aren't other open Pull Requests for the same update/change.

## Does this introduce a breaking change?

---
- [ ] Yes
- [X] No

> If this introduces a breaking change, please describe the impact and migration path for existing applications below.

## Testing

---
After the changes, verified that:
- `test-project/test.sh` runs as expected
- `F5-debug` works as expected


## Other information or known dependencies

---

The _go.mod_ and _go.sum_ files intentionally added to _test-project_ folder.
