### PR TITLE
Switch to correct Xdebug port 9003

### DIFF
--- a/containers/php/.devcontainer/base.Dockerfile
+++ b/containers/php/.devcontainer/base.Dockerfile
@@ -17,7 +17,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get -y install --no-install-recommends lynx \
     && usermod -aG www-data ${USERNAME} \
-    && sed -i -e "s/Listen 80/Listen 80\\nListen 8080/g" /etc/apache2/ports.conf \
+    && sed -i -e "s/Listen 80/Listen 8080/g" $APACHE_CONFDIR/ports.conf \
+    && echo "ServerName localhost" >> $APACHE_CONFDIR/apache2.conf \
+    && sed -i -e "s/<VirtualHost \*:80>/<VirtualHost *:8080>/g" $APACHE_CONFDIR/sites-available/000-default.conf \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # Install xdebug
@@ -25,7 +27,7 @@ RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && echo "xdebug.client_port = 9000" >> /usr/local/etc/php/conf.d/xdebug.ini \
+    && echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && rm -rf /tmp/pear
 
 # Install composer

--- a/containers/php/.devcontainer/base.Dockerfile
+++ b/containers/php/.devcontainer/base.Dockerfile
@@ -22,13 +22,14 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && sed -i -e "s/<VirtualHost \*:80>/<VirtualHost *:8080>/g" $APACHE_CONFDIR/sites-available/000-default.conf \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# Install xdebug
+# Install xdebug and set default development config
 RUN yes | pecl install xdebug \
     && echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode = debug" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.start_with_request = yes" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.client_port = 9003" >> /usr/local/etc/php/conf.d/xdebug.ini \
-    && rm -rf /tmp/pear
+    && rm -rf /tmp/pear \
+    && cp "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 
 # Install composer
 RUN curl -sSL https://getcomposer.org/installer | php \

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "PHP",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"args": { 
+		"args": {
 			// Update VARIANT to pick a PHP version: 8, 8.1, 8.0, 7, 7.4
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
@@ -10,25 +10,30 @@
 			"NODE_VERSION": "lts/*"
 		}
 	},
-	
 	// Set *default* container specific settings.json values on container create.
-	"settings": { 
+	"settings": {
 		"php.validate.executablePath": "/usr/local/bin/php"
 	},
-
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"xdebug.php-debug",
 		"bmewburn.vscode-intelephense-client",
 		"mrmlnc.vscode-apache"
 	],
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [8080],
-
+	// Use 'portsAttributes' to control auto forwarding of ports
+	"portsAttributes": {
+		"8080": {
+			"label": "Application",
+			"onAutoForward": "openBrowser",
+			"requireLocalPort": true
+		},
+		"9003": {
+			"label": "PHP Xdebug",
+			"onAutoForward": "ignore"
+		}
+	},
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
-
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -25,7 +25,6 @@
 		"8080": {
 			"label": "Application",
 			"onAutoForward": "openBrowser",
-			"requireLocalPort": true
 		},
 		"9003": {
 			"label": "PHP Xdebug",

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 	"portsAttributes": {
 		"8080": {
 			"label": "Application",
-			"onAutoForward": "openBrowser",
+			"onAutoForward": "notify",
 		},
 		"9003": {
 			"label": "PHP Xdebug",

--- a/containers/php/.devcontainer/devcontainer.json
+++ b/containers/php/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 	"portsAttributes": {
 		"8080": {
 			"label": "Application",
-			"onAutoForward": "notify",
+			"onAutoForward": "notify"
 		},
 		"9003": {
 			"label": "PHP Xdebug",

--- a/containers/php/.vscode/launch.json
+++ b/containers/php/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "program": "${workspaceFolder}/test-project/main.php",
             "cwd": "${workspaceFolder}/test-project",
-            "port": 9000
+            "port": 9003
         }
     ]
 }


### PR DESCRIPTION
Xdebug was hard to use with the existing setup.  This switches a few configuration items to make it easier to use the debugger.

- Port 80 and 8080 was causing confusion especially when auto-forwarding the ports and opening browsers automatically.
- Port 9003 was offering to auto-forward.  This never needs to forward as the VS Code debugger runs on localhost in the container.
- XDebug is on 9003 with the new version.  Using 9000 is just begging for confusion.
- Apache is always complaining about the ServerName so localhost is set as the default.
- The Apache VirtualHost is set to the same port as the main configuration.  This not matching caused side effects.

Also, regarding #1052, I use this setup with the VS Code debugger running whenever I call PHP directly or via Apache so I don't get the warning.