### PR TITLE
Add note about /var/run to /run in socket mount

### DIFF
--- a/containers/docker-from-docker-compose/README.md
+++ b/containers/docker-from-docker-compose/README.md
@@ -69,6 +69,8 @@ You can adapt your own existing development container Dockerfile to support this
       - /var/run/docker.sock:/var/run/docker.sock
     ```
 
+In some containers which symlink /var/run to /run, you may need to change the last line to `/var/run/docker.sock:/run/docker.sock`
+
 3. Press <kbd>F1</kbd> and run **Remote-Containers: Rebuild Container** so the changes take effect.
 
 ### Enabling non-root access to Docker in the container


### PR DESCRIPTION
Mounts through symlinks in the image do not seem to be reliable. If /var/run/docker.sock is through a symlink, the mount does not seem to get created.

I've been struggling with this for a while, and this resolved the issue nicely. The debian bullseye image sets this symlink, so I assume a lot of devcontainers do as well.