### PR TITLE
refactor: download bazelisk to /usr/local/bin/bazel

### DIFF
--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -17,9 +17,9 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 # Install Bazel
 ARG BAZELISK_VERSION=v1.10.1
 ARG BAZELISK_DOWNLOAD_SHA=dev-mode
-RUN curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64 \
-    && ([ "${BAZELISK_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check - ) \
-    && chmod 0755 /usr/local/bin/bazelisk
+RUN curl -fSsL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64 \
+    && ([ "${BAZELISK_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazel" | sha256sum --check - ) \
+    && chmod 0755 /usr/local/bin/bazel
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
The original implementation of this links `bazelisk` to `/user/local/bin/bazelisk`, but that means a user would have to type `bazelisk` to have it install bazel. The more natural way for a user to interact in a `bazel` project is just to run `bazel`. If `bazelisk` is linked to the `bazel` path it will automatically fetch `bazel` for the end user and not have to worry about different commands.

Here is an ergonmic example of what I expect as an end user when I start a space using this file

```
@Aghassi ➜ /workspaces/bazel-lib (vscodepsaces/dockerfile ✗) $ which bazel
/usr/local/bin/bazel
@Aghassi ➜ /workspaces/bazel-lib (vscodepsaces/dockerfile ✗) $ bazel
2022/06/18 19:05:05 Downloading https://releases.bazel.build/5.0.0/rolling/5.0.0-pre.20211011.2/bazel-5.0.0-pre.20211011.2-linux-x86_64...
Extracting Bazel installation...
```