### PR TITLE
add bzip2 to common-debian.sh

### DIFF
--- a/script-library/common-debian.sh
+++ b/script-library/common-debian.sh
@@ -89,6 +89,7 @@ if [ "${PACKAGES_ALREADY_INSTALLED}" != "true" ]; then
         rsync \
         ca-certificates \
         unzip \
+        bzip2 \
         zip \
         nano \
         vim-tiny \


### PR DESCRIPTION
The following command throws bzip2 missing:
```sh
wget -O - https://anaconda.org/conda-forge/micromamba/0.25.1/download/linux-64/micromamba-0.25.1-0.tar.bz2 | tar -xvj -f - "bin/micromamba" --strip-components=1
```

--
There are other files extensions that maybe valuable to add too:
```
...
  -j, --bzip2                filter the archive through bzip2
  -J, --xz                   filter the archive through xz
      --lzip                 filter the archive through lzip
      --lzma                 filter the archive through xz
      --lzop                 filter the archive through lzop
      --no-auto-compress     do not use archive suffix to determine the
                             compression program
      --zstd                 filter the archive through zstd
  -z, --gzip, --gunzip, --ungzip   filter the archive through gzip
...
```
*xz, gzip, lzma, ... are already present.