### PR TITLE
Make azure dns auto detection variable quoted in comparison

### DIFF
--- a/script-library/docker-in-docker-debian.sh
+++ b/script-library/docker-in-docker-debian.sh
@@ -96,7 +96,7 @@ find_version_from_git_tags() {
     local repository=$2
     local prefix=${3:-"tags/v"}
     local separator=${4:-"."}
-    local last_part_optional=${5:-"false"}    
+    local last_part_optional=${5:-"false"}
     if [ "$(echo "${requested_version}" | grep -o "." | wc -l)" != "2" ]; then
         local escaped_separator=${separator//./\\.}
         local last_part
@@ -370,7 +370,7 @@ dockerd_start="$(cat << 'INNEREOF'
     # Handle DNS
     set +e
     cat /etc/resolv.conf | grep -i 'internal.cloudapp.net'
-    if [ $? -eq 0 ] && [ ${AZURE_DNS_AUTO_DETECTION} = "true" ]
+    if [ $? -eq 0 ] && [ "${AZURE_DNS_AUTO_DETECTION}" = "true" ]
     then
         echo "Setting dockerd Azure DNS."
         CUSTOMDNS="--dns 168.63.129.16"


### PR DESCRIPTION
A user reported an issue when using this script that was caused by the variable in the comparison, `AZURE_DNS_AUTO_DETECTION`, being unset. Because the var is unset, the comparison interpolates to

```bash
[  = "true" ]
```

which is not syntax for the `[` command.

with this change, when `AZURE_DNS_AUTO_DETECTION` is unset, the comparison will interpolate to:

```bash
[ "" = "true" ]
```

which is valid and "evaluates" to false.