### PR TITLE
Fix NotebookApp bug in Jupyter install script

### DIFF
--- a/containers/codespaces-linux/.devcontainer/library-scripts/jupyterlab-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/jupyterlab-debian.sh
@@ -72,4 +72,5 @@ fi
 
 if [ "${ALLOW_ORIGIN}" = 'true' ]; then
   addToJupyterConfig "c.ServerApp.allow_origin = '*'"
+  addToJupyterConfig "c.NotebookApp.allow_origin = '*'"
 fi

--- a/containers/codespaces-linux/.devcontainer/library-scripts/jupyterlab-debian.sh
+++ b/containers/codespaces-linux/.devcontainer/library-scripts/jupyterlab-debian.sh
@@ -14,7 +14,7 @@ set -e
 VERSION=${1:-"latest"}
 USERNAME=${2:-"automatic"}
 PYTHON=${3:-"python"}
-ALLOW_ORIGIN=${4:-""}
+ALLOW_ALL_ORIGINS=${4:-""}
 
 # If in automatic mode, determine if a user already exists, if not use vscode
 if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
@@ -70,7 +70,7 @@ else
   sudoUserIf ${PYTHON} -m pip install jupyterlab=="${VERSION}" --no-cache-dir
 fi
 
-if [ "${ALLOW_ORIGIN}" = 'true' ]; then
+if [ "${ALLOW_ALL_ORIGINS}" = 'true' ]; then
   addToJupyterConfig "c.ServerApp.allow_origin = '*'"
   addToJupyterConfig "c.NotebookApp.allow_origin = '*'"
 fi

--- a/script-library/jupyterlab-debian.sh
+++ b/script-library/jupyterlab-debian.sh
@@ -72,4 +72,5 @@ fi
 
 if [ "${ALLOW_ORIGIN}" = 'true' ]; then
   addToJupyterConfig "c.ServerApp.allow_origin = '*'"
+  addToJupyterConfig "c.NotebookApp.allow_origin = '*'"
 fi

--- a/script-library/jupyterlab-debian.sh
+++ b/script-library/jupyterlab-debian.sh
@@ -14,7 +14,7 @@ set -e
 VERSION=${1:-"latest"}
 USERNAME=${2:-"automatic"}
 PYTHON=${3:-"python"}
-ALLOW_ORIGIN=${4:-""}
+ALLOW_ALL_ORIGINS=${4:-""}
 
 # If in automatic mode, determine if a user already exists, if not use vscode
 if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "automatic" ]; then
@@ -70,7 +70,7 @@ else
   sudoUserIf ${PYTHON} -m pip install jupyterlab=="${VERSION}" --no-cache-dir
 fi
 
-if [ "${ALLOW_ORIGIN}" = 'true' ]; then
+if [ "${ALLOW_ALL_ORIGINS}" = 'true' ]; then
   addToJupyterConfig "c.ServerApp.allow_origin = '*'"
   addToJupyterConfig "c.NotebookApp.allow_origin = '*'"
 fi


### PR DESCRIPTION
Fixes a minor bug in the Jupyter install script by adding a setting for Jupyter Notebook. JupyterLab understands the `ServerApp.allow_origin` setting, but Jupyter Notebook needs `NotebookApp.allow_origin`.

Closes https://github.com/github/codespaces/issues/8194