### PR TITLE
bazel: update bazelisk to 1.12.0

### DIFF
--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 # Install Bazel
-ARG BAZELISK_VERSION=v1.10.1
+ARG BAZELISK_VERSION=v1.12.0
 ARG BAZELISK_DOWNLOAD_SHA=dev-mode
 RUN curl -fSsL -o /usr/local/bin/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64 \
     && ([ "${BAZELISK_DOWNLOAD_SHA}" = "dev-mode" ] || echo "${BAZELISK_DOWNLOAD_SHA} */usr/local/bin/bazelisk" | sha256sum --check - ) \

--- a/containers/bazel/.devcontainer/devcontainer.json
+++ b/containers/bazel/.devcontainer/devcontainer.json
@@ -3,8 +3,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"BAZELISK_VERSION": "v1.10.1",
-			"BAZELISK_DOWNLOAD_SHA": "4cb534c52cdd47a6223d4596d530e7c9c785438ab3b0a49ff347e991c210b2cd"
+			"BAZELISK_VERSION": "v1.12.0",
+			"BAZELISK_DOWNLOAD_SHA": "6b0bcb2ea15bca16fffabe6fda75803440375354c085480fe361d2cbf32501db"
 		}
 	},
 
@@ -13,9 +13,7 @@
 		// Configure properties specific to VS Code.
 		"vscode": {
 			// Add the IDs of extensions you want installed when the container is created.
-			"extensions": [
-				"devondcarew.bazel-code"
-			]
+			"extensions": ["devondcarew.bazel-code"]
 		}
 	},
 


### PR DESCRIPTION
Small change to update `bazel` container to use `bazelisk` 1.12.0 now instead of 1.10.1.

https://github.com/bazelbuild/bazelisk/releases