### PR TITLE
Bump for patching, default to bullseye

### DIFF
--- a/containers/dotnet/.devcontainer/devcontainer.json
+++ b/containers/dotnet/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 		"args": { 
 			// Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
 			// Append -bullseye or -focal to pin to an OS version.
-			"VARIANT": "6.0",
+			"VARIANT": "6.0-bullseye",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/containers/java-8/definition-manifest.json
+++ b/containers/java-8/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "bullseye", "buster" ],
-	"definitionVersion": "0.205.2",
+	"definitionVersion": "0.205.3",
 	"build": {
 		"latest": false,
 		"rootDistro": "debian",

--- a/containers/java/definition-manifest.json
+++ b/containers/java/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": [ "17-bullseye", "17-buster", "11-bullseye", "11-buster" ],
-	"definitionVersion": "0.205.2",
+	"definitionVersion": "0.205.3",
 	"build": {
 		"latest": "17-bullseye",
 		"rootDistro": "debian",

--- a/containers/jekyll/definition-manifest.json
+++ b/containers/jekyll/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["2.7-bullseye", "2.7-buster"],
-	"definitionVersion": "0.1.5",
+	"definitionVersion": "0.1.6",
 	"build": {
 		"latest": "2.7-bullseye",
 		"parent": "ruby",

--- a/containers/php/definition-manifest.json
+++ b/containers/php/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["8.1-apache-bullseye", "8.0-apache-bullseye", "7.4-apache-bullseye", "8.1-apache-buster", "8.0-apache-buster", "7.4-apache-buster" ],
-	"definitionVersion": "0.203.2",
+	"definitionVersion": "0.203.3",
 	"build": {
 		"latest": "8.1-apache-bullseye",
 		"rootDistro": "debian",

--- a/containers/python-3-anaconda/definition-manifest.json
+++ b/containers/python-3-anaconda/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"definitionVersion": "0.202.5",
+	"definitionVersion": "0.202.6",
 	"build": {
 		"latest": true,
 		"rootDistro": "debian",

--- a/containers/python-3/definition-manifest.json
+++ b/containers/python-3/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.10-bullseye", "3.9-bullseye", "3.8-bullseye", "3.7-bullseye", "3.6-bullseye", "3.10-buster", "3.9-buster", "3.8-buster", "3.7-buster", "3.6-buster"],
-	"definitionVersion": "0.203.3",
+	"definitionVersion": "0.203.5",
 	"build": {
 		"latest": "3.10-bullseye",
 		"rootDistro": "debian",

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,8 +1,8 @@
 {
 	"variants": ["3.1-bullseye", "3.0-bullseye", "2.7-bullseye", "2.6-bullseye", "3.1-buster", "3.0-buster", "2.7-buster", "2.6-buster"],
-	"definitionVersion": "0.203.1",
+	"definitionVersion": "0.203.2",
 	"build": {
-		"latest": "3.0-bullseye",
+		"latest": "3.1-bullseye",
 		"rootDistro": "debian",
 		"architectures": {
 			"3.1-bullseye": ["linux/amd64", "linux/arm64"],

--- a/containers/rust/definition-manifest.json
+++ b/containers/rust/definition-manifest.json
@@ -1,8 +1,8 @@
 {
 	"variants": ["buster", "bullseye"],
-	"definitionVersion": "0.201.5",
+	"definitionVersion": "0.202.0",
 	"build": {
-		"latest": "buster",
+		"latest": "bullseye",
 		"rootDistro": "debian",
 		"architectures": {
 			"bullseye": ["linux/amd64", "linux/arm64"],


### PR DESCRIPTION
Bump images that have not been updated recently to pick up latest updates.  Default rust to bullseye given the increase of Apple Silicon macOS devices.  C++/Ubuntu will be updated by #1399 and JS/TS will be updated by #1398 so they were omitted.  Go was just recently updated.

