### PR TITLE
Use Java 17 by default

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -988,7 +988,7 @@
                 "Type": "other",
                 "Other": {
                     "Name": "Eclipse Temurin",
-                    "Version": "1.8.0_332",
+                    "Version": "17.0.3_7",
                     "DownloadUrl": "https://adoptium.net/"
                 }
             }
@@ -998,7 +998,7 @@
                 "Type": "other",
                 "Other": {
                     "Name": "Docker Image: mcr.microsoft.com/vscode/devcontainers/java",
-                    "Version": "11-bullseye",
+                    "Version": "17-bullseye",
                     "DownloadUrl": "https://hub.docker.com/_/openjdk"
                 }
             }
@@ -1008,7 +1008,7 @@
                 "Type": "other",
                 "Other": {
                     "Name": "Docker Image: mcr.microsoft.com/vscode/devcontainers/java",
-                    "Version": "11-buster",
+                    "Version": "17-buster",
                     "DownloadUrl": "https://hub.docker.com/_/openjdk"
                 }
             }

--- a/containers/java-postgres/.devcontainer/Dockerfile
+++ b/containers/java-postgres/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
-ARG VARIANT=11-bullseye
+ARG VARIANT=17-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
 
 # [Option] Install Maven

--- a/containers/java-postgres/.devcontainer/docker-compose.yml
+++ b/containers/java-postgres/.devcontainer/docker-compose.yml
@@ -13,7 +13,7 @@ services:
         # Update 'VARIANT' to pick an version of Java: 11, 17.
         # Append -bullseye or -buster to pin to an OS version.
         # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 11-bullseye
+        VARIANT: 17-bullseye
         # Options
         INSTALL_MAVEN: "false"
         MAVEN_VERSION: ""

--- a/containers/java-postgres/README.md
+++ b/containers/java-postgres/README.md
@@ -45,7 +45,7 @@ build:
       # Update 'VARIANT' to pick an version of Java: 11, 17.
       # Append -bullseye or -buster to pin to an OS version.
       # Use -bullseye variants on local arm64/Apple Silicon.
-      VARIANT: 11-bullseye
+      VARIANT: 17-bullseye
 ```
 
 You also can connect to PostgreSQL from an external tool when using VS Code by updating `.devcontainer/devcontainer.json` as follows:

--- a/containers/java/.devcontainer/devcontainer.json
+++ b/containers/java/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 			// Update the VARIANT arg to pick a Java version: 11, 17
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use the -bullseye variants on local arm64/Apple Silicon.
-			"VARIANT": "11-bullseye",
+			"VARIANT": "17-bullseye",
 			// Options
 			"INSTALL_MAVEN": "false",
 			"INSTALL_GRADLE": "false",

--- a/devcontainer-collection.json
+++ b/devcontainer-collection.json
@@ -523,7 +523,7 @@
 						"11-buster",
 						"17-buster"
 					],
-					"default": "11-bullseye"
+					"default": "17-bullseye"
 				}
 			}
 		},

--- a/migrations/options.json
+++ b/migrations/options.json
@@ -194,7 +194,7 @@
 					"11-buster",
 					"17-buster"
 				],
-				"default": "11-bullseye"
+				"default": "17-bullseye"
 			}
 		}
 	},


### PR DESCRIPTION
JDK 17 is the new long-term support release, so it should be used by default.

This PR follows comment https://github.com/microsoft/vscode-remote-try-java/pull/35#discussion_r869186808 from @chrmarti @joshspicer 