### PR TITLE
docs: allowlist host.docker.internal hostname on Minikube start

### DIFF
--- a/containers/kubernetes-helm/README.md
+++ b/containers/kubernetes-helm/README.md
@@ -128,7 +128,7 @@ See the section below for your operating system for more detailed setup instruct
 
 2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) on your local OS if you have not already.
 
-3. Start Minikube and add `--apiserver-names=host.docker.internal` whitelist the hostname when accessing the Kube API server:
+3. Start Minikube and add `--apiserver-names=host.docker.internal` allowlist the hostname when accessing the Kube API server:
     ```
     minikube start --apiserver-names=host.docker.internal
     kubectl config set-context minikube

--- a/containers/kubernetes-helm/README.md
+++ b/containers/kubernetes-helm/README.md
@@ -128,9 +128,9 @@ See the section below for your operating system for more detailed setup instruct
 
 2. Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) and [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) on your local OS if you have not already.
 
-3. Start Minikube as follows:
+3. Start Minikube and add `--apiserver-names=host.docker.internal` whitelist the hostname when accessing the Kube API server:
     ```
-    minikube start
+    minikube start --apiserver-names=host.docker.internal
     kubectl config set-context minikube
     ```
 


### PR DESCRIPTION
Encountered an issue running `kubectl` commands on the dev container.

```bash
$ kubectl get po -A

Unable to connect to the server: x509: certificate is valid for minikubeCA, control-plane.minikube.internal, kubernetes.default.svc.cluster.local, kubernetes.default.svc, kubernetes.default, kubernetes, localhost, not host.docker.internal
```

Looks like Minikube doesn't allow `host.docker.internal` by default on their "default" (auto-detect) driver.

Feel free to re-word it if needed 🙂

## Fix

Start Minikube on the host machine and add `host.docker.internal` to the generated certificate used on the Kube API server.

```bash
minikube start --apiserver-names=host.docker.internal
```

Alternatively, we can disable TLS on the Kube config with `insecure-skip-tls-verify: true`, however that feels like a larger security risk.

## My system

- M1 Mac `MacOS 12.1`
- Minikube `v1.25.2 on Darwin 12.1 (arm64)`
- Docker `v20.10.12, build e91ed57`
- VSCode `v1.65.2`