### PR TITLE
Use stronger wording in docker-compose template

### DIFF
--- a/container-templates/docker-compose/.devcontainer/devcontainer.json
+++ b/container-templates/docker-compose/.devcontainer/devcontainer.json
@@ -8,8 +8,8 @@
 	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
 	"service": "app",
 
-	// The optional 'workspaceFolder' property is the path VS Code should open by default when
-	// connected. This is typically a volume mount in .devcontainer/docker-compose.yml
+	// The 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. Corresponds to a volume mount in .devcontainer/docker-compose.yml
 	"workspaceFolder": "/workspace",
 
 	// Set *default* container specific settings.json values on container create.


### PR DESCRIPTION
I was playing with different mount options for my workspace and found that `"workspaceFolder"` is not optional. The comment vaguely suggests that you can set this to something other than a volume mount, but that only confused me further.