### PR TITLE
Haskell - Fix GHCup installation

### DIFF
--- a/containers/haskell/.devcontainer/Dockerfile
+++ b/containers/haskell/.devcontainer/Dockerfile
@@ -31,9 +31,7 @@ RUN apt-get update \
 # Install latest GHCup in the non-root user home
 USER $USERNAME
 
-RUN mkdir -p "$HOME/.ghcup/bin" \
-    && curl -LJ "https://downloads.haskell.org/~ghcup/x86_64-linux-ghcup" -o "$HOME/.ghcup/bin/ghcup" \
-    && chmod +x "$HOME/.ghcup/bin/ghcup"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://get-ghcup.haskell.org | sh
 ENV PATH="/home/$USERNAME/.cabal/bin:/home/$USERNAME/.ghcup/bin:$PATH"
 
 # [Choice] GHC version: recommended, latest, 9.2, 9.0, 8.10, 8.8, 8.6


### PR DESCRIPTION
## Problem
GHCup installation fails because of the way it gets installed.

Error:
`
#0 80.95 [ Info  ] Installing GHC (this may take a while)
...
#0 82.44 
#0 85.18 [
[2022-10-08T10:24:48.351Z] 91m[ Error ] Both installation and setting the tool failed. Install error was: Process "gmake" with arguments ["DESTDIR=/home/vscode/.ghcup/tmp/ghcup-3a13a8c583be7176",
#0 85.18 [ ...   ]                                                                                                   "install"] failed with exit code 2. 
#0 85.18 [ ...   ] Set error was: The version 9.2.4 of the tool ghc is not installed.
#0 85.18 [ Error ] Also check the logs in /home/vscode/.ghcup/logs
`


## Solution
Install GHCup as recommended at https://www.haskell.org/ghcup/