### PR TITLE
Drop Ruby 2.6 EOL

### DIFF
--- a/containers/ruby/.devcontainer/Dockerfile
+++ b/containers/ruby/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster
 ARG VARIANT=2-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/base.Dockerfile
+++ b/containers/ruby/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
+# [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster
 ARG VARIANT=2-bullseye
 FROM ruby:${VARIANT}
 

--- a/containers/ruby/.devcontainer/devcontainer.json
+++ b/containers/ruby/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.1, 3.0, 2, 2.7, 2.6
+			// Update 'VARIANT' to pick a Ruby version: 3, 3.1, 3.0, 2, 2.7
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
 			"VARIANT": "3-bullseye",

--- a/containers/ruby/README.md
+++ b/containers/ruby/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/ruby |
-| *Available image variants* | 3 / 3-bullseye, 3.1 / 3.1-bullseye, 3.0 / 3.0-bullseye, 2 / 2-bullseye, 2.7 / 2.7-bullseye, 2.6 / 2.7-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
+| *Available image variants* | 3 / 3-bullseye, 3.1 / 3.1-bullseye, 3.0 / 3.0-bullseye, 2 / 2-bullseye, 2.7 / 2.7-bullseye, 2.6 / 2.7-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/ruby/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -36,7 +36,6 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/ruby:3.0` (or `3.0-bullseye`, `3.0-buster` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2` (or `2-bullseye`, `2-buster` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/ruby:2.7` (or `2.7-bullseye`, `2.7-buster` to pin to an OS version)
-- `mcr.microsoft.com/vscode/devcontainers/ruby:2.6` (or `2.6-bullseye`, `2.6-buster` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,5 +1,5 @@
 {
-	"variants": ["3.1-bullseye", "3.0-bullseye", "2.7-bullseye", "2.6-bullseye", "3.1-buster", "3.0-buster", "2.7-buster", "2.6-buster"],
+	"variants": ["3.1-bullseye", "3.0-bullseye", "2.7-bullseye", "3.1-buster", "3.0-buster", "2.7-buster"],
 	"definitionVersion": "0.203.2",
 	"build": {
 		"latest": "3.1-bullseye",
@@ -8,11 +8,9 @@
 			"3.1-bullseye": ["linux/amd64", "linux/arm64"],
 			"3.0-bullseye": ["linux/amd64", "linux/arm64"],
 			"2.7-bullseye": ["linux/amd64", "linux/arm64"],
-			"2.6-bullseye": ["linux/amd64", "linux/arm64"],
 			"3.1-buster": ["linux/amd64"],
 			"3.0-buster": ["linux/amd64"],
-			"2.7-buster": ["linux/amd64"],
-			"2.6-buster": ["linux/amd64"]
+			"2.7-buster": ["linux/amd64"]
 		},
 		"tags": [
 			"ruby:${VERSION}-${VARIANT}"
@@ -32,7 +30,6 @@
 				"ruby:${VERSION}-2.7",
 				"ruby:${VERSION}-2-bullseye"
 			 ],
-			"2.6-bullseye": [ "ruby:${VERSION}-2.6" ],
 			"3.1-buster": [ 
 				"ruby:${VERSION}-3-buster",
 				"ruby:${VERSION}-buster"

--- a/containers/ruby/definition-manifest.json
+++ b/containers/ruby/definition-manifest.json
@@ -1,6 +1,6 @@
 {
 	"variants": ["3.1-bullseye", "3.0-bullseye", "2.7-bullseye", "3.1-buster", "3.0-buster", "2.7-buster"],
-	"definitionVersion": "0.203.2",
+	"definitionVersion": "0.203.3",
 	"build": {
 		"latest": "3.1-bullseye",
 		"rootDistro": "debian",


### PR DESCRIPTION
Based on https://github.com/microsoft/vscode-dev-containers/issues/532 and https://www.ruby-lang.org/en/downloads/branches/, Ruby 2.6 has reached EOL.

Removing 2.6 from our files (covering files that were updated in a previous Ruby change in [this PR](https://github.com/microsoft/vscode-dev-containers/pull/851/files)).