### PR TITLE
Fedora support

### DIFF
--- a/script-library/README.md
+++ b/script-library/README.md
@@ -8,7 +8,7 @@ Script names end in the Linux distribution "tree" they support. The majority are
 
 - **Debian or Ubuntu**: `-debian`
 - **Alpine Linux**: `-alpine`
-- **CentOS, RHEL**: `-redhat` (when the `yum` package manager is available - usually community supported).
+- **CentOS, RHEL, Fedora**: `-redhat` (when the `yum` package manager is available - usually community supported).
 
 Some scripts have special installation instructions (like `desktop-lite-debian.sh`). Consult the following documents for more information (in order of the script name):
 
@@ -71,7 +71,7 @@ RUN ash /tmp/library-scripts/common-alpine.sh \
     && rm -rf /tmp/library-scripts
 ```
 
-**CentOS/RedHat/Oracle Linux**
+**CentOS/RedHat/Fedora/Oracle Linux**
 
 ```Dockerfile
 COPY library-scripts/*.sh /tmp/library-scripts/

--- a/script-library/docker-redhat.sh
+++ b/script-library/docker-redhat.sh
@@ -109,9 +109,14 @@ fi
 curl -fsSL https://download.docker.com/linux/${OSNAME}/gpg > /tmp/docker.gpg && \
 rpm --import /tmp/docker.gpg
 
-yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${RHEL_COMPAT_VER}.noarch.rpm
-yum install -y yum-utils device-mapper-persistent-data lvm2
-yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+if [ "${OSNAME}" = "fedora" ]; then
+    yum install -y yum-utils device-mapper-persistent-data lvm2
+    yum-config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+else
+    yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-${RHEL_COMPAT_VER}.noarch.rpm
+    yum install -y yum-utils device-mapper-persistent-data lvm2
+    yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+fi
 
 yum -y update
 yum -y install docker-ce-cli

--- a/script-library/docs/common.md
+++ b/script-library/docs/common.md
@@ -4,7 +4,7 @@
 
 **Script status**: Stable
 
-**OS support**: Debian 9+, Ubuntu 16.04+, Alpine 3.9+, CentOS/RHEL 7+ (community supported) and downstream distros.
+**OS support**: Debian 9+, Ubuntu 16.04+, Alpine 3.9+, CentOS/RHEL 7+/Fedora (community supported) and downstream distros.
 
 **Maintainer:** The VS Code and GitHub Codespaces teams
 

--- a/script-library/docs/docker.md
+++ b/script-library/docs/docker.md
@@ -6,7 +6,7 @@
 
 **Script status**: Stable
 
-**OS support**: Debian 9+, Ubuntu 18.04+, CentOS/RHEL 7+ (community supported) and downstream distros.
+**OS support**: Debian 9+, Ubuntu 18.04+, CentOS/RHEL 7+/Fedora (community supported) and downstream distros.
 
 **Maintainer:** The VS Code and GitHub Codespaces teams, [@smankoo](https://github.com/smankoo) (`docker-redhat.sh`)
 

--- a/script-library/docs/docker.md
+++ b/script-library/docs/docker.md
@@ -90,7 +90,7 @@ See the [`docker-from-docker`](../../containers/docker-from-docker) and [`docker
     CMD ["sleep", "infinity"]
     ```
 
-    For CentOS/RedHat, simply replace the `RUN` above with:
+    For CentOS/RedHat/Fedora, simply replace the `RUN` above with:
 
     ```Dockerfile
     RUN bash /tmp/library-scripts/docker-redhat.sh

--- a/script-library/test/regression/fedora/.devcontainer.json
+++ b/script-library/test/regression/fedora/.devcontainer.json
@@ -1,0 +1,23 @@
+{
+	"name": "Script Tester - Fedora",
+	"build": {
+		"dockerfile": "../Dockerfile",
+		"context": "../../../",
+		"args": {
+			"IMAGE_TO_TEST": "fedora:36",
+			"USERNAME": "vscode",
+			"DISTRO": "redhat"
+		}
+	},
+
+	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
+	"workspaceMount": "source=${localWorkspaceFolder}/../../..,target=/workspace,type=bind",
+	"workspaceFolder": "/workspace",
+	"overrideCommand": false,
+
+	"extensions": [
+		"ms-azuretools.vscode-docker"
+	],
+
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
Fedora is fine with using the existing scripts (common-redhat and docker-redhat), with a simple fix in docker-redhat.sh.