### PR TITLE
Add notes for migrated history files

### DIFF
--- a/containers/alpine/history/_history-files-have-moved.md
+++ b/containers/alpine/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `base:alpine` image from [devcontainers/images/src/base-alpine](https://github.com/devcontainers/images/tree/main/src/base-alpine).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/codespaces-linux/history/_history-files-have-moved.md
+++ b/containers/codespaces-linux/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `universal` image from [devcontainers/images/src/universal](https://github.com/devcontainers/images/tree/main/src/universal).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/cpp/history/_history-files-have-moved.md
+++ b/containers/cpp/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `cpp` image from [devcontainers/images/src/cpp](https://github.com/devcontainers/images/tree/main/src/cpp).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/debian/history/_history-files-have-moved.md
+++ b/containers/debian/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `base:debian` image from [devcontainers/images/src/base-debian](https://github.com/devcontainers/images/tree/main/src/base-debian).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/dotnet/history/_history-files-have-moved.md
+++ b/containers/dotnet/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `dotnet` image from [devcontainers/images/src/dotnet](https://github.com/devcontainers/images/tree/main/src/dotnet).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/go/history/_history-files-have-moved.md
+++ b/containers/go/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `go` image from [devcontainers/images/src/go](https://github.com/devcontainers/images/tree/main/src/go).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/java-8/history/_history-files-have-moved.md
+++ b/containers/java-8/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `java:8` image from [devcontainers/images/src/java-8](https://github.com/devcontainers/images/tree/main/src/java-8).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/java/history/_history-files-have-moved.md
+++ b/containers/java/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `java` image from [devcontainers/images/src/java](https://github.com/devcontainers/images/tree/main/src/java).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/javascript-node/history/_history-files-have-moved.md
+++ b/containers/javascript-node/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `javascript-node` image from [devcontainers/images/src/javascript-node](https://github.com/devcontainers/images/tree/main/src/javascript-node).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/jekyll/history/_history-files-have-moved.md
+++ b/containers/jekyll/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `jekyll` image from [devcontainers/images/src/jekyll](https://github.com/devcontainers/images/tree/main/src/jekyll).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/php/history/_history-files-have-moved.md
+++ b/containers/php/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `php` image from [devcontainers/images/src/php](https://github.com/devcontainers/images/tree/main/src/php).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/python-3-anaconda/history/_history-files-have-moved.md
+++ b/containers/python-3-anaconda/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `anaconda` image from [devcontainers/images/src/anaconda](https://github.com/devcontainers/images/tree/main/src/anaconda).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/python-3-miniconda/history/_history-files-have-moved.md
+++ b/containers/python-3-miniconda/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `miniconda` image from [devcontainers/images/src/miniconda](https://github.com/devcontainers/images/tree/main/src/miniconda).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/python-3/history/_history-files-have-moved.md
+++ b/containers/python-3/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `python` image from [devcontainers/images/src/python](https://github.com/devcontainers/images/tree/main/src/python).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/ruby/history/_history-files-have-moved.md
+++ b/containers/ruby/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `ruby` image from [devcontainers/images/src/ruby](https://github.com/devcontainers/images/tree/main/src/ruby).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/rust/history/_history-files-have-moved.md
+++ b/containers/rust/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `rust` image from [devcontainers/images/src/rust](https://github.com/devcontainers/images/tree/main/src/rust).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/typescript-node/history/_history-files-have-moved.md
+++ b/containers/typescript-node/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `typescript-node` image from [devcontainers/images/src/typescript-node](https://github.com/devcontainers/images/tree/main/src/typescript-node).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**

--- a/containers/ubuntu/history/_history-files-have-moved.md
+++ b/containers/ubuntu/history/_history-files-have-moved.md
@@ -1,0 +1,5 @@
+**IMPORTANT NOTE: We're starting to migrate contents of this repo to the [devcontainers org](https://github.com/devcontainers), as part of the work on the [open dev container specification](https://containers.dev).**
+
+**We'll now be publishing the `base:ubuntu` image from [devcontainers/images/src/base-ubuntu](https://github.com/devcontainers/images/tree/main/src/base-ubuntu).**
+
+**For more details, you can review the [announcement issue](https://github.com/microsoft/vscode-dev-containers/issues/1589).**


### PR DESCRIPTION
As part of https://github.com/devcontainers/images/pull/106
Adding notes to the `history` files. 

cc @Chuxel 