### PR TITLE
replace `git.io` links with their actual URLs

### DIFF
--- a/script-library/fish-debian.sh
+++ b/script-library/fish-debian.sh
@@ -83,9 +83,9 @@ fi
 # Install Fisher
 if [ "${INSTALL_FISHER}" = "true" ]; then
     echo "Installing Fisher..."
-    fish -c 'curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher'
+    fish -c 'curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install jorgebucaran/fisher'
     if [ "${USERNAME}" != "root" ]; then
-        sudo -u $USERNAME fish -c 'curl -sL https://git.io/fisher | source && fisher install jorgebucaran/fisher'
+        sudo -u $USERNAME fish -c 'curl -sL https://raw.githubusercontent.com/jorgebucaran/fisher/main/functions/fisher.fish | source && fisher install jorgebucaran/fisher'
     fi
 fi
 


### PR DESCRIPTION
All links on `git.io` will stop redirecting after April 29, 2022: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Replace `git.io` links with their actual URL.