### PR TITLE
trim minor version from VERSION_ID

### DIFF
--- a/script-library/docker-redhat.sh
+++ b/script-library/docker-redhat.sh
@@ -102,7 +102,7 @@ else
             exit
         fi
     else
-        RHEL_COMPAT_VER=$VERSION_ID
+        RHEL_COMPAT_VER=${VERSION_ID%%.*}
     fi
 fi
 


### PR DESCRIPTION
If using alternative distro, such as Rocky Linux, VERSION_ID prints out as "8.5" (depending on current minor version), which won't work well for most enterprise-linux repositories that use only major release version "8".
Here I simply trim out everything that comes after the dot, resulting in VERSION_ID=8, or in this case, RHEL_COMPAT_VER