### PR TITLE
Remove forced "--init" in features to not consume PID 1

### DIFF
--- a/script-library/container-features/src/devcontainer-features.json
+++ b/script-library/container-features/src/devcontainer-features.json
@@ -21,7 +21,6 @@
 			"buildArg": "_VSC_INSTALL_DOCKER_IN_DOCKER",
 			"entrypoint": "/usr/local/share/docker-init.sh",
 			"privileged": true,
-			"init": true,
 			"containerEnv": {
 				"DOCKER_BUILDKIT": "1"
 			},
@@ -76,7 +75,6 @@
 			},
 			"buildArg": "_VSC_INSTALL_DOCKER_FROM_DOCKER",
 			"entrypoint": "/usr/local/share/docker-init.sh",
-			"init": true,
 			"containerEnv": {
 				"DOCKER_BUILDKIT": "1"
 			},
@@ -138,7 +136,6 @@
 					"description": "Select or enter a Minikube version to install"
 				}
 			},
-			"init": true,
 			"buildArg": "_VSC_INSTALL_KUBECTL_HELM_MINIKUBE",
 			"extensions": [
 				"ms-kubernetes-tools.vscode-kubernetes-tools"

--- a/script-library/docs/desktop-lite.md
+++ b/script-library/docs/desktop-lite.md
@@ -52,15 +52,13 @@ You can use this script for your primary dev container by adding it to the `feat
 }
 ```
 
-If you have already built your development container, run the **Rebuild Container** command from the command palette (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>) to pick up the change.
-
-If you run into applications crashing, you may need to increase the size of the shared memory space. For example, this will bump it up to 1 GB in `devcontainer.json`:
+If you run into applications crashing, you may need to increase the size of the shared memory space. For example, this will bump it up to 1 GB in `devcontainer.json` when you are referencing an image or Dockerfile:
 
 ```json
 "runArgs": ["--shm-size=1g"]
 ```
 
-Or using Docker Compose:
+Or when using Docker Compose:
 
 ```yaml
 services:
@@ -69,6 +67,24 @@ services:
     shm_size: '1gb'
     # ...
 ```
+
+**[Optional]** You may also want to enable the [tini init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to handle signals and clean up [Zombie processes](https://en.wikipedia.org/wiki/Zombie_process) if you do not have an alternative set up. To enable it, add the following to `devcontainer.json` if you are referencing an image or Dockerfile:
+
+```json
+"runArgs": ["--init"]
+```
+
+Or when using Docker Compose:
+
+```yaml
+services:
+  your-service-here:
+    # ...
+    init: true
+    # ...
+```
+
+If you have already built your development container, run the **Rebuild Container** command from the command palette (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>) to pick up the change.
 
 ### Script use
 
@@ -109,7 +125,7 @@ services:
       init: true
     ```
 
-    The `runArgs` / Docker Compose setting allows the container to take advantage of an [init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to handle application and process signals in a desktop environment.
+    The `runArgs` / Docker Compose setting allows the container to take advantage of an [init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to handle application and process signals in a desktop environment. However, this is optional.
 
 4. [Optional] If you run into applications crashing, you may need to increase the size of the shared memory space. For example, this will bump it up to 1 GB in `devcontainer.json`:
 

--- a/script-library/docs/docker-in-docker.md
+++ b/script-library/docs/docker-in-docker.md
@@ -52,6 +52,22 @@ You can use this script for your primary dev container by adding it to the `feat
 }
 ```
 
+**[Optional]** You may also want to enable the [tini init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to handle signals and clean up [Zombie processes](https://en.wikipedia.org/wiki/Zombie_process) if you do not have an alternative set up. To enable it, add the following to `devcontainer.json` if you are referencing an image or Dockerfile:
+
+```json
+"runArgs": ["--init"]
+```
+
+Or when using Docker Compose:
+
+```yaml
+services:
+  your-service-here:
+    # ...
+    init: true
+    # ...
+```
+
 If you have already built your development container, run the **Rebuild Container** command from the command palette (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>) to pick up the change.
 
 ### Script use
@@ -93,7 +109,7 @@ See the [`docker-in-docker`](../../containers/docker-in-docker) definition for a
 
     The `dind-var-lib-docker` volume mount is optional but will ensure that containers / volumes you create within the dev container survive a rebuild. You should update `dind-var-lib-docker` with a unique name for your container to avoid corruption when multiple containers write to it at the same time.
 
-    While technically optional, `--init` enables an [init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to properly handle signals and ensure [Zombie Processes](https://en.wikipedia.org/wiki/Zombie_process) are cleaned up. 
+    While technically optional, `--init` enables the [tini init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to properly handle signals and ensure [Zombie Processes](https://en.wikipedia.org/wiki/Zombie_process) are cleaned up. 
 
 4. If you want any containers or volumes you create inside the container to survive it being deleted, you can use a "named volume". And the following to `.devcontainer/devcontainer.json` if you are referencing an image or Dockerfile replacing `dind-var-lib-docker` with a unique name for your container:
 

--- a/script-library/docs/docker.md
+++ b/script-library/docs/docker.md
@@ -55,6 +55,22 @@ You can use this script for your primary dev container by adding it to the `feat
 }
 ```
 
+**[Optional]** You may also want to enable the [tini init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to handle signals and clean up [Zombie processes](https://en.wikipedia.org/wiki/Zombie_process) if you do not have an alternative set up. To enable it, add the following to `devcontainer.json` if you are referencing an image or Dockerfile:
+
+```json
+"runArgs": ["--init"]
+```
+
+Or when using Docker Compose:
+
+```yaml
+services:
+  your-service-here:
+    # ...
+    init: true
+    # ...
+```
+
 If you have already built your development container, run the **Rebuild Container** command from the command palette (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>) to pick up the change.
 
 ### Script use
@@ -98,7 +114,7 @@ See the [`docker-from-docker`](../../containers/docker-from-docker) and [`docker
         - /var/run/docker.sock:/var/run/docker-host.sock
     ```
 
-    While technically optional, `--init` enables an [init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to properly handle signals and ensure [Zombie Processes](https://en.wikipedia.org/wiki/Zombie_process) are cleaned up.
+    While technically optional, `--init` enables the [tini init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to properly handle signals and ensure [Zombie Processes](https://en.wikipedia.org/wiki/Zombie_process) are cleaned up.
 
 4. If you are running the container as something other than root (either via `USER` in your Dockerfile or `containerUser`), you'll need to ensure that the user has `sudo` access. (If you run the container as root and just reference the user in `remoteUser` you will not have this problem, so this is recommended instead.) The [`debian-common.sh`](common.md) script can do this for you, or you [set one up yourself](https://aka.ms/vscode-remote/containers/non-root).
 

--- a/script-library/docs/kubectl-helm.md
+++ b/script-library/docs/kubectl-helm.md
@@ -52,6 +52,22 @@ You can use this script for your primary dev container by adding it to the `feat
 }
 ```
 
+**[Optional]** You may also want to enable the [tini init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to handle signals and clean up [Zombie processes](https://en.wikipedia.org/wiki/Zombie_process) if you do not have an alternative set up. To enable it, add the following to `devcontainer.json` if you are referencing an image or Dockerfile:
+
+```json
+"runArgs": ["--init"]
+```
+
+Or when using Docker Compose:
+
+```yaml
+services:
+  your-service-here:
+    # ...
+    init: true
+    # ...
+```
+
 If you have already built your development container, run the **Rebuild Container** command from the command palette (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>) to pick up the change.
 
 ### Script use
@@ -73,6 +89,23 @@ Usage:
     COPY library-scripts/kubectl-helm-debian.sh /tmp/library-scripts/
     RUN apt-get update && bash /tmp/library-scripts/kubectl-helm-debian.sh latest latest latest
     ```
+
+3. **[Optional]** You may also want to enable the [tini init process](https://docs.docker.com/engine/reference/run/#specify-an-init-process) to properly handle signals and ensure [Zombie Processes](https://en.wikipedia.org/wiki/Zombie_process) are cleaned up if you do not have an alternative set up. To do so, add the following to `.devcontainer/devcontainer.json` if you are referencing an image or Dockerfile:
+
+    ```json
+    "runArgs": ["--init"]
+    ```
+
+    Or if you are referencing a Docker Compose file, add this to your `docker-compose.yml` file instead:
+    
+    ```yaml
+    your-service-name-here:
+      # ...
+      init: true
+      # ...
+    ```
+
+    While technically optional, `
 
 3. You may also want to install Docker using the [docker-in-docker](docker-in-docker.md) or [docker-from-docker](docker.md) scripts.
 


### PR DESCRIPTION
A few of features enable the "tini" init process to help clean up zombie processes. While this is generally a good idea, it will conflict with the use of alternate init systems if added to a base image.

This PR moves this to a doc recommendation instead.