### PR TITLE
fixed name of socket in documentation

### DIFF
--- a/containers/docker-from-docker/README.md
+++ b/containers/docker-from-docker/README.md
@@ -96,7 +96,7 @@ If you get a number other than `0`, you can simply add your non-root user to rig
 
     ```json
     "runArgs": ["--init"],
-    "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind" ]
+    "mounts": [ "source=/var/run/docker.sock,target=/var/run/docker-host.sock,type=bind" ]
     "remoteUser": "vscode",
     "overrideCommand": false
     ```


### PR DESCRIPTION
The name of the destination mount point for the socket container does not match with the documentation

🚨 We are not accepting PRs for new Definitions/Templates or Features in this repository. 🚨

If you are an owner of a community Definition/Template or Feature and would like to have it removed from this repository (e.g., because you are now self-publishing), please create a PR here and let us know. Otherwise, note that the majority of the contents of this repository been migrated to the https://github.com/devcontainers org.  

* For new Dev Container Features, see https://github.com/devcontainers/feature-template to get started and add your Feature into the index.
* For new Definitions/Templates, see https://github.com/devcontainers/template-starter To get started and add your Template into the index.
* Create PRs related to mcr.microsoft.com/devcontainers or mcr.microsoft.com/vscode/devcontainers images at https://github.com/devcontainers/images
* Create PRs related to existing Dev Container Features managed by the Dev Container spec maintainers at https://github.com/devcontainers/features
* Create PRs related to existing Dev Container Templates managed by the Dev Container spec maintainers at https://github.com/devcontainers/templates

🚨 Other locations 🚨
 - VS Code Dev Containers extension: http://github.com/Microsoft/vscode-remote-release 
 - GitHub Codespaces: https://github.com/github/feedback/discussions/categories/codespaces
 - The Dev Container CLI: https://gtihub.com/devcontainers/cli
 - VS Code OSS: http://github.com/Microsoft/vscode
