### PR TITLE
Default to non-ARM64 stable Ruby 3.1 release

### DIFF
--- a/containers/ruby-rails-postgres/.devcontainer/Dockerfile
+++ b/containers/ruby-rails-postgres/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
-ARG VARIANT=2-bullseye
+ARG VARIANT=3.1-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 # Install Rails

--- a/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
+++ b/containers/ruby-rails-postgres/.devcontainer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         # Update 'VARIANT' to pick a version of Ruby: 3, 3.1, 3.0, 2, 2.7, 2.6
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: "2-bullseye"
+        VARIANT: "3.1-bullseye"
         # Optional Node.js version to install
         NODE_VERSION: "lts/*"
 


### PR DESCRIPTION
There’s only [one minor branch left with official support under Ruby 2.x ](https://www.ruby-lang.org/en/downloads/)(2.7) and it will likely be slated for end of life fairly soon, so it feels odd to default to a version that is 2 release behind latest stable. 

Also unless I’m mistaken Codespaces don’t run on ARM64/Apple Silicon so I’m not sure why bullseye is the default as well.