### PR TITLE
Implement fallback logic for go script

### DIFF
--- a/script-library/go-debian.sh
+++ b/script-library/go-debian.sh
@@ -164,8 +164,28 @@ if [ "${TARGET_GO_VERSION}" != "none" ] && ! type go > /dev/null 2>&1; then
     curl -sSL -o /tmp/tmp-gnupg/golang_key "${GO_GPG_KEY_URI}"
     gpg -q --import /tmp/tmp-gnupg/golang_key
     echo "Downloading Go ${TARGET_GO_VERSION}..."
-    curl -sSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz"
-    curl -sSL -o /tmp/go.tar.gz.asc "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz.asc"
+    set +e
+    curl -fsSL -o /tmp/go.tar.gz https://golang.org/dl/go1.177.linux-amd64.tar.gz
+    set -e
+    if [ ! -s "/tmp/go.tar.gz" ] || [ "$?" != "0" ]; then
+        echo "(!) Download failed."
+        # Try one break fix version number less if we get a failure
+        major="$(echo "${TARGET_GO_VERSION}" | grep -oE '^[0-9]+')"
+        minor="$(echo "${TARGET_GO_VERSION}" | grep -oP '^[0-9]+\.\K[0-9]+')"
+        breakfix="$(echo "${TARGET_GO_VERSION}" | grep -oP '^[0-9]+\.[0-9]+\.\K[0-9]+' 2>/dev/null)"
+        if [ "${breakfix}" = "" ] || [ "${breakfix}" = "0" ]; then
+            ((minor=minor-1))
+            TARGET_GO_VERSION="${major}.${minor}"
+            find_version_from_git_tags TARGET_GO_VERSION "https://go.googlesource.com/go" "tags/go" "." "true"
+        else 
+            ((breakfix=breakfix-1))
+           TARGET_GO_VERSION="${major}.${minor}.${breakfix}"
+        fi
+        echo "Trying ${TARGET_GO_VERSION}..."
+        curl -fsSL -o /tmp/go.tar.gz "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz"
+    fi
+    set -e
+    curl -fsSL -o /tmp/go.tar.gz.asc "https://golang.org/dl/go${TARGET_GO_VERSION}.linux-${architecture}.tar.gz.asc"
     gpg --verify /tmp/go.tar.gz.asc /tmp/go.tar.gz
     echo "Extracting Go ${TARGET_GO_VERSION}..."
     tar -xzf /tmp/go.tar.gz -C "${TARGET_GOROOT}" --strip-components=1
@@ -207,9 +227,15 @@ if [ "${INSTALL_GO_TOOLS}" = "true" ]; then
     # Move Go tools into path and clean up
     mv /tmp/gotools/bin/* ${TARGET_GOPATH}/bin/
 
-    # install dlv-dap (dlv@master)
+    # install dlv-dap (dlv@master) - but do not exit on failure
+    set +e
     go ${go_install_command} -v github.com/go-delve/delve/cmd/dlv@master 2>&1 | tee -a /usr/local/etc/vscode-dev-containers/go.log
-    mv /tmp/gotools/bin/dlv ${TARGET_GOPATH}/bin/dlv-dap
+    set -e
+    if [ -e "/tmp/gotools/bin/dlv" ]; then
+        mv /tmp/gotools/bin/dlv ${TARGET_GOPATH}/bin/dlv-dap
+    else
+        echo "(*) Failed to install github.com/go-delve/delve/cmd/dlv@master. Skipping."
+    fi
 
     rm -rf /tmp/gotools
 fi


### PR DESCRIPTION
Resolves #1300 and #1301 by decrementing the version number and trying again if we get a failure when downloading. It also skips installing dlv-dsp if it fails to build given this has happened twice.