### PR TITLE
Add `util-linux` to `common-alpine.sh`

### DIFF
--- a/script-library/common-alpine.sh
+++ b/script-library/common-alpine.sh
@@ -95,6 +95,7 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         zlib \
         sudo \
         coreutils \
+        util-linux \
         sed \
         grep \
         which \


### PR DESCRIPTION
This package comes preinstalled in Debian, and provides some very common commands on Linux. Namely, I miss the `script` command.

The list of commands can be seemed here:

https://www.mankier.com/package/util-linux