### PR TITLE
vscode-dev-containers dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/vscode/devcontainers/repos/microsoft/vscode:latest
+
+COPY fluxbox/* /tmp/fluxbox/
+COPY *.sh /tmp/scripts/
+RUN bash /tmp/scripts/install.sh \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/scripts/ /tmp/fluxbox/

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,6 +2,8 @@
 
 This folder includes a configuration for building dev containers or reviewing PRs inside of another dev container - "Inception" style 😎. It includes the Moby/Docker and a desktop with VS Code stable, insiders, and the Remote - Containers extension installed for quick testing of local scenarios when needed.
 
-The desktop is auto-forwarded via HTTP to port 6080 and the login password is `vscode`.
+An web-based desktop viewer is automatically forwarded. The login password is `vscode`.
+
+Run <kbd>F1</kbd> / <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>p</kbd> and select **Ports: Focus on Ports View** to see the address to use to connect to it.
 
 However, most likely, this was not what you were looking for when you came to this repository. Actual dev container definitions can be found [under the `/containers` folder](https://github.com/microsoft/vscode-dev-containers/tree/main/containers) in this repository.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,7 @@
+# Dev Container for vscode-dev-containers
+
+This folder includes a configuration for building dev containers or reviewing PRs inside of another dev container - "Inception" style 😎. It includes the Moby/Docker and a desktop with VS Code stable, insiders, and the Remote - Containers extension installed for quick testing of local scenarios when needed.
+
+The desktop is auto-forwarded via HTTP to port 6080 and the login password is `vscode`.
+
+However, most likely, this was not what you were looking for when you came to this repository. Actual dev container definitions can be found [under the `/containers` folder](https://github.com/microsoft/vscode-dev-containers/tree/main/containers) in this repository.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"runArgs": [
+		"--shm-size=1g",
+	],
+	"settings": {},
+	"extensions": [
+		"ms-azuretools.vscode-docker",
+		"dbaeumer.vscode-eslint",
+		"rogalmic.bash-debug",
+		"mads-hartmann.bash-ide-vscode",
+		"streetsidesoftware.code-spell-checker",
+		"mutantdino.resourcemonitor",
+		"bierner.github-markdown-preview",
+		"EditorConfig.EditorConfig",
+		"chrisdias.vscode-opennewinstance"
+	],
+	"forwardPorts": [6080, 5901],
+	"portsAttributes": {
+		"6080": {
+			"label": "Desktop web client (noVNC)",
+			"onAutoForward": "silent"
+		},
+		"5901": {
+			"label": "VNC TCP port",
+			"onAutoForward": "silent"
+		},
+	},
+	"postCreateCommand": "bash .devcontainer/postCreateCommand.sh",
+	"remoteUser": "node",
+	"features": {
+		"docker-in-docker": "latest",
+		"github-cli": "latest"
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,10 @@
 	"runArgs": [
 		"--shm-size=1g",
 	],
-	"settings": {},
+	"settings": {
+		"resmon.show.battery": false,
+		"resmon.show.cpufreq": false
+	},
 	"extensions": [
 		"ms-azuretools.vscode-docker",
 		"dbaeumer.vscode-eslint",
@@ -17,7 +20,7 @@
 		"EditorConfig.EditorConfig",
 		"chrisdias.vscode-opennewinstance"
 	],
-	"forwardPorts": [6080, 5901],
+	"forwardPorts": [6080],
 	"portsAttributes": {
 		"6080": {
 			"label": "Desktop web client (noVNC)",
@@ -33,5 +36,9 @@
 	"features": {
 		"docker-in-docker": "latest",
 		"github-cli": "latest"
+	},
+	"overrideCommand": false,
+	"hostRequirements": {
+		"memory": "6gb"
 	}
 }

--- a/.devcontainer/fluxbox/menu
+++ b/.devcontainer/fluxbox/menu
@@ -1,0 +1,21 @@
+[begin] (  Application Menu  )
+    [exec] (File Manager) { nautilus ~ } <>
+    [exec] (Text Editor) { mousepad } <>
+    [exec] (VS Code) { /usr/bin/code } <>
+    [exec] (VS Code Insiders) { /usr/bin/code-insiders } <>
+    [exec] (Terminal) { tilix -w ~ -e /bin/bash -il } <>
+    [exec] (Web Browser) { x-www-browser --disable-dev-shm-usage } <>
+    [submenu] (System) {}
+        [exec] (Set Resolution) { tilix -t "Set Resolution" -e bash /usr/local/bin/set-resolution } <>
+        [exec] (Edit Application Menu) { mousepad ~/.fluxbox/menu } <>
+        [exec] (Passwords and Keys) { seahorse } <>
+        [exec] (Top Processes) { tilix -t "Top" -e htop } <>
+        [exec] (Disk Utilization) { tilix -t "Disk Utilization" -e ncdu / } <>
+        [exec] (Editres) {editres} <>
+        [exec] (Xfontsel) {xfontsel} <>
+        [exec] (Xkill) {xkill} <>
+        [exec] (Xrefresh) {xrefresh} <>
+    [end]
+    [config] (Configuration)
+    [workspaces] (Workspaces)
+[end]

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -2,6 +2,8 @@
 set -e
 export DEBIAN_FRONTEND=noninteractive
 
+MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
+
 # Install VS Code for use in desktop if needed
 curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list

--- a/.devcontainer/install.sh
+++ b/.devcontainer/install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+export DEBIAN_FRONTEND=noninteractive
+
+# Install VS Code for use in desktop if needed
+curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/code stable main" > /etc/apt/sources.list.d/vscode.list
+apt-get update
+apt-get -y install code code-insiders
+
+# Setup Fluxbox menus
+mkdir -p /root/.fluxbox /home/node/.fluxbox
+cp -f /tmp/fluxbox/* /root/.fluxbox/
+cp -f /tmp/fluxbox/* /home/node/.fluxbox/
+chown -R node:node /home/node/.fluxbox
+
+# Install firefox
+apt-get install -y firefox-esr

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+install_extension() {
+    /usr/bin/code --install-extension $1
+    /usr/bin/code-insiders --install-extension $1
+}
+
+# Install VS Code extensions into VS Code in desktop so we can try
+install_extension ms-vscode-remote.remote-containers
+install_extension ms-azuretools.vscode-docker
+install_extension streetsidesoftware.code-spell-checker
+install_extension chrisdias.vscode-opennewinstance
+install_extension mads-hartmann.bash-ide-vscode
+install_extension rogalmic.bash-debug


### PR DESCRIPTION
This adds the dev container we've typically been using to review PRs to this repository to make reviewing easier.  We initally excluded it because we were worried about confusing people as to where things are located.

So, I added a README explaining it a bit to that part.  I'll also enable Codespace prebuilds.