### PR TITLE
Update .NET 5.0 EOL

### DIFF
--- a/containers/dotnet-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnet-fsharp/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 ARG VARIANT=6.0-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14
+# [Choice] Node.js version: none, lts/*, 18, 16, 14
 ARG NODE_VERSION="lts/*"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-fsharp/.devcontainer/Dockerfile
+++ b/containers/dotnet-fsharp/.devcontainer/Dockerfile
@@ -1,6 +1,7 @@
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-5.0
+ARG VARIANT=6.0-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14
 ARG NODE_VERSION="lts/*"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-mssql/.devcontainer/Dockerfile
+++ b/containers/dotnet-mssql/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="6.0-focal"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14
+# [Choice] Node.js version: none, lts/*, 18, 16, 14
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-mssql/.devcontainer/Dockerfile
+++ b/containers/dotnet-mssql/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-# [Choice] .NET version: 6.0-focal, 5.0-focal, 3.1-focal
+# [Choice] .NET version: 6.0-focal, 3.1-focal
 ARG VARIANT="6.0-focal"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-mssql/.devcontainer/docker-compose.yml
+++ b/containers/dotnet-mssql/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # Update 'VARIANT' to pick a version of .NET: 3.1-focal, 5.0-focal, 6.0-focal
+        # Update 'VARIANT' to pick a version of .NET: 3.1-focal, 6.0-focal
         VARIANT: "6.0-focal"
         # Optional version of Node.js
         NODE_VERSION: "lts/*"

--- a/containers/dotnet-mssql/README.md
+++ b/containers/dotnet-mssql/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Docker Compose |
 | *Published image architecture(s)* | x86-64 |
-| *Available image variants* | 3.1-focal, 5.0-focal, 6.0-focal |
+| *Available image variants* | 3.1-focal, 6.0-focal |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu 20.04/focal (Debian 11/bullseye image variants not yet supported by MSSQL client) |

--- a/containers/dotnet-postgres/.devcontainer/Dockerfile
+++ b/containers/dotnet-postgres/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-# [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
+# [Choice] .NET version: 6.0, 3.1, 6.0-bullseye, 3.1-bullseye, 6.0-focal, 3.1-focal
 ARG VARIANT="6.0"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-postgres/.devcontainer/Dockerfile
+++ b/containers/dotnet-postgres/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT="6.0"
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14
+# [Choice] Node.js version: none, lts/*, 18, 16, 14
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet-postgres/.devcontainer/docker-compose.yml
+++ b/containers/dotnet-postgres/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        # Update 'VARIANT' to pick a version of .NET: 3.1, 5.0, 6.0
+        # Update 'VARIANT' to pick a version of .NET: 3.1, 6.0
         VARIANT: "6.0"
         # Optional version of Node.js
         NODE_VERSION: "lts/*"

--- a/containers/dotnet/.devcontainer/Dockerfile
+++ b/containers/dotnet/.devcontainer/Dockerfile
@@ -1,8 +1,8 @@
-# [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
+# [Choice] .NET version: 6.0, 3.1, 6.0-bullseye, 3.1-bullseye, 6.0-focal, 3.1-focal
 ARG VARIANT=6.0-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet/.devcontainer/Dockerfile
+++ b/containers/dotnet/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 ARG VARIANT=6.0-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
-# [Choice] Node.js version: none, lts/*, 16, 14
+# [Choice] Node.js version: none, lts/*, 18, 16, 14
 ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 

--- a/containers/dotnet/.devcontainer/base.Dockerfile
+++ b/containers/dotnet/.devcontainer/base.Dockerfile
@@ -1,4 +1,4 @@
-# [Choice] .NET version: 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
+# [Choice] .NET version: 6.0-bullseye, 3.1-bullseye, 6.0-focal, 3.1-focal
 ARG VARIANT=6.0-bullseye-slim
 FROM mcr.microsoft.com/dotnet/sdk:${VARIANT}
 
@@ -16,7 +16,7 @@ ARG USER_GID=$USER_UID
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
+# [Choice] Node.js version: none, lts/*, 16, 14
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/dotnet/.devcontainer/base.Dockerfile
+++ b/containers/dotnet/.devcontainer/base.Dockerfile
@@ -16,7 +16,7 @@ ARG USER_GID=$USER_UID
 RUN bash /tmp/library-scripts/common-debian.sh "${INSTALL_ZSH}" "${USERNAME}" "${USER_UID}" "${USER_GID}" "${UPGRADE_PACKAGES}" "true" "true" \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
-# [Choice] Node.js version: none, lts/*, 16, 14
+# [Choice] Node.js version: none, lts/*, 18, 16, 14
 ARG NODE_VERSION="none"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \

--- a/containers/dotnet/.devcontainer/devcontainer.json
+++ b/containers/dotnet/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": { 
-			// Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
+			// Update 'VARIANT' to pick a .NET Core version: 3.1, 6.0
 			// Append -bullseye or -focal to pin to an OS version.
 			"VARIANT": "6.0-bullseye",
 			// Options

--- a/containers/dotnet/README.md
+++ b/containers/dotnet/README.md
@@ -10,7 +10,7 @@
 | *Categories* | Core, Languages |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/dotnet |
-| *Available image variants* | 3.1 / 3.1-focal, 5.0 / 5.0-focal, 6.0 /6.0-bullseye, 6.0-focal, 5.0-bullseye, 3.1-bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list)) |
+| *Available image variants* | 3.1 / 3.1-focal / 6.0 /6.0-bullseye, 6.0-focal, 3.1-bullseye ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/dotnet/tags/list)) |
 | *Published image architecture(s)* | x86-64, arm64/aarch64 for `bullseye` variants |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -34,7 +34,6 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 
 - `mcr.microsoft.com/vscode/devcontainers/dotnet` (latest)
 - `mcr.microsoft.com/vscode/devcontainers/dotnet:3.1` (or `3.1-bullseye`, `3.1-focal` to pin to an OS version)
-- `mcr.microsoft.com/vscode/devcontainers/dotnet:5.0` (or `5.0-bullseye`, `5.0-focal` to pin to an OS version)
 - `mcr.microsoft.com/vscode/devcontainers/dotnet:6.0` (or `6.0-bullseye`, `6.0-focal` to pin to an OS version)
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -10,8 +10,6 @@
 		"architectures": {
 			"6.0-focal": ["linux/amd64"],
 			"6.0-bullseye-slim": ["linux/amd64", "linux/arm64"],
-			"5.0-focal": ["linux/amd64"],
-			"5.0-bullseye-slim": ["linux/amd64", "linux/arm64"],
 			"3.1-focal": ["linux/amd64"],
 			"3.1-bullseye": ["linux/amd64", "linux/arm64"]
 		},

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -20,14 +20,6 @@
 				"dotnet:${VERSION}-6.0",
 				"dotnet:${VERSION}-6.0-bullseye"
 			],
-			"5.0-focal": [ 
-				"dotnet:${VERSION}-5.0",
-				"dotnetcore:${VERSION}-5.0"
-			],
-			"5.0-bullseye-slim": [ 
-				"dotnet:${VERSION}-5.0-bullseye",
-				"dotnetcore:${VERSION}-5.0-bullseye"
-			],
 			"3.1-focal": [ 
 				"dotnet:${VERSION}-3.1",
 				"dotnetcore:${VERSION}-3.1"

--- a/containers/dotnet/definition-manifest.json
+++ b/containers/dotnet/definition-manifest.json
@@ -1,6 +1,6 @@
 {
-	"variants": ["6.0-bullseye-slim", "6.0-focal", "5.0-bullseye-slim", "5.0-focal", "3.1-bullseye", "3.1-focal"],
-	"definitionVersion": "0.203.0",
+	"variants": ["6.0-bullseye-slim", "6.0-focal", "3.1-bullseye", "3.1-focal"],
+	"definitionVersion": "0.203.1",
 	"build": {
 		"latest": "6.0-bullseye-slim",
 		"rootDistro": "debian",


### PR DESCRIPTION
Update dotnet definitions as .NET 5.0 is EOL. Context: https://devblogs.microsoft.com/dotnet/dotnet-5-end-of-support-update/

Made a few other updates since Node.js 10 and 12 are also EOL.