### PR TITLE
Bugfix: Ensure all GPG key servers use SSL

### DIFF
--- a/script-library/shared/settings.env
+++ b/script-library/shared/settings.env
@@ -20,9 +20,9 @@ HELM_GPG_KEYS_URI="https://raw.githubusercontent.com/helm/helm/main/KEYS"
 MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
 TFLINT_GPG_KEY_URI="https://raw.githubusercontent.com/terraform-linters/tflint/master/8CE69160EB3F2FE9.key"
 GO_GPG_KEY_URI="https://dl.google.com/linux/linux_signing_key.pub"
-GPG_KEY_SERVERS="keyserver hkp://keyserver.ubuntu.com:80
+GPG_KEY_SERVERS="keyserver hkps://keyserver.ubuntu.com
 keyserver hkps://keys.openpgp.org
-keyserver hkp://keyserver.pgp.com"
+keyserver hkps://keyserver.pgp.com"
 AWSCLI_GPG_KEY=FB5DB77FD5C118B80511ADA8A6310ACC4672475C
 AWSCLI_GPG_KEY_MATERIAL="-----BEGIN PGP PUBLIC KEY BLOCK-----
 


### PR DESCRIPTION
GPG hangs indefindely when accessing these HTTP urls, which prevents Docker build from completing. And fetching these keys over an unprotected channel probably enables MIM attacks.

🚨 We are not accepting PRs for new Definitions/Templates or Features in this repository. 🚨

If you are an owner of a community Definition/Template or Feature and would like to have it removed from this repository (e.g., because you are now self-publishing), please create a PR here and let us know. Otherwise, note that the majority of the contents of this repository been migrated to the https://github.com/devcontainers org.  

* For new Dev Container Features, see https://github.com/devcontainers/feature-template to get started and add your Feature into the index.
* For new Definitions/Templates, see https://github.com/devcontainers/template-starter To get started and add your Template into the index.
* Create PRs related to mcr.microsoft.com/devcontainers or mcr.microsoft.com/vscode/devcontainers images at https://github.com/devcontainers/images
* Create PRs related to existing Dev Container Features managed by the Dev Container spec maintainers at https://github.com/devcontainers/features
* Create PRs related to existing Dev Container Templates managed by the Dev Container spec maintainers at https://github.com/devcontainers/templates

🚨 Other locations 🚨
 - VS Code Dev Containers extension: http://github.com/Microsoft/vscode-remote-release 
 - GitHub Codespaces: https://github.com/github/feedback/discussions/categories/codespaces
 - The Dev Container CLI: https://gtihub.com/devcontainers/cli
 - VS Code OSS: http://github.com/Microsoft/vscode
