### PR TITLE
remove setting npm global location

### DIFF
--- a/containers/codespaces-linux/.devcontainer/base.Dockerfile
+++ b/containers/codespaces-linux/.devcontainer/base.Dockerfile
@@ -101,9 +101,6 @@ RUN bash /tmp/scripts/node-debian.sh "${NVM_DIR}" "none" "${USERNAME}" \
     && (cd ${NVS_HOME} && git remote get-url origin && echo $(git log -n 1 --pretty=format:%H -- .)) > ${NVS_HOME}/.git-remote-and-commit \
     && sudo -u ${USERNAME} bash ${NVS_HOME}/nvs.sh install \
     && rm ${NVS_HOME}/cache/* \
-    # Set npm global location
-    && sudo -u ${USERNAME} npm config set prefix ${NPM_GLOBAL} \
-    && npm config -g set prefix ${NPM_GLOBAL} \
     # Clean up
     && rm -rf ${NVM_DIR}/.git ${NVS_HOME}/.git
 


### PR DESCRIPTION
Justification from @mylesborins

> Hey All, I noticed a weirdness with how npm is setup in codespaces, specifically that there is a a ~/.npmrc with the contents
prefix=/home/codespace/.npm-global
While this is good for making things a bit more “consistent” across versions of node / npm it does result in making it significantly more complicated to update npm independent of Node.js when installed via nvm since npm i -g npm installs into that prefix rather then the ~/.nvm folder, so the nvm installed version always will trump the customer installed npm version due to the order in $PATH