### PR TITLE
Add Go 1.18 images, drop 1.16

### DIFF
--- a/containers/go-postgres/.devcontainer/Dockerfile
+++ b/containers/go-postgres/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.18, 1.17, 1-bullseye, 1.18-bullseye, 1.17-bullseye, 1-buster, 1.18-buster, 1.17-buster
 ARG VARIANT=1-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
 

--- a/containers/go-postgres/.devcontainer/docker-compose.yml
+++ b/containers/go-postgres/.devcontainer/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # [Choice] Go version 1, 1.16, 1.17
+        # [Choice] Go version 1, 1.18, 1.17
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
         VARIANT: 1-bullseye

--- a/containers/go-postgres/README.md
+++ b/containers/go-postgres/README.md
@@ -40,7 +40,7 @@ build:
   context: .
   dockerfile: Dockerfile
     args:
-      # [Choice] Go version 1, 1.16, 1.17
+      # [Choice] Go version 1, 1.18, 1.17
       # Append -bullseye or -buster to pin to an OS version.
       # Use -bullseye variants on local arm64/Apple Silicon.
       VARIANT: 1.17

--- a/containers/go/.devcontainer/base.Dockerfile
+++ b/containers/go/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.16, 1.17, 1-bullseye, 1.16-bullseye, 1.17-bullseye, 1-buster, 1.16-buster, 1.17-buster
+# [Choice] Go version (use -bullseye variants on local arm64/Apple Silicon): 1, 1.18, 1.17, 1-bullseye, 1.18-bullseye, 1.17-bullseye, 1-buster, 1.18-buster, 1.17-buster
 ARG VARIANT=1-bullseye
 FROM golang:${VARIANT}
 

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -1,9 +1,9 @@
 {
 	"name": "Go",
 	"build": {
-		"dockerfile": "Dockerfile",
+		"dockerfile": "base.Dockerfile",
 		"args": {
-			// Update the VARIANT arg to pick a version of Go: 1, 1.16, 1.17
+			// Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local arm64/Apple Silicon.
 			"VARIANT": "1-bullseye",

--- a/containers/go/.devcontainer/devcontainer.json
+++ b/containers/go/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
 	"name": "Go",
 	"build": {
-		"dockerfile": "base.Dockerfile",
+		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a version of Go: 1, 1.18, 1.17
 			// Append -bullseye or -buster to pin to an OS version.
@@ -17,8 +17,7 @@
 	"settings": {
 		"go.toolsManagement.checkForUpdates": "local",
 		"go.useLanguageServer": true,
-		"go.gopath": "/go",
-		"go.goroot": "/usr/local/go"
+		"go.gopath": "/go"
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/containers/go/README.md
+++ b/containers/go/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/go |
-| *Available image variants* | 1 / 1-bullseye, 1.16 / 1.16-bullseye, 1.17 / 1.17-bullseye, 1-buster, 1.17-buster, 1.16-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list)) |
+| *Available image variants* | 1 / 1-bullseye, 1.18 / 1.18-bullseye, 1.17 / 1.17-bullseye, 1-buster, 1.18-buster, 1.17-buster  ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/go/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -32,14 +32,14 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 
 - `mcr.microsoft.com/vscode/devcontainers/go` (latest)
 - `mcr.microsoft.com/vscode/devcontainers/go:1` (or `1-bullseye`, `1-buster` to pin to an OS version)
-- `mcr.microsoft.com/vscode/devcontainers/go:1.16` (or `1.16-bullseye`, `1.16-buster` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/go:1.17` (or `1.17-bullseye`, `1.17-buster` to pin to an OS version)
+- `mcr.microsoft.com/vscode/devcontainers/go:1.18` (or `1.18-bullseye`, `1.18-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 
-- `mcr.microsoft.com/vscode/devcontainers/go:0-1.16` (or `0-1.16-bullseye`, `0-1.16-buster`)
-- `mcr.microsoft.com/vscode/devcontainers/go:0.205-1.16` (or `0.205-1.16-bullseye`, `0.205-1.16-buster`)
-- `mcr.microsoft.com/vscode/devcontainers/go:0.205.0-1.16` (or `0.205.0-1.16-bullseye`, `0.205.0-1.16-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/go:0-1.18` (or `0-1.18-bullseye`, `0-1.18-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/go:0.206-1.18` (or `0.205-1.18-bullseye`, `0.205-1.18-buster`)
+- `mcr.microsoft.com/vscode/devcontainers/go:0.206.0-1.18` (or `0.205.0-1.18-bullseye`, `0.205.0-1.18-buster`)
 
 However, we only do security patching on the latest [non-breaking, in support](https://github.com/microsoft/vscode-dev-containers/issues/532) versions of images (e.g. `0-1.16`). You may want to run `apt-get update && apt-get upgrade` in your Dockerfile if you lock to a more specific version to at least pick up OS security updates.
 

--- a/containers/go/definition-manifest.json
+++ b/containers/go/definition-manifest.json
@@ -1,30 +1,30 @@
 {
-	"variants": ["1.17-bullseye", "1.16-bullseye", "1.17-buster", "1.16-buster"],
-	"definitionVersion": "0.205.4",
+	"variants": ["1.18-bullseye", "1.18-buster", "1.17-bullseye", "1.17-buster"],
+	"definitionVersion": "0.206.0",
 	"build": {
-		"latest": "1.17-bullseye",
+		"latest": "1.18-bullseye",
 		"rootDistro": "debian",
 		"tags": [
 			"go:${VERSION}-${VARIANT}"
 		],
 		"architectures": {
+			"1.18-bullseye": ["linux/amd64", "linux/arm64"],
 			"1.17-bullseye": ["linux/amd64", "linux/arm64"],
-			"1.16-bullseye": ["linux/amd64", "linux/arm64"],
-			"1.17-buster": ["linux/amd64"],
-			"1.16-buster": ["linux/amd64"]
+			"1.18-buster": ["linux/amd64"],
+			"1.17-buster": ["linux/amd64"]
 		},
 		"variantTags": {
-			"1.17-bullseye": [ 
-				"go:${VERSION}-1.17",
+			"1.18-bullseye": [ 
+				"go:${VERSION}-1.18",
 				"go:${VERSION}-1",
 				"go:${VERSION}-1-bullseye",
 				"go:${VERSION}-bullseye" 
 			],
-			"1.16-bullseye": ["go:${VERSION}-1.16"],
-			"1.17-buster": [
+			"1.18-buster": [
 				"go:${VERSION}-1-buster",
 				"go:${VERSION}-buster"
-			]
+			],
+			"1.17-bullseye": ["go:${VERSION}-1.17"]
 		}
 	},
 	"dependencies": {

--- a/script-library/container-features/src/devcontainer-features.json
+++ b/script-library/container-features/src/devcontainer-features.json
@@ -733,7 +733,6 @@
 			"extensions": ["golang.Go"],
 			"containerEnv": {
 				"GOPATH": "/go",
-				"GOROOT": "/usr/local/go",
 				"PATH": "${GOPATH}/bin:${GOROOT}/bin:${PATH}"
 			},
 			"capAdd": [ "SYS_PTRACE" ],


### PR DESCRIPTION
Go 1.18 was just released. Once the upstream official Go 1.18 image is published, we can publish an updated image and drop 1.16 since its EOL.