### PR TITLE
Rust: Target Correct Rust Analyzer Extension

### DIFF
--- a/containers/rust-postgres/.devcontainer/devcontainer.json
+++ b/containers/rust-postgres/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 			"extensions": [
 				"vadimcn.vscode-lldb",
 				"mutantdino.resourcemonitor",
-				"matklad.rust-analyzer",
+				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
 				"serayuzgur.crates"
 			]

--- a/containers/rust-postgres/test-project/test.sh
+++ b/containers/rust-postgres/test-project/test.sh
@@ -9,7 +9,7 @@ checkCommon
 # Definition specific tests
 checkExtension "vadimcn.vscode-lldb"
 checkExtension "mutantdino.resourcemonitor"
-checkExtension "matklad.rust-analyzer"
+checkExtension "rust-lang.rust-analyzer"
 checkExtension "tamasfe.even-better-toml"
 checkExtension "serayuzgur.crates"
 check "cargo-version" cargo -V

--- a/containers/rust/.devcontainer/devcontainer.json
+++ b/containers/rust/.devcontainer/devcontainer.json
@@ -32,7 +32,7 @@
 			"extensions": [
 				"vadimcn.vscode-lldb",
 				"mutantdino.resourcemonitor",
-				"matklad.rust-analyzer",
+				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
 				"serayuzgur.crates"
 			]

--- a/devcontainer-collection.json
+++ b/devcontainer-collection.json
@@ -1978,7 +1978,7 @@
 			"extensions": [
 				"vadimcn.vscode-lldb",
 				"mutantdino.resourcemonitor",
-				"matklad.rust-analyzer",
+				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
 				"serayuzgur.crates"	
 			],

--- a/script-library/container-features/src/devcontainer-features.json
+++ b/script-library/container-features/src/devcontainer-features.json
@@ -1043,7 +1043,7 @@
 			"extensions": [
 				"vadimcn.vscode-lldb",
 				"mutantdino.resourcemonitor",
-				"matklad.rust-analyzer",
+				"rust-lang.rust-analyzer",
 				"tamasfe.even-better-toml",
 				"serayuzgur.crates"
 			],


### PR DESCRIPTION
The `matklad.rust-analyzer` extension has been replaced in favor of `rust-lang.rust-analyzer`. Since the old extension no longer exists, I've updated the referenced extension in the dev container configurations.