### PR TITLE
Update mongo tools install for latest available, add bullseye

### DIFF
--- a/containers/javascript-node-mongo/.devcontainer/Dockerfile
+++ b/containers/javascript-node-mongo/.devcontainer/Dockerfile
@@ -2,16 +2,15 @@
 ARG VARIANT=16-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
-# Install MongoDB command line tools if on buster and x86_64 (arm64 not supported)
-ARG MONGO_TOOLS_VERSION=5.0
+# Install MongoDB command line tools - though mongo-database-tools not available on arm64
+ARG MONGO_TOOLS_VERSION=6.0
 RUN . /etc/os-release \
-    && if [ "${VERSION_CODENAME}" = "buster" ] && [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-        curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
-        && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian $(lsb_release -cs)/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
-        && apt-get update && export DEBIAN_FRONTEND=noninteractive \
-        && apt-get install -y mongodb-database-tools mongodb-mongosh \
-        && apt-get clean -y && rm -rf /var/lib/apt/lists/*; \
-    fi
+    && curl -sSL "https://www.mongodb.org/static/pgp/server-${MONGO_TOOLS_VERSION}.asc" | gpg --dearmor > /usr/share/keyrings/mongodb-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/mongodb-archive-keyring.gpg] http://repo.mongodb.org/apt/debian ${VERSION_CODENAME}/mongodb-org/${MONGO_TOOLS_VERSION} main" | tee /etc/apt/sources.list.d/mongodb-org-${MONGO_TOOLS_VERSION}.list \
+    && apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y mongodb-mongosh \
+    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then apt-get install -y mongodb-database-tools; fi \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
The mongo database tools were originally not available for Debian Bullseye when this definition was last edited.  That has since changed.

In addition, arm64 support is not available for mongodb-database-tools but mongodb-mongosh is available. So this ensures the shell is always installed.