### PR TITLE
Add Alpine 3.16

### DIFF
--- a/containers/alpine/.devcontainer/Dockerfile
+++ b/containers/alpine/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Alpine version: 3.15, 3.14, 3.13
-ARG VARIANT=3.15
+# [Choice] Alpine version: 3.16, 3.15, 3.14, 3.13
+ARG VARIANT=3.16
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-alpine-${VARIANT}
 
 # ** [Optional] Uncomment this section to install additional packages. **

--- a/containers/alpine/.devcontainer/base.Dockerfile
+++ b/containers/alpine/.devcontainer/base.Dockerfile
@@ -1,5 +1,5 @@
-# [Choice] Alpine version: 3.15, 3.14, 3.13
-ARG VARIANT=3.15
+# [Choice] Alpine version: 3.16, 3.15, 3.14, 3.13
+ARG VARIANT=3.16
 FROM alpine:${VARIANT}
 
 # [Option] Install zsh

--- a/containers/alpine/.devcontainer/devcontainer.json
+++ b/containers/alpine/.devcontainer/devcontainer.json
@@ -2,8 +2,8 @@
 	"name": "Alpine",
 	"build": {
 		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Alpine version: 3.13, 3.14, 3.15
-		"args": { "VARIANT": "3.15" }
+		// Update 'VARIANT' to pick an Alpine version: 3.13, 3.14, 3.15, 3.16
+		"args": { "VARIANT": "3.16" }
 	},
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/containers/alpine/README.md
+++ b/containers/alpine/README.md
@@ -4,13 +4,13 @@
 
 *Simple Alpine container with Git installed.*
 
-| Metadata | Value |  
+| Metadata | Value |
 |----------|-------|
 | *Contributors* | The VS Code Team |
 | *Categories* | Core, Other |
 | *Definition type* | Dockerfile |
 | *Published images* | mcr.microsoft.com/vscode/devcontainers/base:alpine |
-| *Available image variants* | 3.15, 3.14, 3.13 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
+| *Available image variants* | 3.16, 3.15, 3.14, 3.13 ([full list](https://mcr.microsoft.com/v2/vscode/devcontainers/base/tags/list)) |
 | *Published image architecture(s)* | x86-64, aarch64/arm64 |
 | *Works in Codespaces* | Yes |
 | *Container host OS support* | Linux, macOS, Windows |
@@ -24,7 +24,7 @@ See **[history](history)** for information on the contents of published images.
  While the definition itself works unmodified, you can select the version of Alpine the container uses by updating the `VARIANT` arg in the included `devcontainer.json` (and rebuilding if you've already created the container).
 
 ```json
-"args": { "VARIANT": "3.15" }
+"args": { "VARIANT": "3.16" }
 ```
 
 You can also directly reference pre-built versions of `.devcontainer/base.Dockerfile` by using the `image` property in `.devcontainer/devcontainer.json` or updating the `FROM` statement in your own  `Dockerfile` to one of the following. An example `Dockerfile` is included in this repository.
@@ -33,6 +33,7 @@ You can also directly reference pre-built versions of `.devcontainer/base.Docker
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.13`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.14`
 - `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.15`
+- `mcr.microsoft.com/vscode/devcontainers/base:alpine-3.16`
 
 You can decide how often you want updates by referencing a [semantic version](https://semver.org/) of each image. For example:
 

--- a/containers/alpine/definition-manifest.json
+++ b/containers/alpine/definition-manifest.json
@@ -1,6 +1,6 @@
 {
-	"variants": ["3.15", "3.14", "3.13"],
-	"definitionVersion": "0.204.4",
+	"variants": ["3.16", "3.15", "3.14", "3.13"],
+	"definitionVersion": "0.204.5",
 	"build": {
 		"latest": false,
 		"rootDistro": "alpine",


### PR DESCRIPTION
Alpine 3.16 was released on 2022-05-23 and is currently at 3.16.1. The new version has some updated stable packages. In particular, I'm interested in the updated `fzf` package, which does not depend on `perl`.

UPDATE: I release now that I need to generate release notes in `alpine/history`. Is there a tool I should use to create `history/0.204.5.md`?