### PR TITLE
Add inotify-tools to elixir phoenix postgres template

### DIFF
--- a/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
+++ b/containers/elixir-phoenix-postgres/.devcontainer/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get update \
   fi \
   #
   # Install dependencies
-  && apt-get install -y build-essential \
+  && apt-get install -y build-essential inotify-tools \
   #
   # Clean up
   && apt-get autoremove -y \


### PR DESCRIPTION
inotify-tools is required in linux environments for live code reloading with Phoenix. Users seeking to use this template to development will be met with a warning when starting a phoenix project for the first time and will need to install it manually. Adding it as a dependency to the dev container would avoid that and help people get going quicker.

I wasn't sure if it would be clearer to put this as a seperate install command, but it felt like it made most sense to put it next to build-essentials. Happy to move it if needed.

ref: https://hexdocs.pm/phoenix/installation.html#inotify-tools-for-linux-users