### PR TITLE
[Static Web Apps] Fix Node.js and Core Tools version mismatch

### DIFF
--- a/containers/azure-static-web-apps/.devcontainer/Dockerfile
+++ b/containers/azure-static-web-apps/.devcontainer/Dockerfile
@@ -14,7 +14,7 @@ ENV NVM_DIR="/usr/local/share/nvm" \
 RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1" \
     && su vscode -c "umask 0002 && npm install --cache /tmp/empty-cache -g @azure/static-web-apps-cli" \
-    && apt-get install -y "azure-functions-core-tools-${CORE_TOOLS_VERSION}" \
+    && if [ $CORE_TOOLS_VERSION != "4" ]; then apt-get remove -y azure-functions-core-tools-4 && apt-get update && apt-get install -y "azure-functions-core-tools-${CORE_TOOLS_VERSION}"; fi \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/azure-static-web-apps/.devcontainer/Dockerfile
+++ b/containers/azure-static-web-apps/.devcontainer/Dockerfile
@@ -1,18 +1,20 @@
-# Find the Dockerfile for mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools at this URL
-# https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/python/python38/python38-core-tools.Dockerfile
-FROM mcr.microsoft.com/azure-functions/python:3.0-python3.8-core-tools
+# Find the Dockerfile at this URL
+# https://github.com/Azure/azure-functions-docker/blob/dev/host/4/bullseye/amd64/python/python39/python39-core-tools.Dockerfile
+FROM mcr.microsoft.com/azure-functions/python:4-python3.9-core-tools
 
 # Copy library scripts to execute
 COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/
 
-# Install Node.js and Azure Static Web Apps CLI
-ARG NODE_VERSION="lts/*"
+# Install Node.js, Azure Static Web Apps CLI and Azure Functions Core Tools
+ARG NODE_VERSION="16"
+ARG CORE_TOOLS_VERSION="4"
 ENV NVM_DIR="/usr/local/share/nvm" \
     NVM_SYMLINK_CURRENT=true \
     PATH="${NVM_DIR}/current/bin:${PATH}"
 RUN bash /tmp/library-scripts/node-debian.sh "${NVM_DIR}" "${NODE_VERSION}" "${USERNAME}" \
     && su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1" \
     && su vscode -c "umask 0002 && npm install --cache /tmp/empty-cache -g @azure/static-web-apps-cli" \
+    && apt-get install -y "azure-functions-core-tools-${CORE_TOOLS_VERSION}" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/azure-static-web-apps/.devcontainer/devcontainer.json
+++ b/containers/azure-static-web-apps/.devcontainer/devcontainer.json
@@ -3,8 +3,10 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Options
-			"NODE_VERSION": "lts/*"
+			// Please look at runtime version support to make sure you're using compatible versions
+			// https://docs.microsoft.com/en-us/azure/azure-functions/supported-languages#languages-by-runtime-version
+			"NODE_VERSION": "16",
+			"CORE_TOOLS_VERSION": "4"
 		}
 	},
 	"forwardPorts": [ 7071, 4280 ],


### PR DESCRIPTION
This PR brings a few changes:

- It updates the base image to `mcr.microsoft.com/azure-functions/python:4-python3.9-core-tools`, updating Python/Core Tools versions and allowing support for M1 macs
- It changes the default Node.js version to 16 instead of LTS to avoid unwanted upgrades and mismatch with core tools version
- It adds a `CORE_TOOLS_VERSION` param to allow switching to a different core tools version that the default one, for example if you wish to use a Node 14 version
- It fixes the mismatch between the previous default Node version (16) and Core Tools (v3) installed in the previous image

Fixes #1306 