### PR TITLE
Updates community templates/definitions

### DIFF
--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -13,7 +13,6 @@ jobs:
         with:
           filters: |
             azure-ansible: ./**/azure-ansible/**
-            azure-cli: ./**/azure-cli/**
             azure-bicep: ./**/azure-bicep/**
             azure-cli: ./**/azure-cli/**
             azure-functions-dotnet-6-inprocess: ./**/azure-functions-dotnet-6-inprocess/**

--- a/.github/workflows/test-pr.yaml
+++ b/.github/workflows/test-pr.yaml
@@ -13,6 +13,47 @@ jobs:
         with:
           filters: |
             azure-ansible: ./**/azure-ansible/**
+            azure-cli: ./**/azure-cli/**
+            azure-bicep: ./**/azure-bicep/**
+            azure-cli: ./**/azure-cli/**
+            azure-functions-dotnet-6-inprocess: ./**/azure-functions-dotnet-6-inprocess/**
+            azure-functions-dotnet-6-isolated: ./**/azure-functions-dotnet-6-isolated/**
+            azure-functions-dotnetcore-3.1: ./**/azure-functions-dotnetcore-3.1/**
+            azure-functions-java-8: ./**/azure-functions-java-8/**
+            azure-functions-java-11: ./**/azure-functions-java-11/**
+            azure-functions-node: ./**/azure-functions-node/**
+            azure-functions-pwsh: ./**/azure-functions-pwsh/**
+            azure-functions-python-3: ./**/azure-functions-python-3/**
+            azure-machine-learning-python-3: ./**/azure-machine-learning-python-3/**
+            azure-static-web-apps: ./**/azure-static-web-apps/**
+            azure-terraform: ./**/azure-terraform/**
+            bash: ./**/bash/**
+            bazel: ./**/bazel/**
+            chef-workstation: ./**/chef-workstation/**
+            clojure: ./**/clojure/**
+            dapr-dotnet: ./**/dapr-dotnet/**
+            dapr-javascript-node: ./**/dapr-javascript-node/**
+            dart: ./**/dart/**
+            deno: ./**/deno/**
+            elixir: ./**/elixir/**
+            elixir-phoenix-postgres: ./**/elixir-phoenix-postgres/**
+            elm: ./**/elm/**
+            haskell: ./**/haskell/**
+            hugo: ./**/hugo/**
+            javascript-node-azurite: ./**/javascript-node-azurite/**
+            julia: ./**/julia/**
+            jupyter-datascience-notebooks: ./**/jupyter-datascience-notebooks/**
+            mit-scheme: ./**/mit-scheme/**
+            perl: ./**/perl/**
+            puppet: ./**/puppet/**
+            python-3-pypy: ./**/python-3-pypy/**
+            r: ./**/r/**
+            reasonml: ./**/reasonml/**
+            ruby-rails: ./**/ruby-rails/**
+            ruby-sinatra: ./**/ruby-sinatra/**
+            sfdx-project: ./**/sfdx-project/**
+            swift: ./**/swift/**
+            vue: ./**/vue/**
 
   test:
     needs: [detect-changes]

--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 COPY library-scripts/*.sh /tmp/library-scripts/
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG upgradePackages="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
@@ -21,11 +21,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 RUN pip3 install ansible[azure]
 
 # [Option] Install Azure CLI
-ARG INSTALL_AZURE_CLI="true"
+ARG INSTALL_AZURE_CLI="${templateOption:installAzureCli}"
 # [Option] Install Docker CLI
-ARG INSTALL_DOCKER="true"
+ARG INSTALL_DOCKER="${templateOption:installDockerCli}"
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
+ARG NODE_VERSION="${templateOption:nodeVersion}"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}

--- a/containers/azure-ansible/.devcontainer/Dockerfile
+++ b/containers/azure-ansible/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
+FROM mcr.microsoft.com/devcontainers/base:bullseye
 
 COPY library-scripts/*.sh /tmp/library-scripts/
 

--- a/containers/azure-ansible/.devcontainer/devcontainer.json
+++ b/containers/azure-ansible/.devcontainer/devcontainer.json
@@ -1,12 +1,7 @@
 {
 	"name": "Azure Ansible (Community)",
 	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			"INSTALL_AZURE_CLI": "true",
-			"INSTALL_DOCKER": "true",
-			"NODE_VERSION": "lts"
-		}
+		"dockerfile": "Dockerfile"
 	},
 	"runArgs": ["--init"],
 	"mounts": [
@@ -36,6 +31,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "ansible --version",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-ansible/devcontainer-template.json
+++ b/containers/azure-ansible/devcontainer-template.json
@@ -1,0 +1,48 @@
+{
+	"id": "azure-ansible",
+	"version": "1.0.0",
+	"name": "Azure Ansible",
+	"description": "Get going quickly with Ansible in Azure. Includes Ansible, the Azure CLI, the Docker CLI (for testing locally), Node.js for Cloud Shell, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-ansible",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages?",
+			"default": "false"
+		},
+		"installAzureCli": {
+			"type": "boolean",
+			"description": "Install Azure CLI!?",
+			"default": "true"
+		},
+		"installDockerCli": {
+			"type": "boolean",
+			"description": "Install Docker CLI!?",
+			"default": "true"
+		},
+		"nodeVersion": {
+			"type": "string",
+			"description": "Node.js version:",
+			"proposals": [
+				"none",
+				"lts/*",
+				"16",
+				"14",
+				"12",
+				"10"
+			],
+			"default": "lts/*"
+		}
+	},
+	"platforms": [
+		"Azure",
+		"Ansible"
+	]
+}

--- a/containers/azure-bicep/.devcontainer/Dockerfile
+++ b/containers/azure-bicep/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] .NET Core version: 3.1, 2.1
 ARG VARIANT=3.1
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${templateOption:imageVariant}
+FROM mcr.microsoft.com/devcontainers/dotnet:0-${templateOption:imageVariant}
 
 COPY library-scripts/azcli-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/azcli-debian.sh \

--- a/containers/azure-bicep/.devcontainer/Dockerfile
+++ b/containers/azure-bicep/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] .NET Core version: 3.1, 2.1
 ARG VARIANT=3.1
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${templateOption:imageVariant}
 
 COPY library-scripts/azcli-debian.sh /tmp/library-scripts/
 RUN bash /tmp/library-scripts/azcli-debian.sh \

--- a/containers/azure-bicep/devcontainer-template.json
+++ b/containers/azure-bicep/devcontainer-template.json
@@ -1,0 +1,23 @@
+{
+	"id": "azure-bicep",
+	"version": "1.0.0",
+	"name": "Azure Bicep",
+	"description": "Debian container with the Azure Bicep, Azure CLI, related extensions, and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-bicep",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": ".NET Core version:",
+			"proposals": [
+				"3.1",
+				"2.1"
+			],
+			"default": "3.1"
+		}
+	},
+	"platforms": [
+		"Azure"
+	]
+}

--- a/containers/azure-cli/.devcontainer/Dockerfile
+++ b/containers/azure-cli/.devcontainer/Dockerfile
@@ -2,9 +2,9 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode

--- a/containers/azure-cli/.devcontainer/Dockerfile
+++ b/containers/azure-cli/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
+FROM mcr.microsoft.com/devcontainers/base:bullseye
 
 # [Option] Install zsh
 ARG INSTALL_ZSH="${templateOption:installZsh}"

--- a/containers/azure-cli/.devcontainer/devcontainer.json
+++ b/containers/azure-cli/.devcontainer/devcontainer.json
@@ -22,6 +22,6 @@
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-cli/devcontainer-template.json
+++ b/containers/azure-cli/devcontainer-template.json
@@ -1,0 +1,24 @@
+{
+	"id": "azure-cli",
+	"version": "1.0.0",
+	"name": "Azure CLI",
+	"description": "Debian container with the Azure CLI, related extensions, and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-cli",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages?",
+			"default": "false"
+		}
+	},
+	"platforms": [
+		"Azure"
+	]
+}

--- a/containers/azure-functions-dotnet-6-inprocess/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnet-6-inprocess/.devcontainer/devcontainer.json
@@ -18,6 +18,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-functions-dotnet-6-inprocess/devcontainer-template.json
+++ b/containers/azure-functions-dotnet-6-inprocess/devcontainer-template.json
@@ -1,0 +1,14 @@
+{
+	"id": "azure-functions-dotnet-6-inprocess",
+	"version": "1.0.0",
+	"name": "Azure Functions & C# - .NET 6 (In-Process)",
+	"description": "Develop Azure Functions in C# (in-process). Includes NET 6, the Azure Functions SDK, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-functions-dotnet-6-inprocess",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Azure Functions",
+		".NET Core",
+		"C#"
+	]
+}

--- a/containers/azure-functions-dotnet-6-isolated/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnet-6-isolated/.devcontainer/devcontainer.json
@@ -18,6 +18,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-functions-dotnet-6-isolated/devcontainer-template.json
+++ b/containers/azure-functions-dotnet-6-isolated/devcontainer-template.json
@@ -1,0 +1,14 @@
+{
+	"id": "azure-functions-dotnet-6-isolated",
+	"version": "1.0.0",
+	"name": "Azure Functions & C- .NET 6 (Isolated)",
+	"description": "Develop Azure Functions in C# (isolated). Includes NET 6, the Azure Functions SDK, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-functions-dotnet-6-isolated",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Azure Functions",
+		".NET Core",
+		"C#"
+	]
+}

--- a/containers/azure-functions-dotnetcore-3.1/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-dotnetcore-3.1/.devcontainer/devcontainer.json
@@ -18,6 +18,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-functions-dotnetcore-3.1/devcontainer-template.json
+++ b/containers/azure-functions-dotnetcore-3.1/devcontainer-template.json
@@ -1,0 +1,14 @@
+{
+	"id": "azure-functions-dotnetcore-3.1",
+	"version": "1.0.0",
+	"name": "Azure Functions & C- .NET Core 3.1",
+	"description": "Develop Azure Functions in C#. Includes NET Core 3.1, the Azure Functions SDK, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-functions-dotnetcore-3.1",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Azure Functions",
+		".NET Core",
+		"C#"
+	]
+}

--- a/containers/azure-functions-java-11/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-11/.devcontainer/devcontainer.json
@@ -22,6 +22,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "java -version",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-functions-java-11/devcontainer-template.json
+++ b/containers/azure-functions-java-11/devcontainer-template.json
@@ -1,0 +1,13 @@
+{
+	"id": "azure-functions-java-11",
+	"version": "1.0.0",
+	"name": "Azure Functions & Java 11",
+	"description": "Develop Azure Functions in Java. Includes JDK 11, Maven, XML tools, the Azure Functions SDK, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-functions-java-11",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Azure Functions",
+		"Java"
+	]
+}

--- a/containers/azure-functions-java-8/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-java-8/.devcontainer/devcontainer.json
@@ -30,6 +30,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "java -version",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-functions-java-8/devcontainer-template.json
+++ b/containers/azure-functions-java-8/devcontainer-template.json
@@ -1,0 +1,13 @@
+{
+	"id": "azure-functions-java-8",
+	"version": "1.0.0",
+	"name": "Azure Functions & Java 8",
+	"description": "Develop Azure Functions in Java. Includes JDK 8, Maven, XML tools, the Azure Functions SDK, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-functions-java-8",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Azure Functions",
+		"Java"
+	]
+}

--- a/containers/azure-functions-node/.devcontainer/Dockerfile
+++ b/containers/azure-functions-node/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 # Node 14: https://github.com/Azure/azure-functions-docker/blob/dev/host/4/bullseye/amd64/node/node14/node14-core-tools.Dockerfile
 # Node 16: https://github.com/Azure/azure-functions-docker/blob/dev/host/4/bullseye/amd64/node/node16/node16-core-tools.Dockerfile
 ARG VARIANT=14
-FROM mcr.microsoft.com/azure-functions/node:4-node${VARIANT}-core-tools
+FROM mcr.microsoft.com/azure-functions/node:4-node${templateOption:imageVariant}-core-tools
 
 # [Optional] Uncomment this section to install additional OS packages.
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/containers/azure-functions-node/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-node/.devcontainer/devcontainer.json
@@ -1,9 +1,7 @@
 {
 	"name": "Azure Functions & Node.js",
 	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick a Node.js version: 14, 16
-		"args": { "VARIANT": "14" }
+		"dockerfile": "Dockerfile"
 	},
 	"forwardPorts": [ 7071 ],
 
@@ -22,6 +20,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "npm install",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"
 }

--- a/containers/azure-functions-node/devcontainer-template.json
+++ b/containers/azure-functions-node/devcontainer-template.json
@@ -1,0 +1,25 @@
+{
+	"id": "azure-functions-node",
+	"version": "1.0.0",
+	"name": "Azure Functions & Node.js",
+	"description": "Develop Azure Functions in Node.js. Includes Node.js, eslint, the Azure Functions SDK, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-functions-node",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Node version:",
+			"proposals": [
+				"14",
+				"16"
+			],
+			"default": "14"
+		}
+	},
+	"platforms": [
+		"Azure Functions",
+		"Node.js",
+		"JavaScript"
+	]
+}

--- a/containers/azure-functions-pwsh/.devcontainer/Dockerfile
+++ b/containers/azure-functions-pwsh/.devcontainer/Dockerfile
@@ -2,5 +2,5 @@
 # https://github.com/Azure/azure-functions-docker/blob/dev/host/3.0/buster/amd64/powershell
 
 # Update the VARIANT arg in devcontainer.json to pick a supported PowerShell version: 7, 6
-ARG VARIANT=7
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/azure-functions/powershell:3.0-powershell${VARIANT}-core-tools

--- a/containers/azure-functions-pwsh/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-pwsh/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
 	"name": "Azure Functions & PowerShell",
 	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			// Update the VARIANT arg to pick a supported PowerShell version: 7, 6
-			"VARIANT": "7"
-		}
+		"dockerfile": "Dockerfile"
 	},
 	"forwardPorts": [ 7071 ],
 
@@ -29,6 +25,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "dotnet restore",
 	
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-functions-pwsh/devcontainer-template.json
+++ b/containers/azure-functions-pwsh/devcontainer-template.json
@@ -1,0 +1,25 @@
+{
+	"id": "azure-functions-pwsh",
+	"version": "1.0.0",
+	"name": "Azure Functions & PowerShell",
+	"description": "Develop Azure Functions in PowerShell. Includes .NET Core , PowerShell, the Azure Functions SDK, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-functions-pwsh",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Update the VARIANT arg in devcontainer.json to pick a supported PowerShell version:",
+			"proposals": [
+				"7",
+				"6"
+			],
+			"default": "7"
+		}
+	},
+	"platforms": [
+		"Azure Functions",
+		".NET Core",
+		"PowerShell"
+	]
+}

--- a/containers/azure-functions-python-3/.devcontainer/devcontainer.json
+++ b/containers/azure-functions-python-3/.devcontainer/devcontainer.json
@@ -19,6 +19,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "npm install",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-functions-python-3/devcontainer-template.json
+++ b/containers/azure-functions-python-3/devcontainer-template.json
@@ -1,0 +1,13 @@
+{
+	"id": "azure-functions-python-3",
+	"version": "1.0.0",
+	"name": "Azure Functions & Python 3",
+	"description": "Develop Azure Functions in Python. Includes Python 3, the Azure Functions SDK, Docker CLI (required to publish to Azure with native dependencies) and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-functions-python-3",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Azure Functions",
+		"Python"
+	]
+}

--- a/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
+++ b/containers/azure-machine-learning-python-3/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Azure ML does not support Debian 10 yet, so cannot use Anaconda image as base
-FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu-18.04
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-18.04
 
 ARG ANACONDA_VERSION=2020.02
 

--- a/containers/azure-machine-learning-python-3/devcontainer-template.json
+++ b/containers/azure-machine-learning-python-3/devcontainer-template.json
@@ -1,0 +1,14 @@
+{
+	"id": "azure-machine-learning-python-3",
+	"version": "1.0.0",
+	"name": "Azure Machine Learning & Python 3 - Anaconda",
+	"description": "Use Azure Machine Learning with Python 3 - Anaconda. Includes Anaconda, the Docker CLI (for local testing), and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-machine-learning-python-3",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Azure Machine Learning",
+		"Python",
+		"Anaconda"
+	]
+}

--- a/containers/azure-static-web-apps/.devcontainer/devcontainer.json
+++ b/containers/azure-static-web-apps/.devcontainer/devcontainer.json
@@ -29,6 +29,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "node --version",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-static-web-apps/devcontainer-template.json
+++ b/containers/azure-static-web-apps/devcontainer-template.json
@@ -1,0 +1,16 @@
+{
+	"id": "azure-static-web-apps",
+	"version": "1.0.0",
+	"name": "Azure Static Web Apps",
+	"description": "Develop Azure Static Web Apps & Azure Functions in any supported language. Includes Node.js, eslint, Python, .NET Core, the Azure Functions SDK, and related extensions and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-static-web-apps",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Azure Functions",
+		"Python",
+		"C#",
+		"Node.js",
+		"JavaScript"
+	]
+}

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -4,9 +4,9 @@ FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
 COPY library-scripts/*.sh /tmp/library-scripts/
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
@@ -18,11 +18,11 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/*
 
 # [Option] Install Azure CLI
-ARG INSTALL_AZURE_CLI="true"
+ARG INSTALL_AZURE_CLI="${templateOption:installAzureCli}"
 # [Option] Install Docker CLI
-ARG INSTALL_DOCKER="true"
+ARG INSTALL_DOCKER="${templateOption:installDockerCli}"
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
+ARG NODE_VERSION="${templateOption:nodeVersion}"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}

--- a/containers/azure-terraform/.devcontainer/Dockerfile
+++ b/containers/azure-terraform/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
+FROM mcr.microsoft.com/devcontainers/base:bullseye
 
 COPY library-scripts/*.sh /tmp/library-scripts/
 

--- a/containers/azure-terraform/.devcontainer/devcontainer.json
+++ b/containers/azure-terraform/.devcontainer/devcontainer.json
@@ -5,10 +5,7 @@
 		"args": { 
 			"TERRAFORM_VERSION": "0.14.5",
 			"TFLINT_VERSION": "0.24.1",
-			"TERRAGRUNT_VERSION": "0.28.1",
-			"INSTALL_AZURE_CLI": "true",
-			"INSTALL_DOCKER": "true",
-			"NODE_VERSION": "lts/*"
+			"TERRAGRUNT_VERSION": "0.28.1"
 		}
 	},
 	"mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ],
@@ -55,6 +52,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "terraform --version",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/azure-terraform/devcontainer-template.json
+++ b/containers/azure-terraform/devcontainer-template.json
@@ -1,0 +1,48 @@
+{
+	"id": "azure-terraform",
+	"version": "1.0.0",
+	"name": "Azure Terraform",
+	"description": "_build, change, and version Azure infrastructure with terraform_",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/azure-terraform",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages?",
+			"default": "false"
+		},
+		"installAzureCli": {
+			"type": "boolean",
+			"description": "Install Azure CLI!?",
+			"default": "true"
+		},
+		"installDockerCli": {
+			"type": "boolean",
+			"description": "Install Docker CLI!?",
+			"default": "true"
+		},
+		"nodeVersion": {
+			"type": "string",
+			"description": "Node.js version:",
+			"proposals": [
+				"none",
+				"lts/*",
+				"16",
+				"14",
+				"12",
+				"10"
+			],
+			"default": "lts/*"
+		}
+	},
+	"platforms": [
+		"Azure",
+		"Terraform"
+	]
+}

--- a/containers/bash/.devcontainer/Dockerfile
+++ b/containers/bash/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
-ARG VARIANT=debian-11
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
 WORKDIR /src
 

--- a/containers/bash/.devcontainer/Dockerfile
+++ b/containers/bash/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon): debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 ARG VARIANT=${templateOption:imageVariant}
-FROM mcr.microsoft.com/vscode/devcontainers/base:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/base:${VARIANT}
 WORKDIR /src
 
 # [Optional] Uncomment this section to install additional OS packages you may want.

--- a/containers/bash/.devcontainer/devcontainer.json
+++ b/containers/bash/.devcontainer/devcontainer.json
@@ -1,10 +1,7 @@
 {
 	"name": "Bash (Community)",
 	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
-		// Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 on local arm64/Apple Silicon
-		"args": { "VARIANT": "debian-11" }
+		"dockerfile": "Dockerfile"
 	},
 
 	// Configure tool-specific properties.

--- a/containers/bash/devcontainer-template.json
+++ b/containers/bash/devcontainer-template.json
@@ -1,0 +1,27 @@
+{
+	"id": "bash",
+	"version": "1.0.0",
+	"name": "Bash",
+	"description": "Develop scripts with Bash, includes [Bash IDE](https://marketplace.visualstudio.com/items?itemName=mads-hartmann.bash-ide-vscode), and [Bash Debug](https://github.com/rogalmic/vscode-bash-debug).",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/bash",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Debian / Ubuntu version (use Debian 11/9, Ubuntu 18.04/21.04 on local arm64/Apple Silicon):",
+			"proposals": [
+				"debian-11",
+				"debian-10",
+				"debian-9",
+				"ubuntu-21.04",
+				"ubuntu-20.04",
+				"ubuntu-18.04"
+			],
+			"default": "debian-11"
+		}
+	},
+	"platforms": [
+		"Bash"
+	]
+}

--- a/containers/bazel/.devcontainer/Dockerfile
+++ b/containers/bazel/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # You can pick any Debian/Ubuntu-based image. 😊
-FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
+FROM mcr.microsoft.com/devcontainers/base:bullseye
 
 # Options for setup script
 ARG INSTALL_ZSH="true"

--- a/containers/bazel/.devcontainer/devcontainer.json
+++ b/containers/bazel/.devcontainer/devcontainer.json
@@ -25,6 +25,6 @@
 	// "postCreateCommand": "uname -a",
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/bazel/devcontainer-template.json
+++ b/containers/bazel/devcontainer-template.json
@@ -1,0 +1,12 @@
+{
+	"id": "bazel",
+	"version": "1.0.0",
+	"name": "Bazel",
+	"description": "Develop and compile efficiently on any language with the Bazel compilation tool.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/bazel",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Any"
+	]
+}

--- a/containers/chef-workstation/devcontainer-template.json
+++ b/containers/chef-workstation/devcontainer-template.json
@@ -1,0 +1,16 @@
+{
+	"id": "chef-workstation",
+	"version": "1.0.0",
+	"name": "Chef Workstation Docker Container",
+	"description": "_Everything you need to get started using Chef products._",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/chef-workstation",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Chef Infra Client",
+		"Chef InSpec",
+		"Chef Command Line Tool",
+		"Test Kitchen",
+		"and Various Test Kitchen and Knife plugins for clouds"
+	]
+}

--- a/containers/clojure/.devcontainer/Dockerfile
+++ b/containers/clojure/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
 ARG VARIANT=${templateOption:imageVariant}
-FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/java:${VARIANT}
 
 # [Optional] Clojure version
 ARG CLOJURE_VERSION=1.10.3

--- a/containers/clojure/.devcontainer/Dockerfile
+++ b/containers/clojure/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 11, 17, 11-bullseye, 17-bullseye, 11-buster, 17-buster
-ARG VARIANT=17
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
 # [Optional] Clojure version
@@ -21,16 +21,16 @@ ENV BOOT_VERSION=2.8.3
 ENV BOOT_CLOJURE_VERSION=${CLOJURE_VERSION}
 
 # [Option] Install Clojure CLI tool
-ARG INSTALL_CLOJURE_CLI="true"
+ARG INSTALL_CLOJURE_CLI="${templateOption:installClojureCli}"
 
 # [Option] Install Boot
-ARG INSTALL_BOOT="true"
+ARG INSTALL_BOOT="${templateOption:installBoot}"
 
 # [Option] Install Leiningen
-ARG INSTALL_LEININGEN="true"
+ARG INSTALL_LEININGEN="${templateOption:installLeiningen}"
 
 # [Option] Install Polylith
-ARG INSTALL_POLYLITH="true"
+ARG INSTALL_POLYLITH="${templateOption:installPolylith}"
 
 RUN if [ "${INSTALL_CLOJURE_CLI}" = "true" ]; then \
     apt-get update \
@@ -68,7 +68,7 @@ RUN if [ "${INSTALL_POLYLITH}" = "true" ]; then \
     && /usr/local/sbin/poly version; fi
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="lts/*"
+ARG NODE_VERSION="${templateOption:nodeVersion}"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/clojure/.devcontainer/devcontainer.json
+++ b/containers/clojure/.devcontainer/devcontainer.json
@@ -3,17 +3,8 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Update the VARIANT arg to pick a Java version.
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use the -bullseye variants on local arm64/Apple Silicon.
-			"VARIANT": "17",
 			// Options
-			"CLOJURE_VERSION": "1.10.3",
-			"INSTALL_CLOJURE_CLI": "true",
-			"INSTALL_BOOT": "true",
-			"INSTALL_LEININGEN": "true",
-			"INSTALL_POLYLITH": "true",
-			"NODE_VERSION": "lts/*"
+			"CLOJURE_VERSION": "1.10.3"
 		}
 	},
 

--- a/containers/clojure/devcontainer-template.json
+++ b/containers/clojure/devcontainer-template.json
@@ -1,0 +1,57 @@
+{
+	"id": "clojure",
+	"version": "1.0.0",
+	"name": "Clojure",
+	"description": "Develop Clojure Applications.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/clojure",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Java version (use -bullseye variants on local arm64/Apple Silicon):",
+			"proposals": [
+				"11",
+				"17",
+				"11-bullseye",
+				"17-bullseye",
+				"11-buster",
+				"17-buster"
+			],
+			"default": "17"
+		},
+		"installClojureCli": {
+			"type": "boolean",
+			"description": "Install Clojure CLI tool",
+			"default": "true"
+		},
+		"installBoot": {
+			"type": "boolean",
+			"description": "Install Boot",
+			"default": "true"
+		},
+		"installLeiningen": {
+			"type": "boolean",
+			"description": "Install Leiningen",
+			"default": "true"
+		},
+		"installPolylith": {
+			"type": "boolean",
+			"description": "Install Polylith",
+			"default": "true"
+		},
+		"nodeVersion": {
+			"type": "string",
+			"description": "Node.js version:",
+			"proposals": [
+				"none",
+				"lts/*",
+				"16",
+				"14",
+				"12",
+				"10"
+			],
+			"default": "lts/*"
+		}
+	}
+}

--- a/containers/dapr-dotnet/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnet/.devcontainer/Dockerfile
@@ -1,21 +1,21 @@
 # [Choice] .NET version: 5.0, 3.1, 2.1
-ARG VARIANT=3.1
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
+ARG NODE_VERSION="${templateOption:nodeVersion}"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # [Option] Install Azure CLI
-ARG INSTALL_AZURE_CLI="false"
+ARG INSTALL_AZURE_CLI="${templateOption:installAzureCli}"
 COPY library-scripts/azcli-debian.sh /tmp/library-scripts/
 RUN if [ "$INSTALL_AZURE_CLI" = "true" ]; then bash /tmp/library-scripts/azcli-debian.sh; fi \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
 
 # [Option] Enable non-root Docker access in container
-ARG ENABLE_NONROOT_DOCKER="true"
+ARG ENABLE_NONROOT_DOCKER="${templateOption:enableNonRootDocker}"
 # [Option] Use the OSS Moby CLI instead of the licensed Docker CLI
-ARG USE_MOBY="true"
+ARG USE_MOBY="${templateOption:moby}"
 
 ARG USERNAME=vscode
 

--- a/containers/dapr-dotnet/.devcontainer/Dockerfile
+++ b/containers/dapr-dotnet/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] .NET version: 5.0, 3.1, 2.1
 ARG VARIANT=${templateOption:imageVariant}
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/dotnet:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="${templateOption:nodeVersion}"

--- a/containers/dapr-dotnet/.devcontainer/devcontainer.json
+++ b/containers/dapr-dotnet/.devcontainer/devcontainer.json
@@ -28,6 +28,6 @@
 	// Ensure Dapr is running on opening the container
 	"postCreateCommand": "dapr uninstall --all && dapr init",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/dapr-dotnet/.devcontainer/docker-compose.yml
+++ b/containers/dapr-dotnet/.devcontainer/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-      args:
-        variant: 3.1
 
     environment:
       ASPNETCORE_Kestrel__Endpoints__Http__Url: http://*:5000

--- a/containers/dapr-dotnet/devcontainer-template.json
+++ b/containers/dapr-dotnet/devcontainer-template.json
@@ -1,0 +1,54 @@
+{
+	"id": "dapr-dotnet",
+	"version": "1.0.0",
+	"name": "Dapr with C#",
+	"description": "Develop Dapr applications using C# and .NET. Includes all needed SDKs, extensions, and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dapr-dotnet",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": ".NET Core version:",
+			"proposals": [
+				"5.0",
+				"3.1",
+				"2.1"
+			],
+			"default": "3.1"
+		},
+		"installAzureCli": {
+			"type": "boolean",
+			"description": "Install Azure CLI!?",
+			"default": "false"
+		},
+		"moby": {
+			"type": "boolean",
+			"default": "true",
+			"description": "Use the OSS Moby CLI instead of the licensed Docker CLI"
+		},
+		"enableNonRootDocker": {
+			"type": "boolean",
+			"description": "Enable non-root Docker access in container?",
+			"default": "true"
+		},
+		"nodeVersion": {
+			"type": "string",
+			"description": "Node.js version:",
+			"proposals": [
+				"none",
+				"lts/*",
+				"16",
+				"14",
+				"12",
+				"10"
+			],
+			"default": "lts/*"
+		}
+	},
+	"platforms": [
+		".NET Core",
+		"C#",
+		"Dapr"
+	]
+}

--- a/containers/dapr-javascript-node/.devcontainer/Dockerfile
+++ b/containers/dapr-javascript-node/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
 # [Choice] Node.js version: 18, 16, 14
-ARG VARIANT=16
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 
 # [Option] Enable non-root Docker access in container
-ARG ENABLE_NONROOT_DOCKER="true"
+ARG ENABLE_NONROOT_DOCKER="${templateOption:enableNonRootDocker}"
 # [Option] Use the OSS Moby Engine instead of the licensed Docker Engine
-ARG USE_MOBY="true"
+ARG USE_MOBY="${templateOption:moby}"
 
 ARG USERNAME=node
 

--- a/containers/dapr-javascript-node/.devcontainer/Dockerfile
+++ b/containers/dapr-javascript-node/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Node.js version: 18, 16, 14
 ARG VARIANT=${templateOption:imageVariant}
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/javascript-node:${VARIANT}
 
 # [Option] Enable non-root Docker access in container
 ARG ENABLE_NONROOT_DOCKER="${templateOption:enableNonRootDocker}"

--- a/containers/dapr-javascript-node/.devcontainer/devcontainer.json
+++ b/containers/dapr-javascript-node/.devcontainer/devcontainer.json
@@ -29,6 +29,6 @@
 	// Ensure Dapr is running on opening the container
 	"postCreateCommand": "dapr uninstall --all && dapr init",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"
 }

--- a/containers/dapr-javascript-node/.devcontainer/docker-compose.yml
+++ b/containers/dapr-javascript-node/.devcontainer/docker-compose.yml
@@ -4,8 +4,6 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-      args:
-        variant: 16-bullseye
 
     environment:
       DAPR_NETWORK: dapr-dev-container

--- a/containers/dapr-javascript-node/devcontainer-template.json
+++ b/containers/dapr-javascript-node/devcontainer-template.json
@@ -1,0 +1,36 @@
+{
+	"id": "dapr-javascript-node",
+	"version": "1.0.0",
+	"name": "Dapr with Node.js & JavaScript",
+	"description": "Develop Dapr applications using Node.js and JavaScript. Includes Dapr, Node.js, eslint, yarn, and the TypeScript compiler.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dapr-javascript-node",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Node.js version:",
+			"proposals": [
+				"18",
+				"16",
+				"14"
+			],
+			"default": "16"
+		},
+		"moby": {
+			"type": "boolean",
+			"default": "true",
+			"description": "Use the OSS Moby CLI instead of the licensed Docker CLI"
+		},
+		"enableNonRootDocker": {
+			"type": "boolean",
+			"description": "Enable non-root Docker access in container?",
+			"default": "true"
+		}
+	},
+	"platforms": [
+		"Node.js",
+		"TypeScript",
+		"Dapr"
+	]
+}

--- a/containers/dapr-javascript-node/test-project/package.json
+++ b/containers/dapr-javascript-node/test-project/package.json
@@ -14,17 +14,17 @@
 		"test": " REGRESSION_TESTING=true npm start"
 	},
 	"dependencies": {
-		"express": "^4.16.1",
-		"isomorphic-fetch": "^2.2.1",
-		"tslint-to-eslint-config": "^0.2.11"
+		"express": "^4.18.2",
+		"isomorphic-fetch": "^3.0.0",
+		"tslint-to-eslint-config": "^2.13.3"
 	},
 	"devDependencies": {
-		"@types/express": "^4.16.0",
-		"@types/isomorphic-fetch": "0.0.35",
-		"@types/node": "^8.0.0",
-		"@typescript-eslint/eslint-plugin": "^2.6.1",
-		"@typescript-eslint/parser": "^2.6.1",
-		"eslint": "^6.6.0",
-		"typescript": "^3.7.2"
+		"@types/express": "^4.17.14",
+		"@types/isomorphic-fetch": "0.0.36",
+		"@types/node": "^18.8.3",
+		"@typescript-eslint/eslint-plugin": "^5.40.0",
+		"@typescript-eslint/parser": "^5.40.0",
+		"eslint": "^8.25.0",
+		"typescript": "^4.8.4"
 	}
 }

--- a/containers/dart/.devcontainer/Dockerfile
+++ b/containers/dart/.devcontainer/Dockerfile
@@ -3,9 +3,9 @@ ARG VARIANT=2
 FROM dart:${VARIANT}
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode

--- a/containers/dart/.devcontainer/devcontainer.json
+++ b/containers/dart/.devcontainer/devcontainer.json
@@ -23,6 +23,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/dart/devcontainer-template.json
+++ b/containers/dart/devcontainer-template.json
@@ -1,0 +1,24 @@
+{
+	"id": "dart",
+	"version": "1.0.0",
+	"name": "Dart",
+	"description": "Develop Dart based applications. Includes the Dart SDK, needed extensions, and dependencies.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/dart",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages?",
+			"default": "false"
+		}
+	},
+	"platforms": [
+		"Dart"
+	]
+}

--- a/containers/deno/.devcontainer/Dockerfile
+++ b/containers/deno/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Debian OS version: bullseye, buster
-ARG VARIANT=bullseye
+ARG VARIANT=${templateOption:imageVariant}
 FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
 
 ENV DENO_INSTALL=/deno

--- a/containers/deno/.devcontainer/Dockerfile
+++ b/containers/deno/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Debian OS version: bullseye, buster
 ARG VARIANT=${templateOption:imageVariant}
-FROM --platform=linux/amd64 mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+FROM --platform=linux/amd64 mcr.microsoft.com/devcontainers/base:0-${VARIANT}
 
 ENV DENO_INSTALL=/deno
 RUN mkdir -p /deno \

--- a/containers/deno/.devcontainer/devcontainer.json
+++ b/containers/deno/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
 	"name": "Deno",
  	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Debian OS version: bullseye, buster
-		"args": {
-			"VARIANT": "bullseye"
-		}
+		"dockerfile": "Dockerfile"
 	},
 
 	// Configure tool-specific properties.

--- a/containers/deno/devcontainer-template.json
+++ b/containers/deno/devcontainer-template.json
@@ -1,0 +1,25 @@
+{
+	"id": "deno",
+	"version": "1.0.0",
+	"name": "Deno",
+	"description": "Develop Deno applications. Includes the latest Deno runtime and extension.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/deno",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Debian OS version:",
+			"proposals": [
+				"bullseye",
+				"buster"
+			],
+			"default": "bullseye"
+		}
+	},
+	"platforms": [
+		"Deno",
+		"TypeScript",
+		"JavaScript"
+	]
+}

--- a/containers/elixir-phoenix-postgres/devcontainer-template.json
+++ b/containers/elixir-phoenix-postgres/devcontainer-template.json
@@ -1,0 +1,13 @@
+{
+	"id": "elixir-phoenix-postgres",
+	"version": "1.0.0",
+	"name": "Elixir, Phoenix, Node.js & PostgresSQL",
+	"description": "Develop Elixir/Phoenix based applications. Includes everything you need to get up and running.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/elixir-phoenix-postgres",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Elixir",
+		"Postgres DB"
+	]
+}

--- a/containers/elixir/devcontainer-template.json
+++ b/containers/elixir/devcontainer-template.json
@@ -1,0 +1,12 @@
+{
+	"id": "elixir",
+	"version": "1.0.0",
+	"name": "Elixir",
+	"description": "Develop Elixir based applications. Includes everything you need to get up and running.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/elixir",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Elixir"
+	]
+}

--- a/containers/elm/.devcontainer/Dockerfile
+++ b/containers/elm/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:16
+FROM mcr.microsoft.com/devcontainers/javascript-node:16
 
 # Configuring Elm version
 ARG ELM_VERSION=latest-0.19.1

--- a/containers/elm/devcontainer-template.json
+++ b/containers/elm/devcontainer-template.json
@@ -1,0 +1,12 @@
+{
+	"id": "elm",
+	"version": "1.0.0",
+	"name": "Elm",
+	"description": "Develop Elm based applications. Includes the Elm language server extension & binary",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/elm",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Elm"
+	]
+}

--- a/containers/haskell/.devcontainer/Dockerfile
+++ b/containers/haskell/.devcontainer/Dockerfile
@@ -3,9 +3,9 @@ FROM debian:bullseye-slim
 ENV LANG C.UTF-8
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user.
 # Use a separate RUN statement to add your own dependencies
@@ -37,7 +37,7 @@ RUN mkdir -p "$HOME/.ghcup/bin" \
 ENV PATH="/home/$USERNAME/.cabal/bin:/home/$USERNAME/.ghcup/bin:$PATH"
 
 # [Choice] GHC version: recommended, latest, 9.2, 9.0, 8.10, 8.8, 8.6
-ARG GHC_VERSION="recommended"
+ARG GHC_VERSION="${templateOption:ghcVersion}"
 
 # Use GHCup to install versions of main utilities
 # If you prefer to let the Haskell extension install everything on demand,

--- a/containers/haskell/.devcontainer/devcontainer.json
+++ b/containers/haskell/.devcontainer/devcontainer.json
@@ -1,11 +1,7 @@
 {
   "name": "Haskell (Community)",
   "build": {
-    "dockerfile": "Dockerfile",
-    "args": {
-      // Update 'GHC_VERSION' to pick a GHC version: recommended, latest, 9.2, 9.0, 8.10, 8.8, 8.6
-      "GHC_VERSION": "recommended"
-    }
+    "dockerfile": "Dockerfile"
   },
   // Configure tool-specific properties.
   "customizations": {

--- a/containers/haskell/devcontainer-template.json
+++ b/containers/haskell/devcontainer-template.json
@@ -1,0 +1,38 @@
+{
+	"id": "haskell",
+	"version": "1.0.0",
+	"name": "Haskell",
+	"description": "_This definition will hopefully get you going quickly with Haskell running as a remote container in vscode_",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/haskell",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages?",
+			"default": "false"
+		},
+		"ghcVersion": {
+			"type": "string",
+			"description": "GHC version:",
+			"proposals": [
+				"recommended",
+				"latest",
+				"9.2",
+				"9.0",
+				"8.10",
+				"8.8",
+				"8.6"
+			],
+			"default": "recommended"
+		}
+	},
+	"platforms": [
+		"Haskell"
+	]
+}

--- a/containers/hugo/.devcontainer/Dockerfile
+++ b/containers/hugo/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # Update the NODE_VERSION arg in docker-compose.yml to pick a Node version: 18, 16, 14
 ARG NODE_VERSION=16
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
+FROM mcr.microsoft.com/devcontainers/javascript-node:${NODE_VERSION}
 
 # VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
 ARG VARIANT=hugo

--- a/containers/hugo/.devcontainer/devcontainer.json
+++ b/containers/hugo/.devcontainer/devcontainer.json
@@ -41,6 +41,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"
 }

--- a/containers/hugo/devcontainer-template.json
+++ b/containers/hugo/devcontainer-template.json
@@ -1,0 +1,12 @@
+{
+	"id": "hugo",
+	"version": "1.0.0",
+	"name": "Hugo",
+	"description": "Develop static sites with Hugo, includes everything you need to get up and running.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/hugo",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Hugo"
+	]
+}

--- a/containers/javascript-node-azurite/.devcontainer/Dockerfile
+++ b/containers/javascript-node-azurite/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
 ARG VARIANT=${templateOption:imageVariant}
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/javascript-node:${VARIANT}
 USER root
 RUN apt-get update
 RUN apt-get install libsecret-1-dev -y

--- a/containers/javascript-node-azurite/.devcontainer/Dockerfile
+++ b/containers/javascript-node-azurite/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-ARG VARIANT=16-bullseye
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${VARIANT}
 USER root
 RUN apt-get update

--- a/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
+++ b/containers/javascript-node-azurite/.devcontainer/docker-compose.yml
@@ -5,11 +5,6 @@ services:
     build: 
       context: .
       dockerfile: Dockerfile
-      args:
-        # Update 'VARIANT' to pick an LTS version of Node.js: 18, 16, 14.
-        # Append -bullseye or -buster to pin to an OS version.
-        # Use -bullseye variants on local arm64/Apple Silicon.
-        VARIANT: 16-bullseye
 
     volumes:
       - ..:/workspace:cached

--- a/containers/javascript-node-azurite/devcontainer-template.json
+++ b/containers/javascript-node-azurite/devcontainer-template.json
@@ -1,0 +1,31 @@
+{
+	"id": "javascript-node-azurite",
+	"version": "1.0.0",
+	"name": "Node.js & Azurite",
+	"description": "Everything you need to get started using Node with Azurite.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/javascript-node-azurite",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Node.js version (use -bullseye variants on local arm64/Apple Silicon):",
+			"proposals": [
+				"18",
+				"16",
+				"14",
+				"18-bullseye",
+				"16-bullseye",
+				"14-bullseye",
+				"18-buster",
+				"16-buster",
+				"14-buster"
+			],
+			"default": "16-bullseye"
+		}
+	},
+	"platforms": [
+		"Azurite",
+		"Node.js"
+	]
+}

--- a/containers/julia/devcontainer-template.json
+++ b/containers/julia/devcontainer-template.json
@@ -1,0 +1,12 @@
+{
+	"id": "julia",
+	"version": "1.0.0",
+	"name": "Julia",
+	"description": "Develop Julia applications.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/julia",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Julia"
+	]
+}

--- a/containers/jupyter-datascience-notebooks/.devcontainer/devcontainer.json
+++ b/containers/jupyter-datascience-notebooks/.devcontainer/devcontainer.json
@@ -34,6 +34,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "jovyan"
 }

--- a/containers/jupyter-datascience-notebooks/devcontainer-template.json
+++ b/containers/jupyter-datascience-notebooks/devcontainer-template.json
@@ -1,0 +1,18 @@
+{
+	"id": "jupyter-datascience-notebooks",
+	"version": "1.0.0",
+	"name": "Jupyter Data Science Notebooks",
+	"description": "Use Jupyter Data Science Notebooks with Python, R, Julia, and more.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/jupyter-datascience-notebooks",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Python",
+		"R",
+		"Julia",
+		"numpy",
+		"pandas",
+		"tidyverse",
+		"much more"
+	]
+}

--- a/containers/mit-scheme/.devcontainer/Dockerfile
+++ b/containers/mit-scheme/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
 # [Choice] Debian version: buster, stretch
-ARG VARIANT_DEBIAN="buster"
+ARG VARIANT_DEBIAN="${templateOption:imageVariant}"
 FROM buildpack-deps:${VARIANT_DEBIAN}-curl
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="true"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.

--- a/containers/mit-scheme/.devcontainer/devcontainer.json
+++ b/containers/mit-scheme/.devcontainer/devcontainer.json
@@ -15,6 +15,6 @@
 	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
 	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/mit-scheme/devcontainer-template.json
+++ b/containers/mit-scheme/devcontainer-template.json
@@ -1,0 +1,33 @@
+{
+	"id": "mit-scheme",
+	"version": "1.0.0",
+	"name": "MIT-Scheme",
+	"description": "Simple mit-scheme container with Git installed.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/mit-scheme",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Debian version:",
+			"proposals": [
+				"buster",
+				"stretch"
+			],
+			"default": "buster"
+		},
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages?",
+			"default": "true"
+		}
+	},
+	"platforms": [
+		"MIT-Scheme"
+	]
+}

--- a/containers/perl/.devcontainer/Dockerfile
+++ b/containers/perl/.devcontainer/Dockerfile
@@ -3,9 +3,9 @@ ARG VARIANT=5
 FROM perl:${VARIANT}
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode

--- a/containers/perl/.devcontainer/devcontainer.json
+++ b/containers/perl/.devcontainer/devcontainer.json
@@ -25,6 +25,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "perl -v",
 	
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/perl/devcontainer-template.json
+++ b/containers/perl/devcontainer-template.json
@@ -1,0 +1,24 @@
+{
+	"id": "perl",
+	"version": "1.0.0",
+	"name": "Perl",
+	"description": "Develop Perl applications on Linux",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/perl",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages to their latest versions",
+			"default": "false"
+		}
+	},
+	"platforms": [
+		"Perl"
+	]
+}

--- a/containers/puppet/devcontainer-template.json
+++ b/containers/puppet/devcontainer-template.json
@@ -1,0 +1,12 @@
+{
+	"id": "puppet",
+	"version": "1.0.0",
+	"name": "Puppet Development Kit Docker Container",
+	"description": "Develop Puppet based applications. Includes everything you need to get up and running.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/puppet",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Puppet"
+	]
+}

--- a/containers/python-3-pypy/.devcontainer/Dockerfile
+++ b/containers/python-3-pypy/.devcontainer/Dockerfile
@@ -1,13 +1,13 @@
 # [Choice] Pypy version: 2, 3
-ARG VARIANT="3"
+ARG VARIANT="${templateOption:imageVariant}"
 FROM pypy:${VARIANT}
 
 # Use the [Option] comment to specify true/false arguments that should appear in VS Code UX
 #
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode

--- a/containers/python-3-pypy/.devcontainer/devcontainer.json
+++ b/containers/python-3-pypy/.devcontainer/devcontainer.json
@@ -3,9 +3,7 @@
 
 	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
 	"build": {
-		"dockerfile": "Dockerfile",
-		// [Optional] You can use build args to set options. e.g. 'VARIANT' below affects the image in the Dockerfile
-		"args": { "VARIANT": "3" }
+		"dockerfile": "Dockerfile"
 	},
 
 	// Configure tool-specific properties.

--- a/containers/python-3-pypy/devcontainer-template.json
+++ b/containers/python-3-pypy/devcontainer-template.json
@@ -1,0 +1,34 @@
+{
+	"id": "python-3-pypy",
+	"version": "1.0.0",
+	"name": "PyPy",
+	"description": "Develop python applications using the PyPy interpreter",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/python-3-pypy",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Pypy version:",
+			"proposals": [
+				"2",
+				"3"
+			],
+			"default": "3"
+		},
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages?",
+			"default": "false"
+		}
+	},
+	"platforms": [
+		"Python",
+		"PyPy"
+	]
+}

--- a/containers/r/.devcontainer/Dockerfile
+++ b/containers/r/.devcontainer/Dockerfile
@@ -1,13 +1,13 @@
 # [Choice] R version: 4, 4.2, 4.1, 4.0
-ARG VARIANT=4
+ARG VARIANT=${templateOption:imageVariant}
 # [Choice] Base image. Minimal (r-ver), tidyverse installed (tidyverse), or full image (binder): rocker/r-ver, rocker/tidyverse, rocker/binder
-ARG BASE_IMAGE=rocker/r-ver
+ARG BASE_IMAGE=${templateOption:baseVariant}
 FROM ${BASE_IMAGE}:${VARIANT}
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=rstudio
@@ -45,7 +45,7 @@ RUN export TAG=$(git ls-remote --tags --refs --sort='version:refname' https://gi
 RUN echo 'if (interactive() && Sys.getenv("TERM_PROGRAM") == "vscode") source(file.path(Sys.getenv("HOME"), ".vscode-R", "init.R"))' >>"${R_HOME}/etc/Rprofile.site"
 
 # [Option] Enable vscode-jupyter support
-ARG ENABLE_JUPYTER="false"
+ARG ENABLE_JUPYTER="${templateOption:enableJupyter}"
 RUN if [ "${ENABLE_JUPYTER}" = "true" ]; then \
         if [ -z "$(dpkg --get-selections | grep libzmq3-dev)" ]; then \
             apt-get update \

--- a/containers/r/.devcontainer/devcontainer.json
+++ b/containers/r/.devcontainer/devcontainer.json
@@ -1,16 +1,7 @@
 {
 	"name": "R (Community)",
 	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			// Update VARIANT to pick a R version: 4, 4.2, 4.1, 4.0
-			"VARIANT": "4",
-			// Start with a minimal image (rocker/r-ver) or a expanded image.
-			// See more details about rocker/r-ver's derived images: https://github.com/rocker-org/rocker-versioned2
-			"BASE_IMAGE": "rocker/r-ver",
-			// Options
-			"ENABLE_JUPYTER": "false"
-		}
+		"dockerfile": "Dockerfile"
 	},
 
 	// Configure tool-specific properties.
@@ -41,6 +32,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "R --version",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "rstudio"
 }

--- a/containers/r/devcontainer-template.json
+++ b/containers/r/devcontainer-template.json
@@ -1,0 +1,50 @@
+{
+	"id": "r",
+	"version": "1.0.0",
+	"name": "R",
+	"description": "Perform statistical computing using the R language on Linux. Includes R and needed extensions.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/r",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "R version:",
+			"proposals": [
+				"4",
+				"4.2",
+				"4.1",
+				"4.0"
+			],
+			"default": "4"
+		},
+		"baseVariant": {
+			"type": "string",
+			"description": "Base image. Minimal (r-ver), tidyverse installed (tidyverse), or full image (binder):",
+			"proposals": [
+				"rocker/r-ver",
+				"rocker/tidyverse",
+				"rocker/binder"
+			],
+			"default": "4"
+		},
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages to their latest versions",
+			"default": "false"
+		},
+		"enableJupyter": {
+			"type": "boolean",
+			"description": "Enable vscode-jupyter support",
+			"default": "false"
+		}
+	},
+	"platforms": [
+		"R"
+	]
+}

--- a/containers/r/devcontainer-template.json
+++ b/containers/r/devcontainer-template.json
@@ -26,7 +26,7 @@
 				"rocker/tidyverse",
 				"rocker/binder"
 			],
-			"default": "4"
+			"default": "rocker/r-ver"
 		},
 		"installZsh": {
 			"type": "boolean",

--- a/containers/reasonml/.devcontainer/Dockerfile
+++ b/containers/reasonml/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:16-bullseye
+FROM mcr.microsoft.com/devcontainers/javascript-node:16-bullseye
 
 RUN sudo -u node npm install -g bs-platform esy@latest
 

--- a/containers/reasonml/.devcontainer/devcontainer.json
+++ b/containers/reasonml/.devcontainer/devcontainer.json
@@ -19,6 +19,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "yarn install",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/reasonml/.devcontainer/devcontainer.json
+++ b/containers/reasonml/.devcontainer/devcontainer.json
@@ -20,5 +20,5 @@
 	// "postCreateCommand": "yarn install",
 
 	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "node"
 }

--- a/containers/reasonml/devcontainer-template.json
+++ b/containers/reasonml/devcontainer-template.json
@@ -1,0 +1,12 @@
+{
+	"id": "reasonml",
+	"version": "1.0.0",
+	"name": "ReasonML",
+	"description": "Develop ReasonML applications.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/reasonml",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"ReasonML"
+	]
+}

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=${templateOption:imageVariant}
-FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
 
 # Install Rails
 RUN gem install rails webdrivers

--- a/containers/ruby-rails/.devcontainer/Dockerfile
+++ b/containers/ruby-rails/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
-ARG VARIANT=2-bullseye
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 # Install Rails
@@ -10,7 +10,7 @@ RUN gem install rails webdrivers
 ENV RAILS_DEVELOPMENT_HOSTS=".githubpreview.dev,.app.github.dev"
 
 # [Choice] Node.js version: lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="lts/*"
+ARG NODE_VERSION="${templateOption:nodeVersion}"
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/ruby-rails/.devcontainer/devcontainer.json
+++ b/containers/ruby-rails/.devcontainer/devcontainer.json
@@ -1,14 +1,7 @@
 {
 	"name": "Ruby on Rails (Community)",
 	"build": {
-		"dockerfile": "Dockerfile",
-		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.1, 3.0, 2, 2.7, 2.6, 2.5
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "2-bullseye",
-			"NODE_VERSION": "lts/*"
-		}
+		"dockerfile": "Dockerfile"
 	},
 
 	// Configure tool-specific properties.
@@ -28,6 +21,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "ruby --version",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/ruby-rails/devcontainer-template.json
+++ b/containers/ruby-rails/devcontainer-template.json
@@ -1,0 +1,52 @@
+{
+	"id": "ruby-rails",
+	"version": "1.0.0",
+	"name": "Ruby on Rails",
+	"description": "_Develop Ruby on Rails applications, includes everything you need to get up and running._",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ruby-rails",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Ruby version (use -bullseye variants on local arm64/Apple Silicon):",
+			"proposals": [
+				"3",
+				"3.1",
+				"3.0",
+				"2",
+				"2.7",
+				"2.6",
+				"3-bullseye",
+				"3.1-bullseye",
+				"3.0-bullseye",
+				"2-bullseye",
+				"2.7-bullseye",
+				"2.6-bullseye",
+				"3-buster",
+				"3.1-buster",
+				"3.0-buster",
+				"2-buster",
+				"2.7-buster",
+				"2.6-buster"
+			],
+			"default": "2-bullseye"
+		},
+		"nodeVersion": {
+			"type": "string",
+			"description": "Node.js version:",
+			"proposals": [
+				"none",
+				"lts/*",
+				"16",
+				"14",
+				"12",
+				"10"
+			],
+			"default": "lts/*"
+		}
+	},
+	"platforms": [
+		"Ruby"
+	]
+}

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
 ARG VARIANT=${templateOption:imageVariant}
-FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
+FROM mcr.microsoft.com/devcontainers/ruby:${VARIANT}
 
 # Install Sinatra
 RUN gem install sinatra sinatra-reloader thin data_mapper dm-sqlite-adapter 

--- a/containers/ruby-sinatra/.devcontainer/Dockerfile
+++ b/containers/ruby-sinatra/.devcontainer/Dockerfile
@@ -1,12 +1,12 @@
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 2.6, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 2.6-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster, 2.6-buster
-ARG VARIANT=2-bullseye
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:${VARIANT}
 
 # Install Sinatra
 RUN gem install sinatra sinatra-reloader thin data_mapper dm-sqlite-adapter 
 
 # [Choice] Node.js version: lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="lts/*"
+ARG NODE_VERSION="${templateOption:nodeVersion}"
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"
 
 # [Optional] Uncomment this section to install additional OS packages.

--- a/containers/ruby-sinatra/.devcontainer/devcontainer.json
+++ b/containers/ruby-sinatra/.devcontainer/devcontainer.json
@@ -1,14 +1,7 @@
 {
 	"name": "Ruby & Sinatra (Community)",
 	"build": {
-		"dockerfile": "Dockerfile",
-		"args": { 
-			// Update 'VARIANT' to pick a Ruby version: 3, 3.1, 3.0, 2, 2.7, 2.6, 2.5
-			// Append -bullseye or -buster to pin to an OS version.
-			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "2-bullseye",
-			"NODE_VERSION": "lts/*"
-		}
+		"dockerfile": "Dockerfile"
 	},
 
 	// Configure tool-specific properties.
@@ -28,6 +21,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/ruby-sinatra/devcontainer-template.json
+++ b/containers/ruby-sinatra/devcontainer-template.json
@@ -1,0 +1,52 @@
+{
+	"id": "ruby-sinatra",
+	"version": "1.0.0",
+	"name": "Ruby & Sinatra",
+	"description": "Develop Ruby and Sinatra applications. Includes everything you need to get up and running.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ruby-sinatra",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Ruby version (use -bullseye variants on local arm64/Apple Silicon):",
+			"proposals": [
+				"3",
+				"3.1",
+				"3.0",
+				"2",
+				"2.7",
+				"2.6",
+				"3-bullseye",
+				"3.1-bullseye",
+				"3.0-bullseye",
+				"2-bullseye",
+				"2.7-bullseye",
+				"2.6-bullseye",
+				"3-buster",
+				"3.1-buster",
+				"3.0-buster",
+				"2-buster",
+				"2.7-buster",
+				"2.6-buster"
+			],
+			"default": "2-bullseye"
+		},
+		"nodeVersion": {
+			"type": "string",
+			"description": "Node.js version:",
+			"proposals": [
+				"none",
+				"lts/*",
+				"16",
+				"14",
+				"12",
+				"10"
+			],
+			"default": "lts/*"
+		}
+	},
+	"platforms": [
+		"Ruby"
+	]
+}

--- a/containers/sfdx-project/devcontainer-template.json
+++ b/containers/sfdx-project/devcontainer-template.json
@@ -1,0 +1,21 @@
+{
+	"id": "sfdx-project",
+	"version": "1.0.0",
+	"name": "SFDX Project",
+	"description": "Salesforce Extension for VS Code supports remote development and allows you to use a docker container as a full-featured development environment.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/sfdx-project",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"platforms": [
+		"Salesforce CLI",
+		"Lightning Web Components",
+		"Apex",
+		"Aura",
+		"Java",
+		"Node.js",
+		"JavaScript",
+		"HTML",
+		"CSS",
+		"Git"
+	]
+}

--- a/containers/swift/.devcontainer/Dockerfile
+++ b/containers/swift/.devcontainer/Dockerfile
@@ -1,11 +1,11 @@
 # [Choice] Swift version: 5.6-focal, 5.5, 5.4, 5.3, 5.2, 5.1, 4.2
-ARG VARIANT=5.6-focal
+ARG VARIANT=${templateOption:imageVariant}
 FROM swift:${VARIANT}
 
 # [Option] Install zsh
-ARG INSTALL_ZSH="true"
+ARG INSTALL_ZSH="${templateOption:installZsh}"
 # [Option] Upgrade OS packages to their latest versions
-ARG UPGRADE_PACKAGES="false"
+ARG UPGRADE_PACKAGES="${templateOption:upgradePackages}"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
 ARG USERNAME=vscode
@@ -17,7 +17,7 @@ RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt-get autoremove -y && apt-get clean -y && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/library-scripts
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
-ARG NODE_VERSION="none"
+ARG NODE_VERSION="${templateOption:nodeVersion}"
 ENV NVM_DIR=/usr/local/share/nvm
 ENV NVM_SYMLINK_CURRENT=true \
     PATH=${NVM_DIR}/current/bin:${PATH}

--- a/containers/swift/.devcontainer/devcontainer.json
+++ b/containers/swift/.devcontainer/devcontainer.json
@@ -1,13 +1,7 @@
 {
 	"name": "Swift (Community)",
 	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			// Update the VARIANT arg to pick a Swift version 
-			"VARIANT": "5.6-focal",
-			// Options
-			"NODE_VERSION": "lts/*"
-		}
+		"dockerfile": "Dockerfile"
 	},
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
@@ -37,6 +31,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "",
 
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/containers/swift/devcontainer-template.json
+++ b/containers/swift/devcontainer-template.json
@@ -1,0 +1,51 @@
+{
+	"id": "swift",
+	"version": "1.0.0",
+	"name": "Swift",
+	"description": "Develop Swift based applications. Includes everything you need to get up and running.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/swift",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Swift version:",
+			"proposals": [
+				"5.6-focal",
+				"5.5",
+				"5.4",
+				"5.3",
+				"5.2",
+				"5.1",
+				"4.2"
+			],
+			"default": "5.6-focal"
+		},
+		"installZsh": {
+			"type": "boolean",
+			"description": "Install ZSH!?",
+			"default": "true"
+		},
+		"upgradePackages": {
+			"type": "boolean",
+			"description": "Upgrade OS packages to their latest versions",
+			"default": "false"
+		},
+		"nodeVersion": {
+			"type": "string",
+			"description": "Node.js version:",
+			"proposals": [
+				"none",
+				"lts/*",
+				"16",
+				"14",
+				"12",
+				"10"
+			],
+			"default": "lts/*"
+		}
+	},
+	"platforms": [
+		"Swift"
+	]
+}

--- a/containers/vue/.devcontainer/Dockerfile
+++ b/containers/vue/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
-ARG VARIANT=16
+ARG VARIANT=${templateOption:imageVariant}
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
 
 RUN su node -c "umask 0002 && npm install -g http-server @vue/cli @vue/cli-service-global"

--- a/containers/vue/.devcontainer/Dockerfile
+++ b/containers/vue/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
 ARG VARIANT=${templateOption:imageVariant}
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+FROM mcr.microsoft.com/devcontainers/javascript-node:0-${VARIANT}
 
 RUN su node -c "umask 0002 && npm install -g http-server @vue/cli @vue/cli-service-global"
 WORKDIR /app

--- a/containers/vue/.devcontainer/devcontainer.json
+++ b/containers/vue/.devcontainer/devcontainer.json
@@ -2,9 +2,7 @@
 	"name": "Vue (Community)",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"context": "..",
-		// Update 'VARIANT' to pick a Node version: 12, 14, 16
-		"args": { "VARIANT": "16" }
+		"context": ".."
 	},
 
 	// Configure tool-specific properties.
@@ -27,6 +25,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "uname -a",
 	
-	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node"
 }

--- a/containers/vue/devcontainer-template.json
+++ b/containers/vue/devcontainer-template.json
@@ -1,0 +1,30 @@
+{
+	"id": "vue",
+	"version": "1.0.0",
+	"name": "Vue",
+	"description": "Develop applications with Vue.js, includes everything you need to get up and running.",
+	"documentationURL": "https://github.com/microsoft/vscode-dev-containers/tree/main/containers/vue",
+	"publisher": "Community",
+	"licenseURL": "https://github.com/microsoft/vscode-dev-containers/blob/main/LICENSE",
+	"options": {
+		"imageVariant": {
+			"type": "string",
+			"description": "Node.js version (use -bullseye variants on local arm64/Apple Silicon):",
+			"proposals": [
+				"18",
+				"16",
+				"14",
+				"18-bullseye",
+				"16-bullseye",
+				"14-bullseye",
+				"18-buster",
+				"16-buster",
+				"14-buster"
+			],
+			"default": "16"
+		}
+	},
+	"platforms": [
+		"Javascript"
+	]
+}


### PR DESCRIPTION
Updates community templates to follow the [spec](https://github.com/devcontainers/spec/blob/main/proposals/devcontainer-templates.md).

All other templates are now hosted from the https://github.com/devcontainers/templates repository.