### PR TITLE
Add missing ctest symlink in PATH directory

### DIFF
--- a/containers/cpp-mariadb/.devcontainer/reinstall-cmake.sh
+++ b/containers/cpp-mariadb/.devcontainer/reinstall-cmake.sh
@@ -56,3 +56,4 @@ sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
 sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
 
 ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest

--- a/containers/cpp/.devcontainer/reinstall-cmake.sh
+++ b/containers/cpp/.devcontainer/reinstall-cmake.sh
@@ -56,3 +56,4 @@ sha256sum -c --ignore-missing "${CMAKE_CHECKSUM_NAME}"
 sh "${TMP_DIR}/${CMAKE_BINARY_NAME}" --prefix=/opt/cmake --skip-license
 
 ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
+ln -s /opt/cmake/bin/ctest /usr/local/bin/ctest


### PR DESCRIPTION
Tools that expect cmake to be on the PATH will likely expect ctest to also be on the PATH, such as the Microsoft's Visual Studio Code extension for CMake.