### PR TITLE
Add dotnet arm64 support

### DIFF
--- a/containers/dotnet-fsharp/README.md
+++ b/containers/dotnet-fsharp/README.md
@@ -9,7 +9,7 @@
 | *Contributors* | The VS Code Team, F# team |
 | *Categories* | Languages |
 | *Definition type* | Dockerfile |
-| *Published image architecture(s)* | x86-64 |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu |

--- a/containers/dotnet-postgres/README.md
+++ b/containers/dotnet-postgres/README.md
@@ -9,7 +9,7 @@
 | *Contributors* | [Berkays](https://github.com/Berkays)  |
 | *Categories* | Core, Languages |
 | *Definition type* | Docker Compose |
-| *Published image architecture(s)* | x86-64 |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 |
 | *Available image variants* | [See C# (.NET) definition](../dotnet). |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |

--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -11,7 +11,7 @@
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/dotnet |
 | *Available image variants* | 3.1 / 3.1-focal, 5.0 / 5.0-focal, 6.0 /6.0-bullseye, 6.0-focal, 5.0-bullseye, 3.1-bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list)) |
-| *Published image architecture(s)* | x86-64 |
+| *Published image architecture(s)* | x86-64, arm64/aarch64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu (`-focal`), Debian (`-bullseye`) |

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -11,7 +11,7 @@
 		"variantTags": {
 			"6.0-focal": [
 				"dotnet:${VERSION}-6.0",
-				"dotnet:${VERSION}-6.0"
+				"dotnetcore:${VERSION}-6.0"
 			],
 			"6.0-bullseye-slim": [
 				"dotnet:${VERSION}-6.0",

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -7,15 +7,12 @@
 		"tags": [
 			"dotnet:${VERSION}-${VARIANT}"
 		],
-		"architectures": {
-			"6.0-focal": ["linux/amd64", "linux/arm64"],
-			"6.0-bullseye-slim": ["linux/amd64", "linux/arm64"],
-			"5.0-focal": ["linux/amd64", "linux/arm64"],
-			"5.0-bullseye-slim": ["linux/amd64", "linux/arm64"],
-			"3.1-focal": ["linux/amd64", "linux/arm64"],
-			"3.1-bullseye": ["linux/amd64", "linux/arm64"]
-		},
+		"architectures": ["linux/amd64", "linux/arm64"],
 		"variantTags": {
+			"6.0-focal": [
+				"dotnet:${VERSION}-6.0",
+				"dotnet:${VERSION}-6.0"
+			],
 			"6.0-bullseye-slim": [
 				"dotnet:${VERSION}-6.0",
 				"dotnet:${VERSION}-6.0-bullseye"

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -7,6 +7,14 @@
 		"tags": [
 			"dotnet:${VERSION}-${VARIANT}"
 		],
+		"architectures": {
+			"6.0-focal": ["linux/amd64", "linux/arm64"],
+			"6.0-bullseye-slim": ["linux/amd64", "linux/arm64"],
+			"5.0-focal": ["linux/amd64", "linux/arm64"],
+			"5.0-bullseye-slim": ["linux/amd64", "linux/arm64"],
+			"3.1-focal": ["linux/amd64", "linux/arm64"],
+			"3.1-bullseye": ["linux/amd64", "linux/arm64"]
+		},
 		"variantTags": {
 			"6.0-bullseye-slim": [
 				"dotnet:${VERSION}-6.0",


### PR DESCRIPTION
#1232  dotnet arm64 support

Description
---
This PR includes:

 - Updated `definition-manifest.json` in the dotnet container to pull both the amd-64 and arm-64 images for all variants
 - Updated dotnet, dotnet-postgres, and dotnet-fsharp `README.md` to reflect new support for arm64

PR Checklist
---
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] My code follows the code style of this project.
- [ ] I ran the lint checks which produced no new errors nor warnings for my changes.
- [X] I have checked to ensure there aren't other open Pull Requests for the same update/change.

Does this introduce a breaking change?
---
- [ ] Yes
- [X] No

Testing
---
- Manual testing that arm64 dotnet image could be used for a dotnet console app
- Manual testing that arm64 dotnet image could be used in conjunction with postgres and with f# to successfully run apps. 

Other information or known dependencies
---
