### PR TITLE
Fixing two small typos

### DIFF
--- a/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
+++ b/container-templates/dockerfile/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/azure-ansible/.devcontainer/library-scripts/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/azure-bicep/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-bicep/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-cli/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/azure-terraform/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/azure-terraform/.devcontainer/library-scripts/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/bazel/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/bazel/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/codespaces-linux/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/codespaces-linux/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -200,7 +200,7 @@ else
         target_compose_arch="x86_64"
     fi
     if [ "${target_compose_arch}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/dapr-dotnet/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/dapr-dotnet/.devcontainer/library-scripts/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/dapr-javascript-node/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/dapr-javascript-node/.devcontainer/library-scripts/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/dart/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dart/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/debian/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/debian/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/docker-from-docker-compose/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/docker-from-docker-compose/.devcontainer/library-scripts/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/docker-from-docker/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/docker-from-docker/.devcontainer/library-scripts/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/docker-in-docker/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/docker-in-docker/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/docker-in-docker/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/containers/docker-in-docker/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -200,7 +200,7 @@ else
         target_compose_arch="x86_64"
     fi
     if [ "${target_compose_arch}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/dotnet/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/dotnet/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/go/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/go/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/haskell/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/haskell/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/java/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/java/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/javascript-node/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/jupyter-datascience-notebooks/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/jupyter-datascience-notebooks/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/docker-in-docker-debian.sh
+++ b/containers/kubernetes-helm-minikube/.devcontainer/library-scripts/docker-in-docker-debian.sh
@@ -200,7 +200,7 @@ else
         target_compose_arch="x86_64"
     fi
     if [ "${target_compose_arch}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/kubernetes-helm/.devcontainer/library-scripts/docker-debian.sh
+++ b/containers/kubernetes-helm/.devcontainer/library-scripts/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/containers/mit-scheme/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/mit-scheme/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/perl/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/perl/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/php/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/php/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/powershell/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/powershell/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/python-3-pypy/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3-pypy/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/python-3/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/python-3/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/r/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/r/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/ruby/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ruby/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/rust/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/rust/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/swift/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/swift/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
+++ b/containers/ubuntu/.devcontainer/library-scripts/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -289,7 +289,7 @@ set -e
 if [ -d "/run/systemd/system" ]; then
     exec /bin/systemctl/systemctl "$@"
 else
-    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services intead. e.g.: \n\nservice --status-all'
+    echo '\n"systemd" is not running in this container due to its overhead.\nUse the "service" command to start services instead. e.g.: \n\nservice --status-all'
 fi
 EOF
 chmod +x /usr/local/bin/systemctl

--- a/script-library/docker-debian.sh
+++ b/script-library/docker-debian.sh
@@ -188,7 +188,7 @@ else
         TARGET_COMPOSE_ARCH="x86_64"
     fi
     if [ "${TARGET_COMPOSE_ARCH}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv

--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -200,7 +200,7 @@ else
         target_compose_arch="x86_64"
     fi
     if [ "${target_compose_arch}" != "x86_64" ]; then
-        # Use pip to get a version that runns on this architecture
+        # Use pip to get a version that runs on this architecture
         if ! dpkg -s python3-minimal python3-pip libffi-dev python3-venv > /dev/null 2>&1; then
             apt_get_update_if_needed
             apt-get -y install python3-minimal python3-pip libffi-dev python3-venv


### PR DESCRIPTION
`intead -> instead` and `runns -> runs` across all library scripts