### PR TITLE
Add Java 11 & MariaDB Definition

### DIFF
--- a/containers/java-11-mariadb/.devcontainer/Dockerfile
+++ b/containers/java-11-mariadb/.devcontainer/Dockerfile
@@ -1,0 +1,36 @@
+# Note: You can use any Debian/Ubuntu based image you want. 
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-bullseye
+
+# [Option] Install zsh
+ARG INSTALL_ZSH="true"
+# [Option] Upgrade OS packages to their latest versions
+ARG UPGRADE_PACKAGES="false"
+# [Option] Enable non-root Docker access in container
+ARG ENABLE_NONROOT_DOCKER="true"
+# [Option] Use the OSS Moby CLI instead of the licensed Docker CLI
+ARG USE_MOBY="true"
+
+# Enable new "BUILDKIT" mode for Docker CLI
+ENV DOCKER_BUILDKIT=1
+
+# Install needed packages and setup non-root user. Use a separate RUN statement to add your
+# own dependencies. A user of "automatic" attempts to reuse an user ID if one already exists.
+ARG USERNAME=automatic
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+COPY library-scripts/*.sh /tmp/library-scripts/
+RUN apt-get update \
+    && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
+    # Use Docker script from script library to set things up
+    && /bin/bash /tmp/library-scripts/docker-debian.sh "${ENABLE_NONROOT_DOCKER}" "/var/run/docker-host.sock" "/var/run/docker.sock" "${USERNAME}" \
+    # Clean up
+    && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts/
+
+# Setting the ENTRYPOINT to docker-init.sh will configure non-root access 
+# to the Docker socket. The script will also execute CMD as needed.
+ENTRYPOINT [ "/usr/local/share/docker-init.sh" ]
+CMD [ "sleep", "infinity" ]
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+     && apt-get -y install --no-install-recommends mariadb-client

--- a/containers/java-11-mariadb/.devcontainer/devcontainer.json
+++ b/containers/java-11-mariadb/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"ms-azuretools.vscode-docker",
+		"vscjava.vscode-java-pack",
 		"vscjava.vscode-java-debug",
 		"vscjava.vscode-java-dependency",
 		"mtxr.sqltools"

--- a/containers/java-11-mariadb/.devcontainer/devcontainer.json
+++ b/containers/java-11-mariadb/.devcontainer/devcontainer.json
@@ -10,6 +10,9 @@
 	"remoteEnv": {
 		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
 		"MYSQL_HOST": "mariadb", // Your application should pull the MYSQL_HOST environment variable to use the MariaDB service
+		"MYSQL_USER": "app_user",
+		"MYSQL_PASSWORD": "app_password",
+		"MYSQL_DATABASE": "app_db_name",
 	},
 	
 	// Set *default* container specific settings.json values on container create.

--- a/containers/java-11-mariadb/.devcontainer/devcontainer.json
+++ b/containers/java-11-mariadb/.devcontainer/devcontainer.json
@@ -13,6 +13,7 @@
 		"MYSQL_USER": "app_user",
 		"MYSQL_PASSWORD": "app_password",
 		"MYSQL_DATABASE": "app_db_name",
+		"MYSQL_PORT": "3306",
 	},
 	
 	// Set *default* container specific settings.json values on container create.

--- a/containers/java-11-mariadb/.devcontainer/devcontainer.json
+++ b/containers/java-11-mariadb/.devcontainer/devcontainer.json
@@ -1,0 +1,39 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.209.6/containers/docker-from-docker-compose
+{
+	"name": "Java 11 & MariaDB (Docker-Compose)",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+
+	// Use this environment variable if you need to bind mount your local source code into a new container.
+	"remoteEnv": {
+		"LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+		"MYSQL_HOST": "mariadb", // Your application should pull the MYSQL_HOST environment variable to use the MariaDB service
+	},
+	
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"vscjava.vscode-java-debug",
+		"vscjava.vscode-java-dependency",
+		"mtxr.sqltools"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "docker --version",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode",
+	"features": {
+		"java": "11",
+		"docker-in-docker": "latest",
+		"maven": "latest"
+	}
+}

--- a/containers/java-11-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/java-11-mariadb/.devcontainer/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3'
+
+services:
+  mariadb:
+          image: mariadb:latest
+          expose:
+              # Expose mariadb port to app service (Access as hostname "mariadb" from within app container)
+              - "3306"
+          # Uncomment to allow access to mariadb from external tools
+          ports:
+               - "3306:3306"
+          environment:
+            MYSQL_ROOT_PASSWORD: root_password
+            MYSQL_DATABASE: app_db_name
+            MYSQL_USER: app_user
+            MYSQL_PASSWORD: app_password
+  app:
+    depends_on:
+      - mariadb
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        UPGRADE_PACKAGES: "true"
+
+    volumes:
+      # Forwards the local Docker socket to the container.
+      - /var/run/docker.sock:/var/run/docker-host.sock
+      # Update this to wherever you want VS Code to mount the folder of your project
+      - ..:/workspace:cached
+
+    # Overrides default command so things don't shut down after the process ends.
+    entrypoint: /usr/local/share/docker-init.sh
+    command: sleep infinity
+    # Uncomment the next four lines if you will use a ptrace-based debuggers like C++, Go, and Rust.
+    # cap_add:
+    #  - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+    # Uncomment the next line to use a non-root user for all processes.
+    # user: vscode
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # (Adding the "ports" property to this file will not forward from a Codespace.)

--- a/containers/java-11-mariadb/.devcontainer/docker-compose.yml
+++ b/containers/java-11-mariadb/.devcontainer/docker-compose.yml
@@ -14,6 +14,8 @@ services:
             MYSQL_DATABASE: app_db_name
             MYSQL_USER: app_user
             MYSQL_PASSWORD: app_password
+            MYSQL_TCP_PORT: 3306
+            MYSQL_UNIX_PORT: 3306
   app:
     depends_on:
       - mariadb

--- a/containers/java-11-mariadb/.vscode/settings.json
+++ b/containers/java-11-mariadb/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "sqltools.connections": [
+        {
+            "database": "app_db",
+            "dialect": "MariaDB",
+            "name": "MariaDB Docker-Compose Service",
+            "password": "root_password",
+            "port": 3306,
+            "server": "mariadb",
+            "username": "root"
+        }
+    ]
+}

--- a/containers/java-11-mariadb/README.md
+++ b/containers/java-11-mariadb/README.md
@@ -1,0 +1,57 @@
+# Java 11 & MariaDB
+
+## Summary
+
+Develop Java 11 based applications with MariaDB (MySQL Compatible).  Includes necessary extensions and tools for both Java 11 and Mariadb.
+| Metadata | Value |  
+|----------|-------|
+| *Contributors* | Nathaniel Suchy [https://github.com/irlcatgirl](https://github.com/irlcatgirl), Richard Morrill [github.com/ThoolooExpress](https://github.com/ThoolooExpress) |
+| *Definition type* | Docker Compose |
+| *Languages, platforms* | Java 11, MariaDB (MySQL Compatible) |
+
+## Description
+
+This definition creates two containers, one for Java 11 and one for MariaDB.  Code will attach to the Java container, and from within that container the
+MariaDB container will be availible with the hostname `mariadb`.  The MariaDB instance can be managed via the automatically installed SQLTools extension,
+or from the container's command line with
+
+```$ mariadb -h mariadb -u root -p```
+
+the password is defined by default as `root_password`, and if desired this may be changed in docker-compose.yml.
+
+## Using this definition with an existing folder
+
+Just follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+
+2. To use VS Code's copy of this definition:
+   1. Start VS Code and open your project folder.
+   2. Press <kbd>F1</kbd> select and **Remote-Containers: Add Development Container Configuration Files...** from the command palette.
+   3. Select the Java 11 & Mariadb definition.
+
+3. To use latest-and-greatest copy of this definition from the repository:
+   1. Clone this repository.
+   2. Copy the contents of this folder in the cloned repository to the root of your project folder.
+   3. Start VS Code and open your project folder.
+
+4. After following step 2 or 3, the contents of the `.devcontainer` folder in your project can be adapted to meet your needs.
+
+5. Finally, press <kbd>F1</kbd> and run **Remote-Containers: Reopen Folder in Container** to start using the definition.
+
+## Testing the definition
+
+This definition includes some test code that will help you verify it is working as expected on your system. Follow these steps:
+
+1. If this is your first time using a development container, please follow the [getting started steps](https://aka.ms/vscode-remote/containers/getting-started) to set up your machine.
+2. Clone this repository.
+3. Start VS Code, press <kbd>F1</kbd>, and select **Remote-Containers: Open Folder in Container...**
+4. Select this folder from the cloned repository.
+5. Run the script `test-project/test.sh`
+
+
+## License
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Licensed under the MIT License. See [LICENSE](https://github.com/Microsoft/vscode-dev-containers/blob/master/LICENSE).

--- a/containers/java-11-mariadb/test-project/test.sh
+++ b/containers/java-11-mariadb/test-project/test.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+cd $(dirname "$0")
+
+# -- Utility functions --
+if [ -z $HOME ]; then
+    HOME="/root"
+fi
+
+FAILED=()
+
+check() {
+    LABEL=$1
+    shift
+    echo -e "\n🧪  Testing $LABEL: $@"
+    if $@; then 
+        echo "🏆  Passed!"
+    else
+        echo "💥  $LABEL check failed."
+        FAILED+=("$LABEL")
+    fi
+}
+
+checkMultiple() {
+    PASSED=0
+    LABEL="$1"
+    shift; MINIMUMPASSED=$1
+    shift; EXPRESSION="$1"
+    while [ "$EXPRESSION" != "" ]; do
+        if $EXPRESSION; then ((PASSED++)); fi
+        shift; EXPRESSION=$1
+    done
+    check "$LABEL" [ $PASSED -ge $MINIMUMPASSED ]
+}
+
+checkExtension() {
+    checkMultiple "$1" 1 "[ -d ""$HOME/.vscode-server/extensions/$1*"" ]" "[ -d ""$HOME/.vscode-server-insiders/extensions/$1*"" ]" "[ -d ""$HOME/.vscode-test-server/extensions/$1*"" ]"
+}
+
+# -- Actual tests - add more here --
+checkMultiple "vscode-server" 1 "[ -d ""$HOME/.vscode-server/bin"" ]" "[ -d ""$HOME/.vscode-server-insiders/bin"" ]" "[ -d ""$HOME/.vscode-test-server/bin"" ]"
+check "non-root-user" "id vscode"
+check "/home/vscode" [ -d "/home/vscode" ]
+check "sudo" sudo -u vscode echo "sudo works."
+check "git" git --version
+check "command-line-tools" which top ip lsb_release
+check "java" java --version
+check "mariadb" mariadb -h mariadb -P 3306 -u root --password=root_password -Bse exit
+
+# -- Report results --
+if [ ${#FAILED[@]} -ne 0 ]; then
+    echo -e "\n💥  Failed tests: ${FAILED[@]}"
+    exit 1
+else 
+    echo -e "\n💯  All passed!"
+    exit 0
+fi


### PR DESCRIPTION
This pull request adds a Java 11 & MariaDB Definition. It is adapted from https://github.com/microsoft/vscode-dev-containers/pull/292 (which was made for PHP) and works similarly.

This was tested with a private Java 11 Spring Boot Application with no modifications necessary. As long as you have the MariaDB Driver and pull MYSQL_HOST as the environment variable for your hostname this should work out of the box.

I appreciate any feedback maintainers are able to give me.