### PR TITLE
[R] Support for R package pre-installed images and arm64 images

### DIFF
--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -1,18 +1,19 @@
-# R version: 4, 4.1, 4.0
-ARG VARIANT="4"
-FROM rocker/r-ver:${VARIANT}
+# [Choice] R version: 4, 4.1, 4.0
+ARG VARIANT=4
+# [Choice] Base image. Minimal (r-ver), tidyverse installed (tidyverse), or full image (binder): rocker/r-ver, rocker/tidyverse, rocker/binder
+ARG BASE_IMAGE=rocker/r-ver
+FROM ${BASE_IMAGE}:${VARIANT}
 
-# Use the [Option] comment to specify true/false arguments that should appear in VS Code UX
-#
 # [Option] Install zsh
 ARG INSTALL_ZSH="true"
 # [Option] Upgrade OS packages to their latest versions
 ARG UPGRADE_PACKAGES="false"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-ARG USERNAME=vscode
+ARG USERNAME=rstudio
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
+USER root
 COPY library-scripts/*.sh /tmp/library-scripts/
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && /bin/bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
@@ -43,6 +44,21 @@ RUN export TAG=$(git ls-remote --tags --refs --sort='version:refname' https://gi
 # See more details: https://github.com/REditorSupport/vscode-R/wiki/R-Session-watcher
 RUN echo 'source(file.path(Sys.getenv("HOME"), ".vscode-R", "init.R"))' >> ${R_HOME}/etc/Rprofile.site
 
+# [Option] Enable vscode-jupyter support
+ARG ENABLE_JUPYTER="false"
+RUN if [ "${ENABLE_JUPYTER}" = "true" ]; then \
+        if [ -z "$(dpkg --get-selections | grep libzmq3-dev)" ]; then \
+            apt-get update \
+            && export DEBIAN_FRONTEND=noninteractive \
+            && apt-get -y install --no-install-recommends libzmq3-dev \
+            && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/*; \
+        fi \
+        && install2.r --error --skipinstalled --ncpus -1 IRkernel \
+        && rm -rf /tmp/downloaded_packages \
+        && python3 -m pip --no-cache-dir install jupyter \
+        && R --vanilla -s -e 'IRkernel::installspec(user = FALSE)'; \
+    fi
+
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update \
 #     && export DEBIAN_FRONTEND=noninteractive \
@@ -50,11 +66,3 @@ RUN echo 'source(file.path(Sys.getenv("HOME"), ".vscode-R", "init.R"))' >> ${R_H
 
 # [Optional] Uncomment this section to install additional R packages.
 # RUN install2.r --error --skipinstalled --ncpus -1 <your-package-list-here>
-
-# [Optional] Uncomment this section to install vscode-jupyter dependencies.
-# RUN apt-get update \
-#     && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends libzmq3-dev \
-#     && install2.r --error --skipinstalled --ncpus -1 IRkernel \
-#     && python3 -m pip --no-cache-dir install jupyter \
-#     && R --vanilla -s -e 'IRkernel::installspec(user = FALSE)'

--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -24,6 +24,8 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
         libssl-dev \
         libxml2-dev \
         libxt-dev \
+        libfontconfig1-dev \
+        libcairo2-dev \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts \
     && python3 -m pip --no-cache-dir install radian \
     && install2.r --error --skipinstalled --ncpus -1 \

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -24,6 +24,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
+	// For example, if you want to use vscode-jupyter, add "ms-toolsai.jupyter".
 	"extensions": [
 		"ikuyadeu.r",
 		"rdebugger.r-debugger"

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -2,8 +2,15 @@
 	"name": "R (Community)",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update VARIANT to pick a specific R version: 4, 4.1, 4.0
-		"args": { "VARIANT": "4" }
+		"args": {
+			// Update VARIANT to pick a R version: 4, 4.1, 4.0
+			"VARIANT": "4",
+			// Start with a minimal image (rocker/r-ver) or a expanded image.
+			// See more details about rocker/r-ver's derived images: https://github.com/rocker-org/rocker-versioned2
+			"BASE_IMAGE": "rocker/r-ver",
+			// Options
+			"ENABLE_JUPYTER": "false"
+		}
 	},
 
 	// Set *default* container specific settings.json values on container create.
@@ -29,5 +36,5 @@
 	// "postCreateCommand": "R --version",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "rstudio"
 }


### PR DESCRIPTION
Suggested by https://github.com/microsoft/vscode-dev-containers/pull/1314#issuecomment-1049423896.

1. Allows the base image to be changed from the VSCode UI.
  We can choose an image with the tidyverse package installed, which is considered to be in high demand (`rocker/tidyverse`), or a huge image with a large number of R packages and jupyter installed (`rocker/binder`).
2. Since a user `rstudio` exists in `rocker/tidyverse` and `rocker/binder` as a user with UID 1000, change the user name from `vscode` to `rstudio` to match this.
3. Allow the build args to control the installation of jupyter.
4. For arm64 builds (only exist for `rocker/r-ver`), the R packages are source installation, so add the necessary dependency packages in that case (`libfontconfig1-dev` and `libcairo2-dev`).

cc @R-icntay