### PR TITLE
Fix docker compose command v2 when not using moby

### DIFF
--- a/script-library/docker-debian.sh
+++ b/script-library/docker-debian.sh
@@ -198,6 +198,7 @@ else
         apt-get -y install --no-install-recommends moby-compose || echo "(*) Package moby-compose (Docker Compose v2) not available for OS ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
     else
         apt-get -y install --no-install-recommends docker-ce-cli${cli_version_suffix}
+        apt-get -y install --no-install-recommends docker-compose-plugin || echo "(*) Package docker-compose-plugin (Docker Compose v2) not available for OS ${ID} ${VERSION_CODENAME} (${architecture}). Skipping."
     fi
 fi
 


### PR DESCRIPTION
It's not working because it's not getting installed. :)