### PR TITLE
Add swift VARIANT for swift 5.6

### DIFF
--- a/containers/swift/.devcontainer/Dockerfile
+++ b/containers/swift/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Swift version: 5.5, 5.4, 5.3, 5.2, 5.1, 4.2
-ARG VARIANT=5.5
+# [Choice] Swift version: 5.6-focal, 5.5, 5.4, 5.3, 5.2, 5.1, 4.2
+ARG VARIANT=5.6-focal
 FROM swift:${VARIANT}
 
 # [Option] Install zsh

--- a/containers/swift/.devcontainer/devcontainer.json
+++ b/containers/swift/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a Swift version 
-			"VARIANT": "5.5",
+			"VARIANT": "5.6-focal",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}


### PR DESCRIPTION
I am using the `5.6-focal` docker image because it has support for both x86_64 and arm64. While the `5.6` image is based off ubuntu bionic and does not have support for arm64.