### PR TITLE
Drop Alpine EOL 3.12

### DIFF
--- a/containers/alpine/.devcontainer/Dockerfile
+++ b/containers/alpine/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Alpine version: 3.14, 3.13, 3.12, 3.11
-ARG VARIANT=3.13
+# [Choice] Alpine version: 3.15, 3.14, 3.13
+ARG VARIANT=3.15
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-alpine-${VARIANT}
 
 # ** [Optional] Uncomment this section to install additional packages. **

--- a/containers/alpine/.devcontainer/base.Dockerfile
+++ b/containers/alpine/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Alpine version: 3.15, 3.14, 3.13, 3.12, 3.11
+# [Choice] Alpine version: 3.15, 3.14, 3.13
 ARG VARIANT=3.15
 FROM alpine:${VARIANT}
 

--- a/containers/alpine/.devcontainer/devcontainer.json
+++ b/containers/alpine/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
 	"name": "Alpine",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Alpine version: 3.12, 3.13, 3.14, 3.15
+		// Update 'VARIANT' to pick an Alpine version: 3.13, 3.14, 3.15
 		"args": { "VARIANT": "3.15" }
 	},
 	

--- a/containers/alpine/README.md
+++ b/containers/alpine/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Other |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/base:alpine |
-| *Available image variants* | 3.15, 3.14, 3.13, 3.12 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
+| *Available image variants* | 3.15, 3.14, 3.13 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
 | *Published image architecture(s)* | x86-64, aarch64/arm64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -24,13 +24,12 @@ See **[history](history)** for information on the contents of published images.
  While the definition itself works unmodified, you can select the version of Alpine the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "3.14" }
+"args": { "VARIANT": "3.15" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
 
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine` (latest)
-- `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.12`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.13`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.14`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.15`

--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["3.15", "3.14", "3.13", "3.12"],
+	"variants": ["3.15", "3.14", "3.13"],
 	"definitionVersion": "0.204.2",
 	"build": {
 		"latest": false,

--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.15", "3.14", "3.13"],
-	"definitionVersion": "0.204.2",
+	"definitionVersion": "0.204.3",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",


### PR DESCRIPTION
Based on https://github.com/microsoft/vscode-dev-containers/issues/532 and https://alpinelinux.org/releases/, it appears Alpine 3.12 has reached EOL. 

Updating our files to reflect this (following https://github.com/microsoft/vscode-dev-containers/pull/1181/files as an example).