### PR TITLE
Update Pylint version

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -204,7 +204,7 @@
                 "Type": "Pip",
                 "Pip": {
                     "Name": "pylint",
-                    "Version": "2.14.3"
+                    "Version": "2.14.5"
                 }
             }
         },
@@ -776,15 +776,6 @@
                     "Name": "Docker Image: php",
                     "Version": "7.4-apache-buster",
                     "DownloadUrl": "https://hub.docker.com/_/php"
-                }
-            }
-        },
-        {
-            "Component": {
-                "Type": "Pip",
-                "Pip": {
-                    "Name": "pylint",
-                    "Version": "2.13.9"
                 }
             }
         },


### PR DESCRIPTION
Update to latest version 2.14.5.

@Chuxel I only found mention of a specific version of Pylint in the cgmanifest - please let me know if I might've missed anything else I should update too.