### PR TITLE
[R] Update info about codespaces

### DIFF
--- a/containers/r/README.md
+++ b/containers/r/README.md
@@ -9,7 +9,7 @@
 | *Contributors* | [kmehant](mailto:kmehant@gmail.com), [eitsupi](https://github.com/eitsupi) |
 | *Categories* | Community, Languages |
 | *Definition type* | Dockerfile |
-| *Works in Codespaces* | No |
+| *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
 | *Container OS* | Ubuntu |
 | *Languages, platforms* | R |


### PR DESCRIPTION
It didn't seem to work well with the previous R definition (which used a different extension), but now it seems to work on Codespaces.