### PR TITLE
rust-debian.sh: fix set -e interaction with nightly rust detection

### DIFF
--- a/script-library/rust-debian.sh
+++ b/script-library/rust-debian.sh
@@ -183,8 +183,8 @@ else
             apt_get_update_if_needed
             apt-get -y install --no-install-recommends git
         fi
-        echo ${RUST_VERSION} | grep -q "nightly"
-        is_nightly=$?
+        is_nightly=0
+        echo ${RUST_VERSION} | grep -q "nightly" || is_nightly=$?
         if [ $is_nightly = 0 ]; then
             check_nightly_version_formatting RUST_VERSION
         else


### PR DESCRIPTION
Currently feature(rust) in devcontainer definition fails
container build unless user specifies nightly rust.

Issue was introduced in commit 10bf6f70c4f467be58dee5df8a7ff19cc598e09f
https://github.com/microsoft/vscode-dev-containers/pull/1554

Lack of "nightly" in RUST_VERSION will result in nonzero return code
from grep. This in turn triggers -e option set for the whole script.
As a result build silently fails.