### PR TITLE
Use regex to install `liblttng-ust` in Common Debian script

### DIFF
--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -102,7 +102,7 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         libkrb5-3 \
         libgssapi-krb5-2 \
         libicu[0-9][0-9] \
-        liblttng-ust0 \
+        liblttng-ust[0-9] \
         libstdc++6 \
         zlib1g \
         locales \


### PR DESCRIPTION
Resolves #1414 